### PR TITLE
1128735 - force character set and numerical separators to good known defaults.

### DIFF
--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -21,6 +21,9 @@ if (not defined $options{db_backend}) {
 	die "Config file [$config_file] does not seem to have database backend info (db_backend) set.\n";
 }
 
+$ENV{NLS_LANG} = 'AMERICAN_AMERICA.UTF8';
+$ENV{NLS_NUMERIC_CHARACTERS} = '.';
+
 my $test = run_query("select '1' || '2' || '3' as testing from dual;");
 if (not defined $test) {
 	die "Connect to database was not successful.\n";


### PR DESCRIPTION
We could have done this directly in spacewalk-sql but that would take away the ability for users to run spacewalk-sql in their locales, if they wish to do so. Hence I'm proposing it to spacewalk-schema-upgrade.
