### PR TITLE
1094526 - remove trailing semi-colon from SQL query

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -53,7 +53,7 @@ def getChannelRepo():
                        from rhnContentSource s,
                        rhnChannelContentSource cs,
                        rhnChannel c
-                       where s.id = cs.source_id and cs.channel_id=c.id;
+                       where s.id = cs.source_id and cs.channel_id=c.id
            """
     h = rhnSQL.prepare(sql)
     h.execute()


### PR DESCRIPTION
The semi-colon in a SQL query breaks under Oracle when prepared.
