### PR TITLE
add funcionality on spacewalk-data-fsck to remove the RPM which does not match checksum

### DIFF
--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -258,7 +258,7 @@ def check_disk_vs_db(disk_content=None, db_content=None):
           if options.checksum and options.fs_only:
               if options.remove_mismatch:
                     report['checksum'] += check_disk_checksum(abs_path,
-                                               row['checksum_type'], row['checksum'], remove=False)
+                                               row['checksum_type'], row['checksum'], remove=True)
              else:
                     report['checksum'] += check_disk_checksum(abs_path,
                                                row['checksum_type'], row['checksum'])


### PR DESCRIPTION
This patch adds the ability to delete packages from the /var/satellite directory which does now match with the checksum on the database. 

This is very useful when having RPM files corrupted.

Running this command with # spacewalk-data-fsck -f -R  clean the corrupted RPM files. Afterwards, satellite-sync we re-download it. 

If committed, I'll send a new patch adding this option to the man page  (see https://github.com/spacewalkproject/spacewalk/pull/29)
