### PR TITLE
fix to support custom kickstart distributions

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -233,6 +233,14 @@ public class KickstartUrlHelper {
         StringBuilder file = new StringBuilder();
         file.append(KS_DIST);
         file.append("/");
+
+        // check for custom distros
+        if(this.ksTree.getOrgId() != null) {
+           file.append("org/");
+           file.append(this.ksTree.getOrgId());
+           file.append("/");
+        }
+
         file.append(this.ksTree.getLabel());
         return file.toString();
     }


### PR DESCRIPTION
reviewed this path with sherr. this will fix the media_path url for newly created custom distros but the existing custom distros will need to be corrected using cobbler cli
