### PR TITLE
remove ; in SQL statement to fix error with oracle DB

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -53,7 +53,7 @@ def getChannelRepo():
                        from rhnContentSource s,
                        rhnChannelContentSource cs,
                        rhnChannel c
-                       where s.id = cs.source_id and cs.channel_id=c.id;
+                       where s.id = cs.source_id and cs.channel_id=c.id
            """
     h = rhnSQL.prepare(sql)
     h.execute()


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "/usr/bin/spacewalk-repo-sync", line 147, in <module>
    sys.exit(abs(main() or 0))
  File "/usr/bin/spacewalk-repo-sync", line 105, in main
    d_chan_repo=reposync.getChannelRepo()
  File "/usr/lib64/python2.6/site-packages/spacewalk/satellite_tools/reposync.py", line 85, in getChannelRepo
    h.execute()
  File "/usr/lib64/python2.6/site-packages/spacewalk/server/rhnSQL/sql_base.py", line 148, in execute
    return self._execute_wrapper(self._execute, _p, *_kw)
  File "/usr/lib64/python2.6/site-packages/spacewalk/server/rhnSQL/driver_cx_Oracle.py", line 109, in _execute_wrapper
    retval = function(_p, *_kw)
  File "/usr/lib64/python2.6/site-packages/spacewalk/server/rhnSQL/sql_base.py", line 203, in _execute
    return self._execute_(args, kwargs)
  File "/usr/lib64/python2.6/site-packages/spacewalk/server/rhnSQL/driver_cx_Oracle.py", line 162, in _execute_
    self._real_cursor.execute(_(None, ), *_params)
spacewalk.server.rhnSQL.sql_base.SQLStatementPrepareError: ('ORA-00911: invalid character\n', 911, 'select s.source_url, c.label from rhnContentSource s, rhnChannelContentSource cs, rhnChannel c where s.id = cs.source_id and cs.channel_id=c.id;')
