### PR TITLE
517468 - sw-repo-sync: adding option [-l|--list]

### DIFF
--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -66,6 +66,8 @@ def main():
                       "spacewalk-repo-sync Exiting.")
 
     parser = OptionParser()
+    parser.add_option('-l', '--list', action='store_true', dest='list',
+                      help='List the custom channels with the assosiated repositories.')
     parser.add_option('-u', '--url', action='store', dest='url',
                       help='The url to sync')
     parser.add_option('-c', '--channel', action='store',
@@ -92,6 +94,20 @@ def main():
     parser.add_option('', '--sync-kickstart', action='store_true', dest='sync_kickstart',
                       default=False, help="Sync kickstartable tree")
     (options, args) = parser.parse_args()
+
+    d_chan_repo=reposync.getChannelRepo()
+    l_ch_custom=reposync.getCustomChannels()
+
+    if options.list:
+        print "======================================"
+        print "|   Channel Label   |   Repository   |"
+        print "======================================"
+        for ch in d_chan_repo:
+            for repo in d_chan_repo[ch]:
+                print "%s | %s" %(ch,repo)
+        for ch in list(set(l_ch_custom)-set(d_chan_repo)):
+            print "%s | No repository set" % ch
+        return 0
 
     if not options.channel_label:
         systemExit(1, "--channel must be specified")

--- a/backend/satellite_tools/spacewalk-repo-sync.sgml
+++ b/backend/satellite_tools/spacewalk-repo-sync.sgml
@@ -25,6 +25,11 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
         </group>
         <sbr>
         <group>
+        <arg>-l</arg>
+        <arg>--list</arg>
+        </group>
+        <sbr>
+        <group>
         <arg>-u<replaceable>URL</replaceable></arg>
         <arg>--url=<replaceable>URL</replaceable></arg>
         </group>
@@ -103,6 +108,12 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
         <term>-u<replaceable>URL</replaceable>, --url=<replaceable>URL</replaceable></term>
         <listitem>
             <para>The repository URL.  Any protocol supported by yum is supported including http://, nfs://, file://. (Optional)</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>-l, --list</term>
+        <listitem>
+            <para>List the custom channels with the assosiated repositories.</para>
         </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
$ spacewalk-repo-sync -l

|   Channel Label   |   Repository   |

test_1 | http://test.repo.rh.com/test_1
test_2 | http://test.repo.rh.com/test_2
test_2 | http://test.repo.rh.com/test_client_2
test_3 | No repository set
