### PR TITLE
Add remove-mismatch option on spacewalk-data-fsck and added it to the man page

### DIFF
--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -211,7 +211,7 @@ def restore_file_path(file, row):
     log(0, "File %s%s successfully restored, new file path: %s" % (prefix, row['path'], new_path))
     return 0
 
-def check_disk_checksum(abs_path, checksum_type, checksum):
+def check_disk_checksum(abs_path, checksum_type, checksum, remove=False):
     try:
         fp = file(abs_path ,'rb')
         h = checksum.getHashlibInstance(checksum_type, False)
@@ -224,7 +224,9 @@ def check_disk_checksum(abs_path, checksum_type, checksum):
     if file_checksum != checksum:
         log(0, "File checksum mismatch: %s (%s: %s vs. %s)" %
                  (abs_path, checksum_type, checksum, file_checksum))
-        ret = 1
+        if remove:
+            remove_mismatch(abs_path, options)
+            ret = 1
     return ret
 
 def check_disk_vs_db(disk_content=None, db_content=None):
@@ -252,7 +254,12 @@ def check_disk_vs_db(disk_content=None, db_content=None):
                     report['size'] += check_disk_size(abs_path, row['package_size'])
           if options.nevrao and options.fs_only:
                     report['nevrao'] += check_disk_nevrao(abs_path, row.copy())
+
           if options.checksum and options.fs_only:
+              if options.remove_mismatch:
+                    report['checksum'] += check_disk_checksum(abs_path,
+                                               row['checksum_type'], row['checksum'], remove=True)
+             else:
                     report['checksum'] += check_disk_checksum(abs_path,
                                                row['checksum_type'], row['checksum'])
     h.close()
@@ -270,6 +277,11 @@ def not_in_db(path, options):
         unlink_package_file(path)
     else:
         log(0, "File missing in db: %s" % (path))
+
+def remove_mismatch(path, options):
+    if options.remove_mismatch:
+        log(0, "Removed file because checksum does not match: %s" % (path))
+        unlink_package_file(path)
 
 def log(level, *args):
     log_debug(level, *args)
@@ -295,7 +307,9 @@ if __name__ == '__main__':
         Option("-f", "--fs-only",       action="store_true",
             help="Check only if packages from filesystem are in the database"),
         Option("-r", "--remove",        action="store_true",
-            help="Automaticaly remove packages from filesystem not present in database"),
+            help="Automatically remove packages from filesystem not present in database"),
+        Option("-R", "--remove-mismatch",   action="store_true", dest="remove_mismatch",
+            help="Automatically remove packages from filesystem that does not match the checksum stored in database. (not valid with --db-only)"),
         Option("-F", "--fix-file-path", action="store_true", dest="restore", default=False,
             help="Restores file paths, try this when you have NEVRAO mismatches. Do not run this command with another commands"),
     ]
@@ -307,6 +321,11 @@ if __name__ == '__main__':
     db_init()
 
     exit_value=0
+    if options.remove_mismatch:
+        if options.db_only or options.nevrao:
+            print "Syntax error: The option --remove-mismatch cannot be used with --db-only or --no-checksum"
+            sys.exit(1)
+
     if not options.fs_only:
         log(1, "Checking if packages from database are present on filesystem")
         exit_value += check_db_vs_disk(options)

--- a/backend/satellite_tools/spacewalk-data-fsck.sgml
+++ b/backend/satellite_tools/spacewalk-data-fsck.sgml
@@ -104,6 +104,16 @@ Helper utility to manage and compare packages on filesystem vs database.
             </para>
         </listitem>
     </varlistentry>
+    <varlistentry>
+        <term>-R, --remove-mismatch</term>
+        <listitem>
+            <para>
+            Remove packages from filesystem that does not match the checksum stored in the database.
+            This option is not valid when combined with options <emphasis>--db-only</emphasis> or <emphasis>--no-checksum</emphasis>.
+            After removing the packages from the filesystem, remember to run <emphasis>satellite-sync</emphasis> or <emphasis>spacewalk-repo-sync</emphasis> to download the RPM file.
+            </para>
+        </listitem>
+    </varlistentry>
 </variablelist>
 </RefSect1>
 


### PR DESCRIPTION
This pull request adds the funcionality on spacewalk-data-fsck to remove the RPM which does not match checksum. 

The second commit adds on spacewalk-data-fsck man page the explanation about the new option. 

Note: this patch have the suggestion proposed by skoty-tkasparek at https://github.com/spacewalkproject/spacewalk/pull/32

Thanks.