### PR TITLE
1128825 - AKey package names separated by spaces.

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -34,6 +34,7 @@ import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.InvalidArgsException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidPackageException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidServerGroupException;
@@ -734,6 +735,10 @@ public class ActivationKeyHandler extends BaseHandler {
         String arch = null;
         for (Map<String, String> pkg : packages) {
             name = pkg.get("name");
+            if (name.contains(" ")) {
+                throw new InvalidArgsException(
+                        "More than one package names are specified.");
+            }
             PackageName packageName = PackageFactory.lookupOrCreatePackageByName(name);
 
             arch = pkg.get("arch");

--- a/java/code/src/com/redhat/rhn/manager/token/ActivationKeyPackagesCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/token/ActivationKeyPackagesCommand.java
@@ -96,6 +96,7 @@ public class ActivationKeyPackagesCommand {
             log.debug("parseAndUpdatePackages() : packagesIn: " + packagesIn);
         }
 
+        packagesIn = packagesIn.replaceAll("[\t\\s]+", NEWLINE);
         for (StringTokenizer strtok = new StringTokenizer(packagesIn, NEWLINE); strtok
                 .hasMoreTokens();) {
             String token = strtok.nextToken();


### PR DESCRIPTION
1128825 - AKey package names separated by spaces.
WebUI: Systems -> Activation Keys -> AK -> Packages -> "test1 test2" -> Press Update Key
API:  client.activationkey.addPackages(key,"1-6477c9a04e508743ad3461fe35bfb026 Satellite",[{'name':"test1 test2"}])
