### PR TITLE
Bug: spacewalk-repo-sync crashes

### DIFF
--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -49,7 +49,8 @@ def releaseLOCK():
 def clear_interrupted_downloads():
     initCFG('server.satellite')
     pkgdir = os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, '1', 'stage')
-    shutil.rmtree(pkgdir)
+    if os.path.exists(pkgdir):
+        shutil.rmtree(pkgdir)
 
 def main():
 


### PR DESCRIPTION
The spacewalk-repo-sync crashes when is trying to delete non-existing directory on interrupted downloads.
