### PR TITLE
Do not look at processes in containers.

### DIFF
--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -55,7 +55,7 @@ ensure_httpd_down() {
     COUNT=0
     LIMIT=10
 
-    while [ "$(pidof httpd | wc -w)" -gt 0 ] && [ "$COUNT" -lt "$LIMIT" ]
+    while [ "$(pidof -c httpd | wc -w)" -gt 0 ] && [ "$COUNT" -lt "$LIMIT" ]
     do
        sleep 1
        ((COUNT++))


### PR DESCRIPTION
Generally `pidof` lists all the processes on the host, so it sees httpd in containers as well. And then `killall`s them all.

Ideally we'd probably like some

```
/usr/sbin/lsof -t -i TCP:80
```

there as well but the `-c` should address my immediate issue.
