### PR TITLE
python: fixed 'empty separator' error

### DIFF
--- a/backend/upload_server/handlers/package_push/package_push.py
+++ b/backend/upload_server/handlers/package_push/package_push.py
@@ -152,7 +152,7 @@ class PackagePush(basePackageUpload.BasePackageUpload):
 
     @staticmethod
     def get_auth_token(value):
-        s = ''.join(map(lambda x: x.strip(), value.split('')))
+        s = ''.join(map(lambda x: x.strip(), value.split(',')))
         arr = map(base64.decodestring, s.split(':'))
         return arr
 


### PR DESCRIPTION
During the refactoring of commit a8ef8f68a4 the ',' character got accidentally removed. This leads to a 'empty separator' error.
