### PR TITLE
1128893 - sw-repo-sync does not work for chann that are children of non-custom parent

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -68,7 +68,7 @@ def getChannelRepo():
 
     return items
 
-def getParentsChilds():
+def getParentsChilds(b_only_custom=False):
 
     initCFG('server')
     rhnSQL.initDB()
@@ -85,7 +85,7 @@ def getParentsChilds():
         row = h.fetchone_dict()
         if not row:
             break
-        if rhnChannel.isCustomChannel(row['id']):
+        if not b_only_custom or rhnChannel.isCustomChannel(row['id']):
             parent_channel = row['parent_channel']
             if not parent_channel:
                 d_parents[row['label']] = []
@@ -101,7 +101,7 @@ def getParentsChilds():
 
 def getCustomChannels():
 
-    d_parents = getParentsChilds()
+    d_parents = getParentsChilds(True)
     l_custom_ch = []
 
     for ch in d_parents:

--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -137,7 +137,8 @@ def main():
         for pch in options.parent_label:
             if pch in d_parent_child:
                for ch in [pch]+d_parent_child[pch]:
-                    d_ch_repo_sync[ch]=[]
+                    if ch in l_ch_custom:
+                        d_ch_repo_sync[ch]=[]
             else:
                 systemExit(1, "Channel %s is not custom base channel." % pch)
 


### PR DESCRIPTION
This pull request is addressing two issues:
        --parent-channel non_custom_parent
        --channel child_channel_of_non_custom_parent
Configuration:
    Base non-custom channel: rhel-x86_64-server-6 
    Child channel of rhel-x86_64-server-6 : epel_repo_6

$ spacewalk-repo-sync   --parent-channel  rhel-x86_64-server-6  --dry-run
|   Channel Label   |   Repository   |
 epel_repo_6 : http:/test.com

 $ spacewalk-repo-sync  --channel epel_repo_6   --dry-run
|   Channel Label   |   Repository   |
 epel_repo_6 : http:/test.com
