### PR TITLE
Implement the new rpm weak dependency tags

### DIFF
--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -164,14 +164,29 @@ class rpmBinaryPackage(Package, rpmPackage):
             'requires'  : rpmRequires,
             'conflicts' : rpmConflicts,
             'obsoletes' : rpmObsoletes,
+            'breaks'    : rpmBreaks,
+            'predepends': rpmPredepends,
+        }
+
+        old_weak_deps_mapping = {
+            'supplements' : rpmOldSupplements,
+            'enhances'  : rpmOldEnhances,
+            'suggests'  : rpmOldSuggests,
+            'recommends'  : rpmOldRecommends,
+        }
+
+        new_weak_deps_mapping = {
             'supplements' : rpmSupplements,
             'enhances'  : rpmEnhances,
             'suggests'  : rpmSuggests,
             'recommends': rpmRecommends,
-            'breaks'    : rpmBreaks,
-            'predepends': rpmPredepends,
         }
+
         for k, v in mapping.items():
+            self._populateTag(header, k, v)
+        for k, v in old_weak_deps_mapping.items():
+            self._populateTag(header, k, v)
+        for k, v in new_weak_deps_mapping.items():
             self._populateTag(header, k, v)
 
     def _populateChangeLog(self, header):
@@ -204,7 +219,9 @@ class rpmBinaryPackage(Package, rpmPackage):
             fix[f] = v
 
         # Now create the array of objects
-        self[tag] = []
+        if self[tag] is None:
+	  self[tag] = []
+
         unique_deps = []
         for i in range(itemcount):
             hash = {}
@@ -218,11 +235,13 @@ class rpmBinaryPackage(Package, rpmPackage):
                 else:
                     hash[k] = v[i]
 
+            # for the old weak dependency tags
             # RPMSENSE_STRONG(1<<27) indicate recommends; if not set it is suggests only
-            if tag in ['recommends', 'supplements', 'breaks', 'predepends'] and not(hash['flags'] & (1 << 27)):
-                continue
-            if tag in ['suggests', 'enhances'] and (hash['flags'] & (1 << 27)):
-                continue
+	    if Class in [rpmOldRecommends, rpmOldSupplements, rpmOldSuggests, rpmOldEnhances]:
+                if tag in ['recommends', 'supplements'] and not(hash['flags'] & (1 << 27)):
+                    continue
+                if tag in ['suggests', 'enhances'] and (hash['flags'] & (1 << 27)):
+                    continue
             # Create a file
             obj = Class()
             # Fedora 10+ rpms have duplicate provides deps,
@@ -334,23 +353,55 @@ class rpmRequires(Dependency):
         'flags'     : 'requireflags',
     }
 
-class rpmSuggests(Dependency):
+class rpmOldSuggests(Dependency):
     # More mappings
     tagMap = {
         'name'      : 1156, #'suggestsname',
         'version'   : 1157, #'suggestsversion',
         'flags'     : 1158, #'suggestsflags',
+    }
+
+class rpmSuggests(Dependency):
+    # More mappings
+    tagMap = {
+        'name'      : 5049, #'suggestsname',
+        'version'   : 5050, #'suggestsversion',
+        'flags'     : 5051, #'suggestsflags',
+    }
+
+class rpmOldRecommends(Dependency):
+    # More mappings
+    tagMap = {
+        'name'      : 1156, #'recommendsname',
+        'version'   : 1157, #'recommendsversion',
+        'flags'     : 1158, #'recommendsflags',
     }
 
 class rpmRecommends(Dependency):
     # More mappings
     tagMap = {
-        'name'      : 1156, #'suggestsname',
-        'version'   : 1157, #'suggestsversion',
-        'flags'     : 1158, #'suggestsflags',
+        'name'      : 5046, #'recommendsname',
+        'version'   : 5047, #'recommendsversion',
+        'flags'     : 5048, #'recommendsflags',
+    }
+
+class rpmOldSupplements(Dependency):
+    # More mappings
+    tagMap = {
+        'name'      : 1159, #'supplementsname',
+        'version'   : 1160, #'supplementsversion',
+        'flags'     : 1161, #'supplementsflags',
     }
 
 class rpmSupplements(Dependency):
+    # More mappings
+    tagMap = {
+        'name'      : 5052, #'supplementsname',
+        'version'   : 5053, #'supplementsversion',
+        'flags'     : 5054, #'supplementsflags',
+    }
+
+class rpmOldEnhances(Dependency):
     # More mappings
     tagMap = {
         'name'      : 1159, #'enhancesname',
@@ -361,9 +412,9 @@ class rpmSupplements(Dependency):
 class rpmEnhances(Dependency):
     # More mappings
     tagMap = {
-        'name'      : 1159, #'enhancesname',
-        'version'   : 1160, #'enhancesversion',
-        'flags'     : 1161, #'enhancesflags',
+        'name'      : 5055, #'enhancesname',
+        'version'   : 5056, #'enhancesversion',
+        'flags'     : 5057, #'enhancesflags',
     }
 
 class rpmConflicts(Dependency):


### PR DESCRIPTION
Both the old IDs and the new ones are read in sequence. That is why
the self[tag] array is initialized only once and not on each _populateTag call.