### PR TITLE
add Korea to the list of timezones

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
@@ -116,6 +116,12 @@
           <context context-type="sourcefile">/rhn/account/UserDetails</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="Asia/Seoul">
+        <source>(GMT+0900) Korea</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/account/UserDetails</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="Australia/Perth">
         <source>(GMT+0800) Australia (Western)</source>
         <context-group name="ctx">

--- a/schema/spacewalk/common/data/rhnTimezone.sql
+++ b/schema/spacewalk/common/data/rhnTimezone.sql
@@ -39,6 +39,13 @@ insert into rhnTimezone
   (id, olson_name, display_name)
 values
   (sequence_nextval('rhn_timezone_id_seq'),
+   'Asia/Seoul', 'Korea');
+
+
+insert into rhnTimezone
+  (id, olson_name, display_name)
+values
+  (sequence_nextval('rhn_timezone_id_seq'),
    'Australia/Perth', 'Australia (Western)');
 
 

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.1-to-spacewalk-schema-2.2/027-rhnTimezone-data.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.1-to-spacewalk-schema-2.2/027-rhnTimezone-data.sql
@@ -1,0 +1,12 @@
+insert into rhnTimezone (id, olson_name, display_name) (
+    select sequence_nextval('rhn_timezone_id_seq'),
+           'Asia/Seoul',
+           'Korea'
+      from dual
+     where not exists (
+           select 1
+             from rhnTimezone
+            where olson_name = 'Asia/Seoul'
+              and display_name = 'Korea'
+     )
+);


### PR DESCRIPTION
People of Korea do not seem to like having to choose the Japan timezone for historical reasons, even if the offset is the same.
