### PR TITLE
1064287 - Use systemctl show to get the pid since /var/run/tomcat.pid is empty.

### DIFF
--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -28,11 +28,11 @@ wait_for_jabberd() {
 
 wait_for_tomcat() {
 if [ -x /etc/init.d/tomcat5 ]; then
-   TOMCAT="tomcat5"
+   TOMCAT_PID=$(cat /var/run/tomcat5.pid 2>/dev/null)
 elif [ -x /etc/init.d/tomcat6 ]; then
-   TOMCAT="tomcat6"
+   TOMCAT_PID=$(cat /var/run/tomcat6.pid 2>/dev/null)
 elif [ -e /lib/systemd/system/tomcat.service ]; then
-   TOMCAT="tomcat"
+   TOMCAT_PID=$(systemctl show --property=MainPID tomcat.service | sed 's/^MainPID=0*//')
 else
    echo "No tomcat service found."
    exit 0;
@@ -40,7 +40,6 @@ fi
 
 if [ -x /usr/sbin/lsof ]; then
     echo "Waiting for tomcat to be ready ..."
-    TOMCAT_PID=$(cat /var/run/$TOMCAT.pid 2>/dev/null)
     while [ -n "$TOMCAT_PID" ] ; do
         /usr/sbin/lsof -t -i TCP:8005 | grep "^$TOMCAT_PID$" > /dev/null \
         && /usr/sbin/lsof -t -i TCP:8009 | grep "^$TOMCAT_PID$" > /dev/null \


### PR DESCRIPTION
Otherwise wait-for-pid is not waiting, really.
