### PR TITLE
1009430 - traceback when running rhn-satellite-exporter/spacewalk-remove-channel as non-root

### DIFF
--- a/backend/satellite_tools/disk_dumper/rhn-satellite-exporter
+++ b/backend/satellite_tools/disk_dumper/rhn-satellite-exporter
@@ -8,16 +8,21 @@
 # FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-# 
+#
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
-# in this software or its documentation. 
+# in this software or its documentation.
 #
 
 import cStringIO
 
 import sys
 import os
+
+# quick check to see if you are a super-user.
+if os.getuid() != 0:
+    sys.stderr.write('ERROR: must be root to execute\n')
+    sys.exit(8)
 
 from spacewalk.satellite_tools.disk_dumper import iss
 from spacewalk.satellite_tools.syncLib import log2stderr, log2email
@@ -77,7 +82,7 @@ if __name__ == "__main__":
             iss.sendMail()
 
         if main.options.print_report:
-            iss.print_report()        
+            iss.print_report()
 
         sys.exit(-1)
 

--- a/backend/satellite_tools/spacewalk-remove-channel
+++ b/backend/satellite_tools/spacewalk-remove-channel
@@ -23,6 +23,11 @@ import os
 import shutil
 from optparse import Option, OptionParser
 
+# quick check to see if you are a super-user.
+if os.getuid() != 0:
+    sys.stderr.write('ERROR: must be root to execute\n')
+    sys.exit(8)
+
 try:
     from rhn import rhnLockfile    #new place for rhnLockfile
 except:
@@ -63,12 +68,8 @@ LOCK = []
 LOCK_DIR = '/var/run'
 
 def main():
+
     global LOCK
-
-    if os.getuid() != 0:
-        sys.stderr.write('ERROR: must be root to execute\n')
-        sys.exit(8)
-
     global options_table
     parser = OptionParser(option_list=options_table)
 


### PR DESCRIPTION
1009430 - traceback when running rhn-satellite-exporter/spacewalk-remove-channel as non-root: spacewalk.common.rhnConfig.ConfigParserError: ('config file read error', '/etc/rhn/rhn.conf', 'Permission denied') 
