### PR TITLE
Remove table from /rhn/configuration/ChannelOverview.do?ccid=1 task list

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
@@ -119,6 +119,7 @@ public class IconTag extends TagSupport {
         icons.put("item-download-csv", "fa spacewalk-icon-download-csv");
         icons.put("item-edit", "fa fa-edit");
         icons.put("item-enabled", "fa fa-check text-success");
+        icons.put("item-import", "fa fa-level-down");
         icons.put("item-search", "fa fa-eye");
         icons.put("item-ssm-add", "fa fa-plus-circle");
         icons.put("item-ssm-del", "fa fa-minus-circle");

--- a/java/code/webapp/WEB-INF/pages/common/fragments/configuration/channel/tasks.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/configuration/channel/tasks.jspf
@@ -1,112 +1,99 @@
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
 <!--  Channel-overview-tasks -->
 <!--  Divide into three sections, Deploy, Compare, and Add/Create -->
 <div class="panel panel-default">
-	<div class="panel-heading">
-		<h4><bean:message key="channelOverview.jsp.actions" /></h4>
-	</div>
-	<div class="panel-body">
-		<%-- This is here so that we can display a message if none of the following tables get shown --%>
-		<c:set var="tableshown" scope="request" value="false" />
+    <div class="panel-heading">
+        <h4><bean:message key="channelOverview.jsp.actions" /></h4>
+    </div>
+    <ul class="list-group">
+        <%-- This is here so that we can display a message if none of the following tables get shown --%>
+        <c:set var="tableshown" scope="request" value="false" />
 
-		<rhn:require acl="not config_channel_type(server_import); config_channel_has_files(); config_channel_has_systems()"
-		             mixins="com.redhat.rhn.common.security.acl.ConfigAclHandler">
-		  <c:set var="tableshown" scope="request" value="true" />
-		  <!-- Deploy Files table -->
-		  <div class="col-md-6">
-		  <table class="table">
-			<thead>
-				<tr>
-					<th style="text-align: left;"><bean:message
-						key="channelOverview.jsp.tasks.deploy" /></th>
-				</tr>
-			</thead>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=all2all"> <bean:message
-					key="channelOverview.jsp.tasks.deployAll2All" /></a></td>
-			</tr>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=sel2all"> <bean:message
-					key="channelOverview.jsp.tasks.deploySel2All" /></a></td>
-			</tr>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=all2sel"> <bean:message
-					key="channelOverview.jsp.tasks.deployAll2Sel" /></a></td>
-			</tr>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=sel2sel"> <bean:message
-					key="channelOverview.jsp.tasks.deploySel2Sel" /></a></td>
-			</tr>
-		  </table>
-		  </div>
-		</rhn:require>
+        <rhn:require acl="not config_channel_type(server_import); config_channel_has_files(); config_channel_has_systems()"
+                     mixins="com.redhat.rhn.common.security.acl.ConfigAclHandler">
+            <c:set var="tableshown" scope="request" value="true" />
 
-		<rhn:require acl="config_channel_has_files(); config_channel_has_systems()"
-		             mixins="com.redhat.rhn.common.security.acl.ConfigAclHandler">
-		  <c:set var="tableshown" scope="request" value="true" />
-		  <!-- Compare Files table -->
-		  <table class="col-md-6">
-			<thead>
-				<th class="text-left"><bean:message
-					key="channelOverview.jsp.tasks.compare" /></th>
-			</thead>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=compare"> <bean:message
-					key="channelOverview.jsp.tasks.compareAll" /></a></td>
-			</tr>
-		  </table>
-		</rhn:require>
+            <li class="list-group-item">
+                <strong>
+                    <rhn:icon type="nav-bullet"/>
+                    <bean:message key="channelOverview.jsp.tasks.deploy" />
+                </strong>
+            </li>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=all2all">
+                    <rhn:icon type="nav-bullet"/>
+                    <bean:message key="channelOverview.jsp.tasks.deployAll2All" />
+                </a>
+            </li>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=sel2all">
+                    <bean:message key="channelOverview.jsp.tasks.deploySel2All" />
+                </a>
+            </li>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=all2sel">
+                    <bean:message key="channelOverview.jsp.tasks.deployAll2Sel" />
+                </a>
+            </li>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=sel2sel">
+                    <bean:message key="channelOverview.jsp.tasks.deploySel2Sel" />
+                </a>
+            </li>
 
-		<rhn:require acl="config_channel_editable()"
-		             mixins="com.redhat.rhn.common.security.acl.ConfigAclHandler">
-		  <c:set var="tableshown" scope="request" value="true" />
-		  <!-- Add/Create Files table -->
-		  <table class="table">
-			<thead>
-				<th style="text-align: left;"><bean:message
-					key="channelOverview.jsp.tasks.modify" /></th>
-			</thead>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/ChannelCreateFiles.do?ccid=${ccid}"> <bean:message
-					key="channelOverview.jsp.tasks.modifyCreate" /></a></td>
-			</tr>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/ChannelUploadFiles.do?ccid=${ccid}"> <bean:message
-					key="channelOverview.jsp.tasks.modifyUpload" /></a></td>
-			</tr>
-			<tr class="list-row-odd">
-				<td style="text-align: left;"><img
-					style="margin-left: 4px;" src="/img/parent_node.gif"
-					alt="" /> <a
-					href="/rhn/configuration/ChannelImportFiles.do?ccid=${ccid}"> <bean:message
-					key="channelOverview.jsp.tasks.modifyImport" /></a></td>
-			</tr>
-		  </table>
-		</rhn:require>
+        </rhn:require>
 
-		<%-- If none of the tables got shown, show a message --%>
-		<c:if test="${not tableshown}">
-		  <bean:message key="channelOverview.jsp.tasks.noTasks" />
-		</c:if>
-	</div>
+        <rhn:require acl="config_channel_has_files(); config_channel_has_systems()"
+                     mixins="com.redhat.rhn.common.security.acl.ConfigAclHandler">
+            <c:set var="tableshown" scope="request" value="true" />
+            <!-- Compare Files table -->
+            <div class="list-group-item">
+                <strong>
+                    <rhn:icon type="nav-bullet"/>
+                    <bean:message key="channelOverview.jsp.tasks.compare" />
+                </strong>
+            </div>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/channel/ChannelDeployTasks.do?ccid=${ccid}&amp;mode=compare">
+                    <bean:message key="channelOverview.jsp.tasks.compareAll" />
+                </a>
+            </li>
+        </rhn:require>
+
+        <rhn:require acl="config_channel_editable()" mixins="com.redhat.rhn.common.security.acl.ConfigAclHandler">
+            <c:set var="tableshown" scope="request" value="true" />
+            <!-- Add/Create Files table -->
+            <div class="list-group-item">
+                <strong>
+                    <rhn:icon type="nav-bullet"/>
+                    <bean:message key="channelOverview.jsp.tasks.modify" />
+                </strong>
+            </div>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/ChannelCreateFiles.do?ccid=${ccid}">
+                    <rhn:icon type="item-add"/>
+                    <bean:message key="channelOverview.jsp.tasks.modifyCreate" />
+                </a>
+            </li>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/ChannelUploadFiles.do?ccid=${ccid}">
+                    <rhn:icon type="item-upload"/>
+                    <bean:message key="channelOverview.jsp.tasks.modifyUpload" />
+                </a>
+            </li>
+            <li class="list-group-item">
+                <a href="/rhn/configuration/ChannelImportFiles.do?ccid=${ccid}">
+                    <rhn:icon type="item-import"/>
+                    <bean:message key="channelOverview.jsp.tasks.modifyImport" />
+                </a>
+            </li>
+        </rhn:require>
+
+        <%-- If none of the tables got shown, show a message --%>
+        <c:if test="${not tableshown}">
+            <li class="list-group-item">
+                <bean:message key="channelOverview.jsp.tasks.noTasks" />
+            </li>
+        </c:if>
+    </ul>
 </div>


### PR DESCRIPTION
Make the list of tasks a list-group. Unlike the table is responsive. Do not use images as bullets but the font-icons.

before

![spacewalk configuration overview_old](https://f.cloud.github.com/assets/15332/2383176/f58f1ab2-a8f7-11e3-9049-6324c945faf2.png)

after

![spacewalk configuration overview](https://f.cloud.github.com/assets/15332/2383178/f9e5b9f4-a8f7-11e3-8e2b-f6f1fde8f5d4.png)
