### PR TITLE
1138275 - spacewalk-debug is not fully PostgreSQL aware.

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -183,14 +183,14 @@ fi
 
 # /etc/passwd
 if [ -f /etc/passwd ] ; then
-	echo "    * copying apache, oracle, tomcat, nocpulse entries from /etc/passwd"
-	getent passwd apache tomcat oracle nocpulse > $DIR/conf/passwd
+	echo "    * copying apache, postgres, tomcat, nocpulse entries from /etc/passwd"
+	getent passwd apache tomcat postgres nocpulse > $DIR/conf/passwd
 fi
 
 # /etc/group
 if [ -f /etc/group ] ; then
-	echo "    * copying apache, oracle, tomcat, nocpulse entries from /etc/group"
-	getent group apache tomcat oracle nocpulse dba > $DIR/conf/group
+	echo "    * copying apache, postgres, tomcat, nocpulse entries from /etc/group"
+	getent group apache tomcat postgres nocpulse > $DIR/conf/group
 fi
 
 echo "    * querying RPM database (versioning of Spacewalk, etc.)"
@@ -218,9 +218,6 @@ if [ -f /rhnsat/admin/rhnsat/bdump/alert_rhnsat.log ] ; then
 	echo "    * copying alert_rhnsat.log"
 	cp -fa /rhnsat/admin/rhnsat/bdump/alert_rhnsat.log $DIR/database/
 fi
-
-ls /rhnsat/admin/rhnsat/bdump/*.trc 2>/dev/null | xargs -I file cp -fa file $DIR/database
-ls /rhnsat/admin/rhnsat/logs/*.log 2>/dev/null | xargs -I file cp -fa file $DIR/database
 
 # PostgreSQL logs
 if [ -f /var/lib/pgsql/pgstartup.log ] ; then


### PR DESCRIPTION
->> oracle -> postgres.
    \* copying apache, oracle, tomcat, nocpulse entries from /etc/passwd
    \* copying apache, oracle, tomcat, nocpulse entries from /etc/group

Some Oracle related code from the script can be removed.
 ->> /rhnsat is Oracle related
ls /rhnsat/admin/rhnsat/bdump/_.trc 2>/dev/null | xargs -I file cp -fa file $DIR/database
ls /rhnsat/admin/rhnsat/logs/_.log 2>/dev/null | xargs -I file cp -fa file $DIR/database

->> dba Group is Oracle related
getent group apache tomcat oracle nocpulse dba > $DIR/conf/group
