### PR TITLE
Since Spacewalk is no longer built for Fedoras 18 and older, simplify the 0%{?fedora} tests in .specs.

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -27,7 +27,7 @@ Requires: %{name}-libs >= 1.1.16-1
 BuildRequires: /usr/bin/msgfmt
 BuildRequires: /usr/bin/docbook2man
 BuildRequires: docbook-utils
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 BuildRequires: spacewalk-pylint
 BuildRequires: rhnlib >= 2.5.57
 BuildRequires: rpm-python
@@ -109,7 +109,7 @@ receivers and get them enabled automatically.
 Summary: Handler for /XMLRPC
 Group: Applications/Internet
 Requires: %{name}-server = %{version}-%{release}
-%if 0%{?fedora} >= 19
+%if 0%{?fedora}
 # temporary workaround for bug BZ#1067443
 Requires: rpm-python < 4.11.2
 %endif
@@ -293,7 +293,7 @@ rm -rf $RPM_BUILD_ROOT
 %check
 make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} test || :
 
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # check coding style
 export PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib}:/usr/lib/rhn
 spacewalk-pylint $RPM_BUILD_ROOT%{pythonrhnroot}/common \

--- a/client/rhel/rhn-client-tools/rhn-client-tools.spec
+++ b/client/rhel/rhn-client-tools/rhn-client-tools.spec
@@ -141,7 +141,7 @@ make -f Makefile.rhn-client-tools install VERSION=%{version}-%{release} PREFIX=$
 mkdir -p $RPM_BUILD_ROOT/var/lib/up2date
 mkdir -pm700 $RPM_BUILD_ROOT%{_localstatedir}/spool/up2date
 touch $RPM_BUILD_ROOT%{_localstatedir}/spool/up2date/loginAuth.pkl
-%if 0%{?fedora} >= 18
+%if 0%{?fedora}
 mkdir -p $RPM_BUILD_ROOT/%{_presetdir}
 install 50-spacewalk-client.preset $RPM_BUILD_ROOT/%{_presetdir}
 %endif
@@ -252,7 +252,7 @@ make -f Makefile.rhn-client-tools test
 #public keys and certificates
 %{_datadir}/rhn/RHNS-CA-CERT
 
-%if 0%{?fedora} >= 18
+%if 0%{?fedora}
 %{_presetdir}/50-spacewalk-client.preset
 %endif
 
@@ -312,7 +312,7 @@ make -f Makefile.rhn-client-tools test
 %{_datadir}/icons/hicolor/24x24/apps/up2date.png
 %{_datadir}/icons/hicolor/32x32/apps/up2date.png
 %{_datadir}/icons/hicolor/48x48/apps/up2date.png
-%if 0%{?rhel} > 6 || 0%{?fedora} > 17
+%if 0%{?rhel} > 6 || 0%{?fedora}
 %{_datadir}/icons/hicolor/22x22/apps/up2date.png
 %{_datadir}/icons/hicolor/256x256/apps/up2date.png
 %endif

--- a/client/tools/osad/osad.spec
+++ b/client/tools/osad/osad.spec
@@ -143,7 +143,7 @@ make -f Makefile.osad all
 
 %if 0%{?include_selinux_package}
 %{__perl} -i -pe 'BEGIN { $VER = join ".", grep /^\d+$/, split /\./, "%{version}.%{release}"; } s!\@\@VERSION\@\@!$VER!g;' osa-dispatcher-selinux/%{modulename}.te
-%if 0%{?fedora} >= 17
+%if 0%{?fedora}
 cat osa-dispatcher-selinux/%{modulename}.te.fedora17 >> osa-dispatcher-selinux/%{modulename}.te
 %endif
 for selinuxvariant in %{selinux_variants}

--- a/client/tools/rhncustominfo/rhn-custom-info.spec
+++ b/client/tools/rhncustominfo/rhn-custom-info.spec
@@ -11,7 +11,7 @@ BuildArch: noarch
 BuildRequires: python-devel
 Requires: rhnlib
 
-%if 0%{?rhel} >= 5 || 0%{?fedora} >= 1
+%if 0%{?rhel} >= 5 || 0%{?fedora}
 Requires: yum-rhn-plugin
 %else
 # rpm do not support elif

--- a/client/tools/rhnpush/rhnpush.spec
+++ b/client/tools/rhnpush/rhnpush.spec
@@ -19,7 +19,7 @@ BuildRequires:      rhn-client-tools
 %endif
 BuildRequires: docbook-utils, gettext
 BuildRequires: python-devel
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # pylint check
 BuildRequires:  spacewalk-pylint >= 0.6
 BuildRequires:  rhn-client-tools
