### PR TITLE
969637 - sw-clone-by-date man page desc for --parents is not correct.

### DIFF
--- a/utils/spacewalk-clone-by-date
+++ b/utils/spacewalk-clone-by-date
@@ -232,9 +232,12 @@ def parse_args():
     # correctly determins if a channel already exists and does not try
     # to re-create it.
     parser.add_option("-a", "--parents", dest="parents", nargs=2,
-            help="Already existing channels that will be used as the "
-            + "original parent and destination parent of child "
-            + "channels cloned this session.")
+            help="Space separated list of source parent channel and "
+            + "destination parent channel. These channels are used for "
+            + "resolving dependencies and cloning the children, but will "
+            + "not be cloned themselves. Both channels specified here must "
+            + "already exist. There is no way to specify this option through "
+            + "the config file.")
     parser.add_option("-z", "--use-update-date", dest="use_update_date",
             action='store_true', help="While cloning errata by date, clone "
             + "all errata that have last been updated on or before the date "

--- a/utils/spacewalk-clone-by-date.sgml
+++ b/utils/spacewalk-clone-by-date.sgml
@@ -228,7 +228,7 @@ Utility for cloning errata by date (For RHEL5 and above).
     <varlistentry>
         <term>-a <replaceable>SRC_PARENT DEST_PARENT</replaceable>, --parents=<replaceable>SRC_PARENT DEST_PARENT</replaceable></term>
         <listitem>
-            <para>Space separated list of source parent channel and destination parent channel.  These channels are used for resolving dependencies and cloning the children, but will not be cloned themselves.  Both channels specified here must already exist.  There is no way to specify this option through the config channel, you must simply re-list the parent src:dest channels as part of the list to clone.  Spacewalk-clone-by-date will detect that the dest parent channel already exists and will not try to re-create it.</para>
+            <para>Space separated list of source parent channel and destination parent channel. These channels are used for resolving dependencies and cloning the children, but will not be cloned themselves. Both channels specified here must already exist. There is no way to specify this option through the config file.</para>
         </listitem>
     </varlistentry>
 </variablelist>


### PR DESCRIPTION
Bug 969637 - While using spacewalk-clone-by-date with configuration file, updates already existing base channel along with creating clone of child channel.
