### PR TITLE
Crash due to RecurringDatePicker setHour

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/DatePicker.java
+++ b/java/code/src/com/redhat/rhn/common/util/DatePicker.java
@@ -273,6 +273,16 @@ public class DatePicker {
     }
 
     /**
+     * set the hour of the day
+     *
+     * This also sets the am/pm flag
+     * @param v the hour (0 to 23)
+     */
+    public void setHourOfDay(Integer v) {
+        cal.set(Calendar.HOUR_OF_DAY, v);
+    }
+
+    /**
      * Set the minute
      * @param v the minute, a number from 0 to 59
      */

--- a/java/code/src/com/redhat/rhn/common/util/RecurringEventPicker.java
+++ b/java/code/src/com/redhat/rhn/common/util/RecurringEventPicker.java
@@ -212,21 +212,21 @@ public class RecurringEventPicker {
                 p.setStatus(STATUS_DAILY);
                 p.setCronEntry(cronEntry);
                 DatePicker timePicker = p.getDailyTimePicker();
-                timePicker.setHour(p.getHourLong().intValue());
+                timePicker.setHourOfDay(p.getHourLong().intValue());
                 timePicker.setMinute(p.getMinuteLong().intValue());
             }
             else if (matches(cronEntry, WEEKLY_REGEX)) {
                 p.setStatus(STATUS_WEEKLY);
                 p.setCronEntry(cronEntry);
                 DatePicker timePicker = p.getWeeklyTimePicker();
-                timePicker.setHour(p.getHourLong().intValue());
+                timePicker.setHourOfDay(p.getHourLong().intValue());
                 timePicker.setMinute(p.getMinuteLong().intValue());
             }
             else if (matches(cronEntry, MONTHLY_REGEX)) {
                 p.setStatus(STATUS_MONTHLY);
                 p.setCronEntry(cronEntry);
                 DatePicker timePicker = p.getMonthlyTimePicker();
-                timePicker.setHour(p.getHourLong().intValue());
+                timePicker.setHourOfDay(p.getHourLong().intValue());
                 timePicker.setMinute(p.getMinuteLong().intValue());
             }
             else {


### PR DESCRIPTION
RecurringDatePicker sets HOUR_OF_DAY, however DatePicker design is kind of
broken and it internally uses HOUR or HOUR_OF_DAY depending of the isLatin()
flag. This does not make much sense as in Calendar itself HOUR, HOUR_OF_DAY and
AM_PM are all interconnected.

as DatePicker already has getHourOfDay, add setHourOfDay and set the hours
correctly and let Calendar take care of inconsistencies.

This fixes a crash in the recurring date picker. The crash does not seems to affect
Spacewalk master on Fedora 19, but it seems that some Calendar implementations do not
behave the same.
