### PR TITLE
Fix Events > History (none) gives Internal Server Error caused by NPE

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
@@ -21,6 +21,8 @@ import com.redhat.rhn.domain.action.PackageActionFormatter;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -104,8 +106,9 @@ public class PackageAction extends Action {
             retval.append("<li>");
             Long evrId = pad.getEvr() != null ? pad.getEvr().getId() : null;
             Long archId = pad.getArch() != null ? pad.getArch().getId() : null;
-            retval.append(PackageManager.buildPackageNevra(pad.getPackageName().getId(),
-                    evrId, archId));
+            String nevra = PackageManager.buildPackageNevra(pad.getPackageName().getId(),
+                    evrId, archId);
+            retval.append(StringEscapeUtils.escapeHtml(nevra));
             retval.append("</li>");
         }
         retval.append("</ul>");


### PR DESCRIPTION
This PR contains a fix for a NPE found in Events > History whenever a package action was "scheduled by (none)" which could be e.g. package installations initiated from a bootstrap script.

Further a possible script injection has been fixed: whenever a package name contains a script (not sure though if actually a script can somehow slip into the database as a package name) it is now going to be escaped before it is listed here.