@@ -55,7 +55,7 @@ rm -fv $RPM_BUILD_ROOT%{_mandir}/man8/solaris2mpm.8*
 rm -rf $RPM_BUILD_ROOT
 
 %check
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # check coding style
 export PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib}:/usr/share/rhn
 spacewalk-pylint $RPM_BUILD_ROOT%{rhnroot}

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -221,7 +221,7 @@ Provides: rhn-java = %{version}-%{release}
 Provides: rhn-java-sat = %{version}-%{release}
 Provides: rhn-oracle-jdbc-tomcat5 = %{version}-%{release}
 
-%if 0%{?fedora} && 0%{?fedora} >= 15
+%if 0%{?fedora}
 Requires: classpathx-jaf
 %endif
 
@@ -391,7 +391,7 @@ if test -d /usr/share/tomcat6; then
     fi
 fi
 
-%if 0%{?fedora} && 0%{?fedora} >= 19
+%if 0%{?fedora}
 %define skip_xliff  1
 %endif
 
@@ -464,15 +464,9 @@ find . -type f -name '*.xml' | xargs perl -CSAD -lne '
 
 %install
 rm -rf $RPM_BUILD_ROOT
-%if 0%{?fedora} && 0%{?fedora} < 18
-mkdir -p $RPM_BUILD_ROOT%{_javadir}/hibernate3
-ln -s -f %{_javadir}/hibernate3/hibernate-core.jar $RPM_BUILD_ROOT%{_javadir}/hibernate3/hibernate-core-3.jar
-ln -s -f %{_javadir}/hibernate3/hibernate-c3p0.jar $RPM_BUILD_ROOT%{_javadir}/hibernate3/hibernate-c3p0-3.jar
-ln -s -f %{_javadir}/hibernate3/hibernate-ehcache.jar $RPM_BUILD_ROOT%{_javadir}/hibernate3/hibernate-ehcache-3.jar
-%endif
 
 # on Fedora 19 some jars are named differently
-%if 0%{?fedora} && 0%{?fedora} > 18
+%if 0%{?fedora}
 mkdir -p $RPM_BUILD_ROOT%{_javadir}
 %if 0%{?fedora} < 20
 ln -s -f %{_javadir}/apache-commons-validator.jar $RPM_BUILD_ROOT%{_javadir}/commons-validator.jar
@@ -582,7 +576,7 @@ ln -s -f %{_javadir}/asm/asm.jar  $RPM_BUILD_ROOT%{_datadir}/rhn/lib/spacewalk-a
 %endif
 
 # 732350 - On Fedora 15, mchange's log stuff is no longer in c3p0.
-%if 0%{?fedora} >= 15
+%if 0%{?fedora}
 ln -s -f %{_javadir}/mchange-commons.jar $RPM_BUILD_ROOT%{jardir}/mchange-commons.jar
 %endif
 

--- a/monitoring/nocpulse-common/nocpulse-common.spec
+++ b/monitoring/nocpulse-common/nocpulse-common.spec
@@ -51,7 +51,7 @@ mkdir -p %{buildroot}%{_var}/lib/%{package_name}/.ssh
 
 # install log rotation stuff
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d
-%if 0%{?fedora} && 0%{?fedora} >= 16
+%if 0%{?fedora}
 install -m644 nocpulse.logrotate.new \
    $RPM_BUILD_ROOT/etc/logrotate.d/%{name}
 %else

--- a/monitoring/spacewalk-monitoring/spacewalk-monitoring.spec
+++ b/monitoring/spacewalk-monitoring/spacewalk-monitoring.spec
@@ -49,13 +49,7 @@ Requires:       tsdb
 Requires: spacewalk-monitoring-selinux
 
 %if 0%{?fedora}
-%if 0%{?fedora} > 18
 BuildRequires: systemd
-%else
-Requires(post): systemd
-Requires(preun): systemd
-Requires(postun): systemd
-%endif
 %else
 Requires(post): chkconfig
 Requires(preun): chkconfig

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -20,7 +20,7 @@ Requires: chkconfig
 Requires: libxslt
 Requires: spacewalk-certs-tools >= 1.6.4
 BuildRequires: /usr/bin/docbook2man
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # pylint check
 BuildRequires: spacewalk-pylint
 BuildRequires: rhnlib
