### PR TITLE
updated links to proper sections in Satellite 5.6 documentation

### DIFF
--- a/branding/conf/rhn_docs.conf
+++ b/branding/conf/rhn_docs.conf
@@ -1,7 +1,7 @@
-docs.reference_guide=https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/5.6/
-docs.install_guide=https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/5.6/
-docs.proxy_guide=https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/5.6/
-docs.client_config_guide=https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/5.6/
-docs.user_guide=https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/5.6/
-docs.getting_started_guide=https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/5.6/
+docs.reference_guide=https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/5.6/html/Reference_Guide/index.html
+docs.install_guide=https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/5.6/html/Installation_Guide/index.html
+docs.proxy_guide=https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/5.6/html/Proxy_Installation_Guide/index.html
+docs.client_config_guide=https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/5.6/html/Client_Configuration_Guide/index.html
+docs.user_guide=https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/5.6/html/User_Guide/index.html
+docs.getting_started_guide=https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/5.6/html/Getting_Started_Guide/index.html
 docs.release_notes=https://fedorahosted.org/spacewalk/wiki/ReleaseNotes


### PR DESCRIPTION
All documentation links point to the very same site. We want them to point to the proper sections in the Satellite 5.6 documentation.
