### PR TITLE
905129 - Speed up satellite-sync by avoiding commonly-called dblink_exec

### DIFF
--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -82,6 +82,7 @@ class Backend:
                                  % format)
         sth.execute()
 
+    # Note: postgres-specific implementation overrides this in PostgresBackend
     def processCapabilities(self, capabilityHash):
         h = self.dbmodule.prepare("select lookup_package_capability(:name, :version) as id from dual")
         for name, version in capabilityHash.keys():
@@ -494,6 +495,7 @@ class Backend:
             if row:
                 evrHash[evr] = row['id']
 
+    # Note: postgres-specific implementation overrides this in PostgresBackend
     def lookupChecksums(self, checksumHash):
         if not checksumHash:
             return

--- a/schema/spacewalk/postgres/procs/lookup_checksum.sql
+++ b/schema/spacewalk/postgres/procs/lookup_checksum.sql
@@ -53,3 +53,36 @@ begin
 end;
 $$
 language plpgsql immutable;
+
+-- NOTE: This is intentionally not thread safe! You must lock rhnChecksum
+-- if you are going to use this procedure!
+create or replace function
+lookup_checksum_fast(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    if checksum_in is null then
+        return null;
+    end if;
+
+    select c.id
+      into checksum_id
+      from rhnChecksumView c
+     where c.checksum = checksum_in and
+           c.checksum_type = checksum_type_in;
+
+    if not found then
+        checksum_id := nextval('rhnchecksum_seq');
+        insert into rhnChecksum (id, checksum_type_id, checksum) values (
+            checksum_id,
+            (select id from rhnChecksumType where label = checksum_type_in),
+            checksum_in);
+    end if;
+
+    return checksum_id;
+end;
+$$
+language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_package_capability.sql
+++ b/schema/spacewalk/postgres/procs/lookup_package_capability.sql
@@ -63,3 +63,37 @@ begin
 end;
 $$
 language plpgsql immutable;
+
+-- Note: intentionally not thread-safe! You must aquire a write lock on the
+-- rhnPackageCapability tabel if you are going to use this proc!
+create or replace function lookup_package_capability_fast(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    if version_in is null then
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version is null;
+    else
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version = version_in;
+    end if;
+
+    if not found then
+        name_id = nextval('rhn_pkg_capability_id_seq');
+        insert into rhnPackageCapability(id, name, version) values (
+               name_id, name_in, version_in);
+    end if;
+
+    return name_id;
+end;
+$$
+language plpgsql;

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/001-lookup_package_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/001-lookup_package_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- This file intentionally left empty.

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/001-lookup_package_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/001-lookup_package_capability.sql.postgresql
@@ -1,0 +1,35 @@
+-- oracle equivalent source sha1 add856b7a87a02b324232caad9383c6103ed7abd
+
+-- Note: intentionally not thread-safe! You must aquire a write lock on the
+-- rhnPackageCapability tabel if you are going to use this proc!
+create or replace function lookup_package_capability_fast(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    if version_in is null then
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version is null;
+    else
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version = version_in;
+    end if;
+
+    if not found then
+        name_id = nextval('rhn_pkg_capability_id_seq');
+        insert into rhnPackageCapability(id, name, version) values (
+               name_id, name_in, version_in);
+    end if;
+
+    return name_id;
+end;
+$$
+language plpgsql;

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/002-lookup_checksum.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/002-lookup_checksum.sql.oracle
@@ -1,0 +1,1 @@
+-- This file intentionally left empty.

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/002-lookup_checksum.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/002-lookup_checksum.sql.postgresql
@@ -1,0 +1,34 @@
+-- oracle equivalent source sha1 add856b7a87a02b324232caad9383c6103ed7abd
+
+-- NOTE: This is intentionally not thread safe! You must lock rhnChecksum
+-- if you are going to use this procedure!
+create or replace function
+lookup_checksum_fast(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    if checksum_in is null then
+        return null;
+    end if;
+
+    select c.id
+      into checksum_id
+      from rhnChecksumView c
+     where c.checksum = checksum_in and
+           c.checksum_type = checksum_type_in;
+
+    if not found then
+        checksum_id := nextval('rhnchecksum_seq');
+        insert into rhnChecksum (id, checksum_type_id, checksum) values (
+            checksum_id,
+            (select id from rhnChecksumType where label = checksum_type_in),
+            checksum_in);
+    end if;
+
+    return checksum_id;
+end;
+$$
+language plpgsql;


### PR DESCRIPTION
This speeds up the initial sync of a base channel from 20:30 to 5:20. More details at https://bugzilla.redhat.com/show_bug.cgi?id=905129