@@ -74,7 +74,7 @@ install -m 640 jabberd/sm.xml jabberd/c2s.xml $RPM_BUILD_ROOT%{_usr}/share/rhn/i
 rm -rf $RPM_BUILD_ROOT
 
 %check
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # check coding style
 export PYTHONPATH=$RPM_BUILD_ROOT/usr/share/rhn:/usr/share/rhn
 spacewalk-pylint $RPM_BUILD_ROOT/usr/share/rhn

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -10,7 +10,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: python
 BuildArch: noarch
 Requires: httpd
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # pylint check
 BuildRequires: spacewalk-pylint
 BuildRequires: rhnpush >= 5.5.52
@@ -169,7 +169,7 @@ touch $RPM_BUILD_ROOT/%{httpdconf}/cobbler-proxy.conf
 rm -rf $RPM_BUILD_ROOT
 
 %check
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # check coding style
 export PYTHONPATH=$RPM_BUILD_ROOT/usr/share/rhn:$RPM_BUILD_ROOT%{python_sitelib}:/usr/share/rhn
 spacewalk-pylint $RPM_BUILD_ROOT/usr/share/rhn

--- a/schema/spacewalk/spacewalk-schema.spec
+++ b/schema/spacewalk/spacewalk-schema.spec
@@ -33,7 +33,7 @@ Oracle tablespace name conversions have NOT been applied.
 %setup -q
 
 %build
-%if 0%{?fedora} >= 16
+%if 0%{?fedora}
 find . -name '*.91' | while read i ; do mv $i ${i%%.91} ; done
 %endif
 make -f Makefile.schema SCHEMA=%{name} VERSION=%{version} RELEASE=%{release}

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -37,7 +37,7 @@ Requires: javapackages-tools
 Requires: jpackage-utils >= 0:1.5
 %endif
 Requires: log4j
-%if 0%{?fedora} >= 16
+%if 0%{?fedora}
 Requires: jakarta-oro
 %else
 Requires: oro
@@ -71,7 +71,7 @@ BuildRequires: jakarta-commons-logging
 %endif
 BuildRequires: java-devel >= 1.6.0
 BuildRequires: log4j
-%if 0%{?fedora} >= 16
+%if 0%{?fedora}
 BuildRequires: jakarta-oro
 %else
 BuildRequires: oro
@@ -82,13 +82,13 @@ BuildRequires: redstone-xmlrpc
 #BuildRequires: picocontainer
 BuildRequires: tanukiwrapper
 BuildRequires: simple-core
-%if 0%{?fedora} <=16
+%if 0%{?rhel}
 Requires(post): chkconfig
 Requires(preun): chkconfig
 # This is for /sbin/service
 Requires(preun): initscripts
 %endif
-%if 0%{?fedora} > 18
+%if 0%{?fedora}
 BuildRequires: systemd
 %endif
 

--- a/selinux/oracle-xe-selinux/oracle-xe-selinux.spec
+++ b/selinux/oracle-xe-selinux/oracle-xe-selinux.spec
@@ -40,7 +40,7 @@ SELinux policy module supporting Oracle XE server.
 %build
 # Build SELinux policy modules
 perl -i -pe 'BEGIN { $VER = join ".", grep /^\d+$/, split /\./, "%{version}.%{release}"; } s!\@\@VERSION\@\@!$VER!g;' %{modulename}.te
-%if 0%{?fedora} >= 17
+%if 0%{?fedora}
 cat %{modulename}.te.fedora17 >> %{modulename}.te
 %endif
 for selinuxvariant in %{selinux_variants}
@@ -81,7 +81,7 @@ rm -rf %{buildroot}
 
 %pre
 
-%if 0%{?fedora} >= 16
+%if 0%{?fedora}
 %define min_uid 1000
 %else
 %define min_uid 500

--- a/selinux/spacewalk-monitoring-selinux/spacewalk-monitoring-selinux.spec
+++ b/selinux/spacewalk-monitoring-selinux/spacewalk-monitoring-selinux.spec
@@ -77,7 +77,7 @@ SELinux policy module supporting Spacewalk monitoring.
 %build
 # Build SELinux policy modules
 perl -i -pe 'BEGIN { $VER = join ".", grep /^\d+$/, split /\./, "%{version}.%{release}"; } s!\@\@VERSION\@\@!$VER!g;' %{modulename}.te
-%if 0%{?fedora} >= 17
+%if 0%{?fedora}
 cat %{modulename}.te.fedora17 >> %{modulename}.te
 %endif
 for selinuxvariant in %{selinux_variants}

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -12,7 +12,7 @@ Requires: spacewalk-base
 Requires: perl-URI, perl(MIME::Base64)
 Requires: lsof
 BuildRequires: /usr/bin/pod2man
-%if 0%{?fedora} > 18
+%if 0%{?fedora}
 BuildRequires: systemd
 %endif
 Obsoletes: satellite-utils < 5.3.0

