### PR TITLE
[spacecmd] force the deployment of a given configchannel

### DIFF
--- a/spacecmd/src/lib/configchannel.py
+++ b/spacecmd/src/lib/configchannel.py
@@ -139,7 +139,7 @@ def do_configchannel_forcedeploy(self, args):
             print '================='
             print '\n'.join(systems)
     if self.user_confirm('Really force deployment [y/N]:'):
-        forcedeploy = self.client.configchannel.deployAllSystems(self.session, channel)
+        self.client.configchannel.deployAllSystems(self.session, channel)
 
 ####################
 


### PR DESCRIPTION
This patch creates an additional command within spacecmd to force a deployment of a given softwarechannel to all subscribed systems.
