### PR TITLE
compare_packages_to_snapshot query fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -2162,19 +2162,19 @@ select  pn.name as package_name,
         case when server_pkgs.max_evr is null then null
           else evr_t_as_vre_simple(server_pkgs.max_evr)
         end as server_nvrea,
-        srvpe.epoch as server_epoch,
-        srvpe.version as server_version,
-        srvpe.release as server_release,
+        (server_pkgs.max_evr).epoch as server_epoch,
+        (server_pkgs.max_evr).version as server_version,
+        (server_pkgs.max_evr).release as server_release,
         case when snapshot_pkgs.max_evr is null then null
           else evr_t_as_vre_simple(snapshot_pkgs.max_evr)
         end as snapshot_nvrea,
-        snape.epoch as snapshot_epoch,
-        snape.version as snapshot_version,
-        snape.release as snapshot_release,
+        (snapshot_pkgs.max_evr).epoch as snapshot_epoch,
+        (snapshot_pkgs.max_evr).version as snapshot_version,
+        (snapshot_pkgs.max_evr).release as snapshot_release,
         case when server_pkgs.max_evr is null then -2
              when snapshot_pkgs.max_evr is null then 2
-             else rpm.vercmp(srvpe.epoch, srvpe.version, srvpe.release,
-                             snape.epoch, snape.version, snape.release)
+             else rpm.vercmp((server_pkgs.max_evr).epoch, (server_pkgs.max_evr).version, (server_pkgs.max_evr).release,
+                             (snapshot_pkgs.max_evr).epoch, (snapshot_pkgs.max_evr).version, (snapshot_pkgs.max_evr).release)
         end as comparison
   from (select max(pem1.evr) as max_evr, sp.name_id, sp.package_arch_id
           from rhnServerPackage sp
@@ -2201,13 +2201,10 @@ select  pn.name as package_name,
     on pn.id = coalesce(server_pkgs.name_id, snapshot_pkgs.name_id)
   join rhnPackageArch pa
     on pa.id = coalesce(server_pkgs.package_arch_id, snapshot_pkgs.package_arch_id)
-  left join rhnPackageEvr srvpe
-    on server_pkgs.max_evr = srvpe.evr
-  left join rhnPackageEvr snape
-    on snapshot_pkgs.max_evr = snape.evr
  where server_pkgs.max_evr is null
     or snapshot_pkgs.max_evr is null
-    or srvpe.id != snape.id
+    or (rpm.vercmp((server_pkgs.max_evr).epoch, (server_pkgs.max_evr).version, (server_pkgs.max_evr).release,
+                   (snapshot_pkgs.max_evr).epoch, (snapshot_pkgs.max_evr).version, (snapshot_pkgs.max_evr).release) &lt;&gt; 0)
  order by pn.name
   </query>
 </mode>


### PR DESCRIPTION
First commit addresses an Oracle error that might show up depending on data.

Second commit should speed up execution considerably. At the best of my knowledge this should not alter behavior, please highlight errors if you spot any.
