### PR TITLE
adjusted the output of package_listdependencies

### DIFF
--- a/spacecmd/src/lib/package.py
+++ b/spacecmd/src/lib/package.py
@@ -332,8 +332,8 @@ def do_package_listdependencies(self, args):
 
         package_id = int(package_id)
         pkgdeps = self.client.packages.list_dependencies(self.session, package_id)
+        print 'Package Name: %s' % package
         for dep in pkgdeps:
-            print 'Package Name: %s' % package
             print 'Dependency: %s Type: %s Modifier: %s' % (dep['dependency'], dep['dependency_type'], dep['dependency_modifier'])
 
 # vim:ts=4:expandtab:


### PR DESCRIPTION
New Output:
Package Name: spacecmd-2.1.25-1.el6.noarch
Dependency: config(spacecmd) Type: requires Modifier: = 2.1.25-1.el6
Dependency: python Type: requires Modifier:
...

Old Output:
Package Name: spacecmd-2.1.25-1.el6.noarch
Dependency: config(spacecmd) Type: requires Modifier: = 2.1.25-1.el6
Package Name: spacecmd-2.1.25-1.el6.noarch
Dependency: python Type: requires Modifier:
...
