### PR TITLE
Base channel column missing in CSV export

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf
@@ -179,7 +179,7 @@
 	<c:if test = "${empty noCsv}">
 	<rl:csv dataset="pageList"
 	        name="systemList"
-	        exportColumns="name,id,securityErrata,bugErrata,enhancementErrata,outdatedPackages,lastCheckin,entitlement"/>
+	        exportColumns="name,id,securityErrata,bugErrata,enhancementErrata,outdatedPackages,lastCheckin,entitlement,channelLabels"/>
 	</c:if>
     <rhn:csrf />
 	<rhn:submitted/>


### PR DESCRIPTION
I would have liked to change the name, as it results in "Channel Labels", but there seems to be no straightforward way to do it. Already discussed it with @tomas-kasparek 
