### PR TITLE
Ensure bytes strings are sent to pyOpenSSL

### DIFF
--- a/client/debian/packages-already-in-debian/rhnlib/rhn/SSL.py
+++ b/client/debian/packages-already-in-debian/rhnlib/rhn/SSL.py
@@ -61,7 +61,10 @@ class SSLSocket:
         """
         if not os.access(file, os.R_OK):
             raise ValueError, "Unable to read certificate file %s" % file
-        self._trusted_certs.append(file)
+        try:
+            self._trusted_certs.append(file.encode("ascii"))
+        except UnicodeEncodeError:
+            raise ValueError, "Filename {0} contains non-ascii characters which would break libopenssl, please rename the file".format(file)
 
     def init_ssl(self):
         """

--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -74,7 +74,10 @@ class SSLSocket:
         """
         if not os.access(file, os.R_OK):
             raise ValueError, "Unable to read certificate file %s" % file
-        self._trusted_certs.append(file)
+        try:
+            self._trusted_certs.append(file.encode("ascii"))
+        except UnicodeEncodeError:
+            raise ValueError, "Filename {0} contains non-ascii characters which would break libopenssl, please rename the file".format(file)
 
     def init_ssl(self):
         """


### PR DESCRIPTION
pyOpenSSL relies on libopenssl which does not support unicode strings. Starting from version 0.14 pyOpenSSL refuses to take unicode strings as parameters for certain APIs. By refuse I meant certain APIs are going to throw a `TypeError` exception if the given string is a not an instance of `bytes`.

This problem affects python2 clients, but would get even more serious on machines using python3 because all python3 strings are unicode.

I reviewed our usage of pyOpenSSL's API and I found only the following places which got broken.

This patch should be applied even to systems which are running with previous versions of pyOpenSSL since it provides a better error message to the user. I did some tests against pyOpenSSL 0.13, I confirm our code would break with a `UnicodeEncodeErrors`, but this time without a meaningful explanation.

Just a small test program which can be used to reproduce the problem:

```
from OpenSSL import SSL

context = SSL.Context(SSL.SSLv23_METHOD)

cert = u"/tmp/certificates/this_works/RHN-ORG-TRUSTED-SSL-CERT"
context.load_verify_locations(cert)

cert = u"/tmp/certificates/©rashes/RHN-ORG-TRUSTED-SSL-CERT"
context.load_verify_locations(cert)
```

When using a pyOpenSSL version prior to 0.14 the program raises a `UnicodeEncodeError` exception on the last line:

> 'ascii' codec can't encode character u'\xa9' in position 18:
> ordinal not in range(128)

When running with pyOpenSSL 0.14 all the calls to `load_verify_locations` are going to raise a `TypeError` exception.