--- a/spacewalk/pylint/spacewalk-pylint.spec
+++ b/spacewalk/pylint/spacewalk-pylint.spec
@@ -10,7 +10,7 @@ Source0:	https://fedorahosted.org/releases/s/p/spacewalk/%{name}-%{version}.tar.
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch:	noarch
 
-%if 0%{?fedora} >= 19
+%if 0%{?fedora}
 Requires:	pylint > 1.1
 %else
 Requires:	pylint < 1.0
@@ -38,7 +38,7 @@ install -d -m 755 %{buildroot}/%{_bindir}
 install -p -m 755 spacewalk-pylint %{buildroot}/%{_bindir}/
 install -d -m 755 %{buildroot}/%{_sysconfdir}
 install -p -m 644 spacewalk-pylint.rc %{buildroot}/%{_sysconfdir}/
-%if 0%{?fedora} < 19
+%if 0%{?rhel}
 # new checks in pylint 1.1
 sed -i '/disable=/ s/,bad-whitespace,unpacking-non-sequence,superfluous-parens//g;' \
         %{buildroot}%{_sysconfdir}/spacewalk-pylint.rc

--- a/spec-tree/cobbler20/cobbler20.spec
+++ b/spec-tree/cobbler20/cobbler20.spec
@@ -35,13 +35,9 @@ Requires: mod_wsgi
 
 Requires: createrepo
 %if 0%{?fedora}
-%if 0%{?fedora} >= 19
 Requires: fence-agents-all
-%else
-Requires: fence-agents
 %endif
-%endif
-%if 0%{?fedora} >= 11 || 0%{?rhel} >= 6
+%if 0%{?fedora} || 0%{?rhel} >= 6
 Requires: genisoimage
 %else
 Requires: mkisofs
@@ -51,7 +47,7 @@ Requires: python-cheetah
 Requires: python-devel
 Requires: python-netaddr
 Requires: python-simplejson
-%if 0%{?fedora} >= 8
+%if 0%{?fedora}
 BuildRequires: python-setuptools-devel
 %else
 BuildRequires: python-setuptools
@@ -62,24 +58,19 @@ Requires: PyYAML
 BuildRequires: redhat-rpm-config
 %endif
 Requires: rsync
-%if 0%{?fedora} >= 6 || 0%{?rhel} >= 5
+%if 0%{?fedora} || 0%{?rhel} >= 5
 Requires: yum-utils
 %endif
 
 %if 0%{?fedora}
-%if 0%{?fedora} > 18
 BuildRequires: systemd
-%else
-Requires(post):  /bin/systemctl
-Requires(preun): /bin/systemctl
-%endif
 %else
 Requires(post):  /sbin/chkconfig
 Requires(preun): /sbin/chkconfig
 Requires(preun): /sbin/service
 %endif
 
-%if 0%{?fedora} >= 11 || 0%{?rhel} >= 6
+%if 0%{?fedora} || 0%{?rhel} >= 6
 %{!?pyver: %define pyver %(%{__python} -c "import sys ; print sys.version[:3]" || echo 0)}
 Requires: python(abi) >= %{pyver}
 %endif
