### PR TITLE
Fix human dates now() staying unmodified and displayed incorrectly (bnc#880081) 

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
@@ -291,6 +291,17 @@ public class FormatDateTag extends TagSupport {
         return (SKIP_BODY);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws JspException
+     */
+    @Override
+    public int doEndTag() throws JspException {
+        reset();
+        return super.doEndTag();
+    }
+
     protected String getCssClass() {
         if (FROM.equalsIgnoreCase(getHumanStyle())) {
             return " class=\"human-from\"";
@@ -386,12 +397,4 @@ public class FormatDateTag extends TagSupport {
         pattern = null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void release() {
-        reset();
-        super.release();
-    }
 }


### PR DESCRIPTION
TagSupport:release() is not called between invocations by the container if tag pooling is enabled, but only on GC or invocations with different set of optional paramenters.

See https://issues.apache.org/bugzilla/show_bug.cgi?id=16001 for details.

We should check other tags later.
