### PR TITLE
1044527 - when adding "Virtualization" add-on entitlement to RHEL7 host, red warning about missing VT channel is displayed

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -1729,9 +1729,8 @@ public class SystemManager extends BaseManager {
             }
 
             if ((base != null) &&
-                    base.isRhelChannel() &&
-                    base.isReleaseXChannel(6)) {
-                // do some actions for RHEL6
+                    base.isRhelChannel() && !base.isReleaseXChannel(5)) {
+                // do some actions for EL6/EL7/...
             }
             else {
                 // otherwise subscribe to the virt channel if possible


### PR DESCRIPTION
Bug 1044527 - when adding "Virtualization" add-on entitlement to RHEL7 host, red warning about missing VT channel is displayed
