### PR TITLE
Java cleanup fix: ensure an Iterator<String> is passed

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/errata/EditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/EditAction.java
@@ -31,7 +31,10 @@ import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.frontend.struts.StrutsDelegate;
 import com.redhat.rhn.manager.errata.ErrataManager;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections.Transformer;
 import org.apache.commons.lang.StringUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
@@ -85,8 +88,14 @@ public class EditAction extends LookupDispatchAction {
         DynaActionForm form = (DynaActionForm) formIn;
 
         String keywordDisplay = StringUtil.join(
-                LocalizationService.getInstance().getMessage("list delimiter"),
-                IteratorUtils.getIterator(errata.getKeywords()));
+            LocalizationService.getInstance().getMessage("list delimiter"),
+            IteratorUtils.getIterator(CollectionUtils.collect(errata.getKeywords(),
+                new Transformer() {
+                    @Override
+                    public Object transform(Object o) {
+                        return o.toString();
+                    }
+                })));
 
         //pre-populate form with current values
         form.set("synopsis", errata.getSynopsis());

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupAction.java
@@ -26,6 +26,9 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.errata.ErrataManager;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.collections.Transformer;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
@@ -63,8 +66,14 @@ public class ErrataDetailsSetupAction extends RhnAction {
         String keywordsDisplay = null;
         if (keywords != null) {
             keywordsDisplay = StringUtil.join(
-                    LocalizationService.getInstance().getMessage("list delimiter"),
-                    keywords.iterator());
+                LocalizationService.getInstance().getMessage("list delimiter"),
+                IteratorUtils.getIterator(CollectionUtils.collect(keywords,
+                        new Transformer() {
+                            @Override
+                            public Object transform(Object o) {
+                                return o.toString();
+                            }
+                        })));
         }
 
         request.setAttribute("errata", errata);


### PR DESCRIPTION
This commit fixes a rather subtle error introduced with the recent Java generics cleanup.

In this case we have an Iterator without generic type information that gets passed to a method that expects Iterator<String>, this results in a runtime type error at runtime.

Independently from the solution of this specific issue, the following broader questions arise:
- do you guys periodically run the testsuite against master? I ask because I have been fixing quite some bugs lately just by running it.
- is there any specific requirement (eg. packaging) for updating commons-collections and other very basic libraries? It seems that many generics warnings can't really be fixed otherwise, and bugs like this slip in.

Thanks
