### PR TITLE
1088813 - spacewalk-remove-channel --justdb option has no impact on kickstart trees.

### DIFF
--- a/backend/satellite_tools/spacewalk-remove-channel
+++ b/backend/satellite_tools/spacewalk-remove-channel
@@ -301,7 +301,7 @@ def delete_channels(channelLabels, force=0, justdb=0, skip_packages=0, skip_chan
         _delete_srpms(srpms_ids)
         _delete_rpms(rpms_ids)
 
-    if not skip_kickstart_trees:
+    if not skip_kickstart_trees and not justdb:
         _delete_ks_files(channelLabels)
 
     if not justdb and not skip_packages:


### PR DESCRIPTION
Spacewalk-remove-channel --justdb option has no impact on kickstart trees.