@@ -266,7 +257,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %{python_sitelib}/cobbler/*.py*
 #%{python_sitelib}/cobbler/server/*.py*
 %{python_sitelib}/cobbler/modules/*.py*
-%if 0%{?fedora} >= 9 || 0%{?rhel} >= 5
+%if 0%{?fedora} || 0%{?rhel} >= 5
 %exclude %{python_sitelib}/cobbler/sub_process.py*
 %endif
 %{_mandir}/man1/cobbler.1.gz
@@ -347,7 +338,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /var/lib/cobbler/cobbler_hosts
 
 %defattr(-,root,root)
-%if 0%{?fedora} > 8 || 0%{?rhel} >= 6
+%if 0%{?fedora} || 0%{?rhel} >= 6
 %{python_sitelib}/cobbler*.egg-info
 %endif
 %doc AUTHORS CHANGELOG README COPYING
@@ -358,11 +349,11 @@ Summary: Helper tool that performs cobbler orders on remote machines.
 Group: Applications/System
 Requires: python >= 1.5
 BuildRequires: python-devel
-%if 0%{?fedora} >= 11 || 0%{?rhel} >= 6
+%if 0%{?fedora} || 0%{?rhel} >= 6
 %{!?pyver: %define pyver %(%{__python} -c "import sys ; print sys.version[:3]")}
 Requires: python(abi) >= %{pyver}
 %endif
-%if 0%{?fedora} >= 8
+%if 0%{?fedora}
 BuildRequires: python-setuptools-devel
 %endif
 %if 0%{?rhel} >= 4
@@ -382,15 +373,12 @@ of an existing system.  For use with a boot-server configured with Cobbler
 %files -n koan
 %defattr(-,root,root)
 # FIXME: need to generate in setup.py
-#%if 0%{?fedora} > 8
-#%{python_sitelib}/koan*.egg-info
-#%endif
 %dir /var/spool/koan
 %{_bindir}/koan
 %{_bindir}/cobbler-register
 %dir %{python_sitelib}/koan
 %{python_sitelib}/koan/*.py*
-%if 0%{?fedora} >= 9 || 0%{?rhel} >= 5
+%if 0%{?fedora} || 0%{?rhel} >= 5
 %exclude %{python_sitelib}/koan/sub_process.py*
 %exclude %{python_sitelib}/koan/opt_parse.py*
 %exclude %{python_sitelib}/koan/text_wrap.py*
@@ -434,11 +422,11 @@ Requires: apache2-mod_python
 %else
 Requires: mod_python
 %endif
-%if 0%{?fedora} >= 11 || 0%{?rhel} >= 6
+%if 0%{?fedora} || 0%{?rhel} >= 6
 %{!?pyver: %define pyver %(%{__python} -c "import sys ; print sys.version[:3]")}
 Requires: python(abi) >= %{pyver}
 %endif
-%if 0%{?fedora} >= 8
+%if 0%{?fedora}
 BuildRequires: python-setuptools-devel
 %else
 BuildRequires: python-setuptools

--- a/spec-tree/gyp/gyp.spec
+++ b/spec-tree/gyp/gyp.spec
@@ -1,6 +1,6 @@
 %global		revision	1010
 %{expand:	%%global	archivename	gyp-%{version}%{?revision:-svn%{revision}}}
-%if !(0%{?fedora} > 12 || 0%{?rhel} > 5)
+%if !(0%{?fedora} || 0%{?rhel} > 5)
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %endif
 

--- a/spec-tree/spacewalk-jpp-workaround/spacewalk-jpp-workaround.spec
+++ b/spec-tree/spacewalk-jpp-workaround/spacewalk-jpp-workaround.spec
@@ -27,9 +27,6 @@ Provides:   spring-all = 1.2.9.0
 Obsoletes:  spring-all < 1.2.9.0
 Provides:   spring = 1:1.2.9.0
 Obsoletes:  spring < 1:1.2.9.0
-%endif
-
-%if 0%{?fedora} && 0%{?fedora} >= 17
 Provides:   struts-taglib = 1.3.10
 Provides:   struts-tiles = 1.3.10
 Requires:   struts >= 1.3.10

--- a/spec-tree/v8/v8.spec
+++ b/spec-tree/v8/v8.spec
@@ -91,7 +91,7 @@ visibility=default \
 env=CCFLAGS:"-fPIC" \
 I_know_I_should_build_with_GYP=yes
 
-%if 0%{?fedora} >= 16
+%if 0%{?fedora}
 export ICU_LINK_FLAGS=`pkg-config --libs-only-l icu-i18n`
 %else
 export ICU_LINK_FLAGS=`pkg-config --libs-only-l icu`

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -16,7 +16,7 @@ BuildRequires:  /usr/bin/docbook2man
 BuildRequires:  docbook-utils
 BuildRequires:  python
 BuildRequires: /usr/bin/pod2man
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # pylint check
 BuildRequires:  spacewalk-pylint
 BuildRequires:  yum
@@ -73,7 +73,7 @@ make install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} \
 rm -rf $RPM_BUILD_ROOT
 
 %check
-%if 0%{?fedora} > 15 || 0%{?rhel} > 5
+%if 0%{?fedora} || 0%{?rhel} > 5
 # check coding style
 spacewalk-pylint $RPM_BUILD_ROOT%{rhnroot}
 %endif

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -153,7 +153,7 @@ mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/cron.daily
 install -m 644 conf/rhn_web.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
 install -m 644 conf/rhn_dobby.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
 install -m 755 modules/dobby/scripts/check-database-space-usage.sh $RPM_BUILD_ROOT/%{_sysconfdir}/cron.daily/check-database-space-usage.sh
-%if 0%{?fedora} < 18
+%if 0%{?rhel}
 rm -f $RPM_BUILD_ROOT%{perl_vendorlib}/PXT/Apache24Config.pm
 %endif
 


### PR DESCRIPTION
Also, replacing

```
0%{?fedora} < some-low-version
```

with

```
0%{?rhel}
```

Will this break SUSE?
