### PR TITLE
python: convert trusted certificates filenames to utf-8

### DIFF
--- a/client/debian/packages-already-in-debian/rhnlib/rhn/SSL.py
+++ b/client/debian/packages-already-in-debian/rhnlib/rhn/SSL.py
@@ -61,10 +61,7 @@ class SSLSocket:
         """
         if not os.access(file, os.R_OK):
             raise ValueError, "Unable to read certificate file %s" % file
-        try:
-            self._trusted_certs.append(file.encode("ascii"))
-        except UnicodeEncodeError:
-            raise ValueError, "Filename {0} contains non-ascii characters which would break libopenssl, please rename the file".format(file)
+        self._trusted_certs.append(file.encode("utf-8"))
 
     def init_ssl(self):
         """

--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -74,10 +74,7 @@ class SSLSocket:
         """
         if not os.access(file, os.R_OK):
             raise ValueError, "Unable to read certificate file %s" % file
-        try:
-            self._trusted_certs.append(file.encode("ascii"))
-        except UnicodeEncodeError:
-            raise ValueError, "Filename {0} contains non-ascii characters which would break libopenssl, please rename the file".format(file)
+        self._trusted_certs.append(file.encode("utf-8"))
 
     def init_ssl(self):
         """


### PR DESCRIPTION
Commit e20cf3d4ecb6 encodes the strings containing the certificates filenames to "ascii". 

I realized libopenssl, which is being used by pyOpenSSL, uses `fopen()` to open these files. On Linux `fopen()` supports UTF-8 strings out of the box. Hence we can switch the encoding from 'ascii' to 'utf-8', making possible to support a wider set of characters.
