### PR TITLE
1104087 - [RFE] spacewalk-repo-sync can obtain channel and repo set from a configuration file.

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -154,6 +154,7 @@ class RepoSync(object):
         """Trigger a reposync"""
         start_time = datetime.now()
         for (repo_id, url, repo_label) in self.urls:
+            print
             self.print_msg("Repo URL: %s" % url)
             plugin = None
 

--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -16,7 +16,9 @@
 #
 
 LOCK = None
-
+import re
+import StringIO
+import simplejson as json
 import shutil
 import sys
 import os
@@ -69,17 +71,18 @@ def main():
     parser.add_option('-l', '--list', action='store_true', dest='list',
                       help='List the custom channels with the assosiated repositories.')
     parser.add_option('-u', '--url', action='append', dest='url',
-                      default=[], help='The url to sync')
+                      default=[], help='The url of the repository. Can be used multiple times.')
     parser.add_option('-c', '--channel', action='store',
                       dest='channel_label',
-                      help='The label of the channel to sync packages to')
+                      help='The label of the channel to sync packages to. In order to specify more than one channel see option --config.')
     parser.add_option('-p', '--parent-channel', action='append',
                       dest='parent_label', default=[],
                       help='The label of the channel to sync packages to')
-
     parser.add_option('-d', '--dry-run', action='store_true',
                       dest='dry_run',
                       help='Test run. No sync takes place.')
+    parser.add_option('-g', '--config', action='store', dest='config',
+		       help='Configuration file')
     parser.add_option('-t', '--type', action='store', dest='repo_type',
                       help='The type of repo, currently only "yum" and "uln" are supported',
                       default='yum')
@@ -129,8 +132,30 @@ def main():
     # > afd8c60d7908b2b0e2d95ad0b333920aea9892eb', 'Invalid information uploaded to the server')
     clear_interrupted_downloads()
 
-    if not options.channel_label and not options.parent_label:
-        systemExit(1, "--channel or --parent-channel  must be specifed.")
+    if not options.channel_label and not options.parent_label and not options.config:
+        systemExit(1, "--channel, --parent-channel or --config must be specifed. must be specified")
+
+    if options.config:
+        try:
+            config_file = open(options.config).read()
+            # strip  all whitespace
+            config_file = re.sub(r'\s', '', config_file)
+            config = json.load(StringIO.StringIO(config_file))
+
+        except:
+            systemExit(1, "Configuration file is invalid, please check syntax.")
+
+        for key in l_params:
+		    if config.has_key(key) and not getattr(options, key):
+		        setattr(options, key, config[key])
+
+        # Channels
+        if config.has_key('channel'):
+            for ch,repo in config['channel'].iteritems():
+                 d_ch_repo_sync[ch]=repo
+
+        if config.has_key('parent_channel'):
+            options.parent_label+=config['parent_channel']
 
     if options.channel_label:
         d_ch_repo_sync[options.channel_label]=options.url
@@ -168,7 +193,11 @@ def main():
          return 0
 
     for ch,repo in d_ch_repo_sync.items():
