### PR TITLE
fixing web_contact upgrade script

### DIFF
--- a/schema/spacewalk/upgrade/spacewalk-schema-2.1-to-spacewalk-schema-2.2/006-web_contact-password.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.1-to-spacewalk-schema-2.2/006-web_contact-password.sql.oracle
@@ -1,1 +1,1 @@
-alter table web_contact modify password varchar2(110) not null;
+alter table web_contact modify password varchar2(110);


### PR DESCRIPTION
Spacewalk schema upgrade from 2.1 to nightly on Oracle fails on modifying web_contact.password column.
