### PR TITLE
Fix ISE when tag name is left empty

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotTagCreateAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotTagCreateAction.java
@@ -73,7 +73,11 @@ public class SnapshotTagCreateAction extends RhnAction {
             else {
                 snap = ServerFactory.lookupLatestForServer(server);
             }
-            if (!snap.addTag(tagName)) {
+            if (tagName.isEmpty()) {
+                createErrorMessage(request,
+                        "system.history.snapshot.tagNameEmpty", null);
+            }
+            else if (!snap.addTag(tagName)) {
                 createErrorMessage(request,
                         "system.history.snapshot.tagCreateFailure", null);
             }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -12298,6 +12298,9 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
         <trans-unit id="system.history.snapshot.tagCreateSuccess">
           <source>Tag added to system</source>
         </trans-unit>
+        <trans-unit id="system.history.snapshot.tagNameEmpty">
+          <source>Tag name may not be left empty, please choose a name for the new tag.</source>
+        </trans-unit>
         <trans-unit id="system.history.snapshot.tagCreateFailure">
           <source>That tag already exists for this system. Please choose another tag name.</source>
         </trans-unit>


### PR DESCRIPTION
This is a fix for an ISE that happens whenever the form to create a new snapshot tag is submitted with an empty tag name.