-        print "#### Channel label: %s ####" % ch
+
+        print "======================================"
+        print "| Channel: %s" % ch
+        print "======================================"
+
         sync = reposync.RepoSync(channel_label=ch,
                       repo_type=options.repo_type,
                       url=repo,

--- a/backend/satellite_tools/spacewalk-repo-sync.sgml
+++ b/backend/satellite_tools/spacewalk-repo-sync.sgml
@@ -40,6 +40,11 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
         </group>
         <sbr>
         <group>
+        <arg>-g<replaceable>CONF_FILEe</replaceable></arg>
+        <arg>--config=<replaceable>CONF_FILE</replaceable></arg>
+        </group>
+        <sbr>
+        <group>
         <arg>-t<replaceable>TYPE</replaceable></arg>
         <arg>--type=<replaceable>TYPE</replaceable></arg>
         </group>
@@ -116,7 +121,7 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
     <varlistentry>
         <term>-p<replaceable>CHANNEL</replaceable>, --parent-channel=<replaceable>CHANNEL</replaceable></term>
         <listitem>
-            <para>Synchronize the parent channel and all its child channels. All must have repositories already assigned via WebUI.</para>
+            <para>Synchronize the parent channel and all its child channels. All must have repositories already assigned via WebUI or API.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -129,6 +134,12 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
         <term>-l, --list</term>
         <listitem>
             <para>List the custom channels with the assosiated repositories.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>-g, --config</term>
+        <listitem>
+            <para>Configuration file where more than one channel can be specified for synchronization. See section Examples.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -184,11 +195,40 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
 
 <refsect1><title>Examples</title>
 <simplelist>
-        <member><command>spacewalk-repo-sync --channel=my-custom-channel</command></member>
-        <member><command>spacewalk-repo-sync -crepo1 --url=http://example.com/yum-repo/</command></member>
-        <member><command>spacewalk-repo-sync -crepo2 --url=file:///var/share/localrepo/</command></member>
-        <member><command>spacewalk-repo-sync -crepom --url=http://example.com/mirrorlist.xml/</command></member>
-        <member><command>spacewalk-repo-sync --type uln --channel=orcl-channel --url=uln:///ol6_x86_64_latest</command></member>
+        <member>List all custom channels and the repositories assigned to them.</member>
+        <member><command>spacewalk-repo-sync --list </command></member>
+        <member>Synchronize single channel to all repositories assigned to it via WebUI or API.</member>
+        <member><command>spacewalk-repo-sync --channel custom-channel</command></member>
+        <member>Synchronize single channel to a repository specified on the command line.</member>
+        <member><command>spacewalk-repo-sync -c custom-channel --url=http://example.com/yum-repo/</command></member>
+        <member>Synchronize single channel to a local repository specified on the command line.</member>
+        <member><command>spacewalk-repo-sync -c custom-channel --url=file:///var/share/localrepo/</command></member>
+        <member>Synchronize single channel to a repository(mirror list) specified on the command line.</member>
+        <member><command>spacewalk-repo-sync -c custom-channel --url=http://example.com/mirrorlist.xml/</command></member>
+        <member>Synchronize single channel to more than one repository specified on the command line.</member>
+        <member><command>spacewalk-repo-sync -c custom-channel --url=http://example.com/yum-repo/ --url=http://example.com/yum-repo_2/</command></member>
+        <member>Synchronize parent channel and all its chiled channels. All channeles must have repository assigned via WebUI or API.</member>
+        <member><command>spacewalk-repo-sync -p parent-channel </command></member>
+        <member><command>spacewalk-repo-sync -c custom-channel --url=http://example.com/yum-repo/ -p parent-channel </command></member>
+        <member>Synchronize channels specified in configuration file.</member>
+        <member><command>spacewalk-repo-sync --config example.conf</command></member>
+        <member><command>spacewalk-repo-sync --config example.conf -c custom-channel --url=http://example.com/yum-repo/ -p parent-channel --fail</command></member>
+<member>Example configuration file.</member>
+<member>
+ <command>
+{<sbr>
+ "no_errata":false,<sbr>
+ "sync_kickstart":false,<sbr>
+ "quiet":false,<sbr>
+ "fail":true,<sbr>
+ "dry_run":false,<sbr>
+ "channel":{"chann_1":["http://ex.rh.com/repo1","http://ex.rh.com/repo2"],"chann_2":[]},<sbr>
+ "parent_channel":["parent_1","parent_2"]<sbr>
+}<sbr>
+ </command>
+</member>
+        <member>In order just to test the configuration use option --dry-run.</member>
+        <member><command>spacewalk-repo-sync --config example.conf --dry-run</command></member>
 </simplelist>
 </refsect1>
 


### PR DESCRIPTION
This [RFE]  implements the following features:
     - possibility to specify more than one channel to sync in configuration file
          # spacewalk-repo-sync   -c example_ch  --config example.conf
     - possibility to specify more than one repository URL for a channel from command line
          #  spacewalk-repo-sync   -c example_ch  --url  http://example.redhat.com --url http://example_1.redhat.com
    - updates the man page with examples for all possible usages of spacewalk-repo-sync
  