### PR TITLE
Use proxy host for kickstarting a virtual guest (if available)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1527,7 +1527,11 @@ public class ActionManager extends BaseManager {
                 pcmd.getKsdata());
         kad.setCobblerSystemName(vcmd.getCobblerSystemRecordName());
 
-        kad.setKickstartHost(pcmd.getKickstartServerName());
+        String hostname = pcmd.getKickstartServerName();
+        if (pcmd.getProxyHost() != null) {
+            hostname = pcmd.getProxyHost();
+        }
+        kad.setKickstartHost(hostname);
         ksAction.setKickstartGuestActionDetails(kad);
         return ksAction;
     }


### PR DESCRIPTION
This is a rather long-standing patch from the Manager code base, fixes a bug we encountered in an internal test (which, unfortunately, has not been tracked).

I really believe this also affects Spacewalk, please review.
