### PR TITLE
Update spacewalk-backend.spec

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -32,7 +32,7 @@ BuildRequires: /usr/bin/msgfmt
 BuildRequires: /usr/bin/docbook2man
 BuildRequires: docbook-utils
 %if 0%{?pylint_check}
-BuildRequires: spacewalk-pylint
+BuildRequires: spacewalk-pylint >= 2.2
 BuildRequires: rhnlib >= 2.5.57
 BuildRequires: rhn-client-tools
 BuildRequires: rpm-python


### PR DESCRIPTION
I had some problems on building this rpm package by using tito. Before I did this, you have to do a yum-builddep and it is possible, that the os installs spacewalk-pylint from the epel repository (if it is installed).
