### PR TITLE
1073543 - sw-clone-by-date validation update

### DIFF
--- a/utils/cloneByDate.py
+++ b/utils/cloneByDate.py
@@ -65,7 +65,8 @@ def confirm(txt, options):
 
 def validate(channel_labels):
     tmp_dirs = {}
-    for label in channel_labels:
+    for llabel in channel_labels:
+        label=llabel[0]
         path = repodata(label)
         tmp = tempfile.mkdtemp()
         tmp_dirs[label] = tmp


### PR DESCRIPTION
Spacewalk-clone-by-date  channel validation option is not updated according to the last changes.
# spacewalk-clone-by-date  -l channel  clone-channel  --username xxxxxx --password xxxxxx --validate

Traceback (most recent call last):
  File "/usr/bin/spacewalk-clone-by-date", line 375, in <module>
    sys.exit(abs(main() or 0))
  File "/usr/bin/spacewalk-clone-by-date", line 365, in main
    return cloneByDate.main(args)
  File "/usr/share/rhn/utils/cloneByDate.py", line 186, in main
    validate(channel_list.values())
  File "/usr/share/rhn/utils/cloneByDate.py", line 72, in validate
    tmp_dirs[label] = tmp
TypeError: unhashable type: 'list'

-- Related code 
def validate(channel_labels):
    tmp_dirs = {}
    for label in channel_labels:
        path = repodata(label)
        tmp = tempfile.mkdtemp()
        tmp_dirs[label] = tmp
        shutil.copytree(path, "%s/repodata/" % tmp)

--Debug info
(Pdb) channel_labels
[['clone-channel']]
