### PR TITLE
Do not enable spacewalk-service in runlevel 4

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -1188,7 +1188,7 @@ sub setup_gpg {
 
 # Satellite services are handled by chkconfig now.
 sub setup_services {
-  Spacewalk::Setup::system_or_exit(["/usr/sbin/spacewalk-service", "--level", "345", "enable"], 11, 'Could not turn spacewalk services on.');
+  Spacewalk::Setup::system_or_exit(["/usr/sbin/spacewalk-service", "--level", "35", "enable"], 11, 'Could not turn spacewalk services on.');
 
   return 1;
 }


### PR DESCRIPTION
Runlevel 4 is not used in SUSE Linux and this causes some errors, related to "insserv" when the services are setup. The issue does not affects the Spacewalk installation, however it outputs error to STDERR where other tools reacts critically.

Seems like RHEL does not use this level too and runlevel 4 was left for historical reasons. We suggest to remove it.
