### PR TITLE
1071657 - Adding Custom Errata to Custom Channel feature on WebUI offers Red Hat Erratas as well.

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddCustomErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddCustomErrataAction.java
@@ -113,7 +113,7 @@ public class AddCustomErrataAction extends RhnListAction {
 
         //If this is a clone, go ahead and pre-select the original Channel
         Channel original = ChannelFactory.lookupOriginalChannel(currentChan);
-        if (!requestContext.isSubmitted() && original != null) {
+        if (!requestContext.isSubmitted() && original != null && original.isCustom()) {
             selectedChannel = original;
             selectedChannelStr = selectedChannel.getId().toString();
         }


### PR DESCRIPTION
Adding check if the parent channel is rhn or custom channel.
In case the parent is a custom channel  then can be pre-selected otherwise do not pre-select  any channel.
