### PR TITLE
1076864 - [RFE] params for sw-repo-sync UI/API.

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
@@ -89,10 +89,6 @@ public class SyncRepositoriesAction extends RhnAction implements Listable {
 
         }
 
-
-
-
-
         RecurringEventPicker picker = RecurringEventPicker.prepopulatePicker(
                 request, "date", oldCronExpr);
 
@@ -114,9 +110,18 @@ public class SyncRepositoriesAction extends RhnAction implements Listable {
             }
 
             try {
+                Map<String, String> mparams = new HashMap<String, String>();
+                String [] lparams = {"no-errata", "sync-kickstart", "fail"};
+
+                for (String p : lparams) {
+                    if  (request.getParameter(p) != null) {
+                        mparams.put(p, "true");
+                    }
+                }
+
                 if (context.wasDispatched("repos.jsp.button-sync")) {
                     // schedule one time repo sync
-                    taskomatic.scheduleSingleRepoSync(chan, user);
+                    taskomatic.scheduleSingleRepoSync(chan, user, mparams);
                     createSuccessMessage(request, "message.syncscheduled",
                             chan.getName());
 
@@ -131,7 +136,7 @@ public class SyncRepositoriesAction extends RhnAction implements Listable {
                     }
                     else if (!StringUtils.isEmpty(picker.getCronEntry())) {
                         Date date = taskomatic.scheduleRepoSync(chan, user,
-                                picker.getCronEntry());
+                                picker.getCronEntry(), mparams);
                         createSuccessMessage(request, "message.syncscheduled",
                                 chan.getName());
                     }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -19889,6 +19889,24 @@ given channel.</source>
           <context context-type="sourcefile">/rhn/channels/manage/ConfirmPrivate.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="channel.manage.sync.noerrata.jsp">
+        <source>Do not sync erratas</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Sync.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="channel.manage.sync.synckickstart.jsp">
+        <source>Create kickstartable tree</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Sync.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="channel.manage.sync.fail.jsp">
+        <source>Terminate upon any error</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Sync.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="extauth.org.message">
         <source>Even externally authenticated users need to be created within @@PRODUCT_NAME@@. You may specify, in what organization new users shall be created. An option is to use the Org. Unit set on IPA server that has to match the organization name. Another option is to set a default organization, where all the newly created users will be created.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2768,6 +2768,33 @@ public class ChannelSoftwareHandler extends BaseHandler {
         new TaskomaticApi().scheduleSingleRepoSync(chan, loggedInUser);
         return 1;
     }
+
+    /**
+     * Trigger immediate repo synchronization
+     * @param sessionKey session key
+     * @param channelLabel channel label
+     * @param params parameters
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Trigger immediate repo synchronization
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "channelLabel", "channel label")
+     * @xmlrpc.param
+     *  #struct("params_map")
+     *    #prop_desc("Boolean", "sync-kickstars", "Create kickstartable tree - Optional")
+     *    #prop_desc("Boolean", "no-errata", "Do not sync errata - Optional")
+     *    #prop_desc("Boolean", "fail", "Terminate upon any error - Optional")
+     *  #struct_end()
+     * @xmlrpc.returntype  #return_int_success()
+     */
+    public int syncRepo(String sessionKey, String channelLabel,
+                                               Map <String, String> params) {
+        User loggedInUser = getLoggedInUser(sessionKey);
+        Channel chan = lookupChannelByLabel(loggedInUser, channelLabel);
+        new TaskomaticApi().scheduleSingleRepoSync(chan, loggedInUser, params);
+        return 1;
+    }
+
     /**
      * Schedule periodic repo synchronization
      * @param sessionKey session key
@@ -2790,6 +2817,40 @@ public class ChannelSoftwareHandler extends BaseHandler {
         }
         else {
             new TaskomaticApi().scheduleRepoSync(chan, loggedInUser, cronExpr);
+        }
+        return 1;
+    }
+
+    /**
+     * Schedule periodic repo synchronization
+     * @param sessionKey session key
+     * @param channelLabel channel label
+     * @param cronExpr cron expression, if empty all periodic schedules will be disabled
+     * @param params parameters
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Schedule periodic repo synchronization
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "channelLabel", "channel label")
+     * @xmlrpc.param #param_desc("string", "cron expression",
+     *      "if empty all periodic schedules will be disabled")
+     * @xmlrpc.param
+     *  #struct("params_map")
+     *    #prop_desc("Boolean", "sync-kickstars", "Create kickstartable tree - Optional")
+     *    #prop_desc("Boolean", "no-errata", "Do not sync errata - Optional")
+     *    #prop_desc("Boolean", "fail", "Terminate upon any error - Optional")
+     *  #struct_end()
+     * @xmlrpc.returntype  #return_int_success()
+     */
+    public int syncRepo(String sessionKey,
+            String channelLabel, String cronExpr, Map <String, String> params) {
+        User loggedInUser = getLoggedInUser(sessionKey);
+        Channel chan = lookupChannelByLabel(loggedInUser, channelLabel);
+        if (StringUtils.isEmpty(cronExpr)) {
+            new TaskomaticApi().unscheduleRepoSync(chan, loggedInUser);
+        }
+        else {
+            new TaskomaticApi().scheduleRepoSync(chan, loggedInUser, cronExpr, params);
         }
         return 1;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -94,6 +94,24 @@ public class TaskomaticApi {
                 "repo-sync-bunch", scheduleParams);
     }
 
+    /**
+     * Schedule a single reposync
+     * @param chan the channel
+     * @param user the user
+     * @param params parameters
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRepoSync(Channel chan, User user, Map <String, String>params)
+                                    throws TaskomaticApiException {
+
+        Map <String, String> scheduleParams = new HashMap<String, String>();
+        scheduleParams.put("channel_id", chan.getId().toString());
+        scheduleParams.putAll(params);
+
+        invoke("tasko.scheduleSingleBunchRun", user.getOrg().getId(),
+                "repo-sync-bunch", scheduleParams);
+    }
+
     private String createRepoSyncScheduleName(Channel chan, User user) {
         return "repo-sync-" + user.getOrg().getId() + "-" + chan.getId();
     }
@@ -116,6 +134,33 @@ public class TaskomaticApi {
         }
         Map scheduleParams = new HashMap();
         scheduleParams.put("channel_id", chan.getId().toString());
+        return (Date) invoke("tasko.scheduleBunch", user.getOrg().getId(),
+                "repo-sync-bunch", jobLabel , cron,
+                scheduleParams);
+    }
+
+    /**
+     * Schedule a recurring reposync
+     * @param chan the channel
+     * @param user the user
+     * @param cron the cron format
+     * @param params parameters
+     * @return the Date?
+     * @throws TaskomaticApiException if there was an error
+     */
+    public Date scheduleRepoSync(Channel chan, User user, String cron,
+                                                     Map <String, String>params)
+                                        throws TaskomaticApiException {
+        String jobLabel = createRepoSyncScheduleName(chan, user);
+
+        Map task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
+        if (task != null) {
+            unscheduleRepoTask(jobLabel, user);
+        }
+        Map <String, String> scheduleParams = new HashMap<String, String>();
+        scheduleParams.put("channel_id", chan.getId().toString());
+        scheduleParams.putAll(params);
+
         return (Date) invoke("tasko.scheduleBunch", user.getOrg().getId(),
                 "repo-sync-bunch", jobLabel , cron,
                 scheduleParams);

--- a/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
@@ -36,6 +36,34 @@
                 </rl:column>
 
             </rl:list>
+
+            <div class="text-left">
+                <input type="checkbox"
+                      name="no-errata"
+                        id="no-errata"/>
+                <label class="col-lg-3 control-label">
+                    <bean:message key="channel.manage.sync.noerrata.jsp"/>
+                </label>
+            </div>
+
+            <div class="text-left">
+                <input type="checkbox"
+                 name="sync-kickstart"
+                   id="sync-kickstart"/>
+                <label class="col-lg-3 control-label">
+                    <bean:message key="channel.manage.sync.synckickstart.jsp"/>
+                </label>
+            </div>
+
+            <div class="text-left">
+               <input type="checkbox"
+                          name="fail"
+                           id="fail"/>
+               <label class="col-lg-3 control-label">
+                    <bean:message key="channel.manage.sync.fail.jsp"/>
+               </label>
+            </div>
+
             <div class="text-right">
                 <hr />
                 <button type="submit" name="dispatch" value="<bean:message key='repos.jsp.button-sync'/>"


### PR DESCRIPTION
Spacewalk tool spacewalk-repo-sync has parameters "no-errata", "sync-kickstart" and "fail" that can be used currently only if the tool is executed directly from shell.
RFE implementation:
 WebUI :  Adding one check box for each option to "rhn/channels/manage/Sync.do?cid=<ch_id>" page.
 API: channel.software.syncRepo(key, channel_label, map_sw_repo_sync_parameters)
        channel.software.syncRepo(key, channel_label, map_sw_repo_sync_parameters)
