### PR TITLE
Default manufacturer as empty string

### DIFF
--- a/backend/server/handlers/xmlrpc/registration.py
+++ b/backend/server/handlers/xmlrpc/registration.py
@@ -47,7 +47,7 @@ def hash_validate(data, *keylist):
 def parse_smbios(smbios):
     vendor = smbios.get('smbios.bios.vendor')
     serial = smbios.get('smbios.system.serial', '')
-    manufacturer = smbios.get('smbios.system.manufacturer')
+    manufacturer = smbios.get('smbios.system.manufacturer', '')
     product = smbios.get('smbios.system.product')
 
     # XXX need to worry about uuid being none for other virt types and


### PR DESCRIPTION
We have self-assembled server that incorrectly reports SMBIOS values and it was unable to register it to Spacewalk because 'manufacturer' (line 72) was None instead of str().

Exact error:

``` Python
Exception Handler Information
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/spacewalk/server/apacheRequest.py", line 123, in call_function
    response = apply(func, params)
  File "/usr/share/rhn/server/handlers/xmlrpc/registration.py", line 509, in new_system
    architecture, data)
  File "/usr/share/rhn/server/handlers/xmlrpc/registration.py", line 368, in create_system
    parse_smbios(data['smbios'])
  File "/usr/share/rhn/server/handlers/xmlrpc/registration.py", line 69, in parse_smbios
    elif manufacturer.startswith('Red Hat') and product == 'OpenStack Nova' and uuid is not None:
AttributeError: 'NoneType' object has no attribute 'startswith'
```

dmidecode reports:

```
Handle 0x0001, DMI type 1, 27 bytes
System Information
    Manufacturer: Empty
    Product Name: Empty
    Version: Empty
    Serial Number: Empty
    UUID: 00000000-0000-0000-0000-F0AB0C00C04D
    Wake-up Type: Power Switch
    SKU Number: Not Specified
    Family: Not Specified
```
