### PR TITLE
increase source_url column size to 2048

### DIFF
--- a/schema/spacewalk/common/tables/rhnContentSource.sql
+++ b/schema/spacewalk/common/tables/rhnContentSource.sql
@@ -27,7 +27,7 @@ rhnContentSource
         type_id         number NOT NULL
                         constraint rhn_cs_type_fk
                                 references rhnContentSourceType(id),
-        source_url      varchar2(512) NOT NULL,
+        source_url      varchar2(2048) NOT NULL,
         label           varchar2(64) NOT NULL,
         created         timestamp with local time zone default(current_timestamp) NOT NULL,
         modified        timestamp with local time zone default(current_timestamp) NOT NULL

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/014-inc-length-rhnContentSource-source_url.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/014-inc-length-rhnContentSource-source_url.sql.oracle
@@ -1,0 +1,1 @@
+alter table rhnContentSource MODIFY (source_url varchar2(2048));

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/014-inc-length-rhnContentSource-source_url.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/014-inc-length-rhnContentSource-source_url.sql.postgresql
@@ -1,0 +1,4 @@
+-- oracle equivalent source sha1 d13c8c89702350c8ff76b39a96c37e301a8b5298
+
+ALTER TABLE rhnContentSource
+    ALTER COLUMN source_url TYPE varchar(2048);


### PR DESCRIPTION
Needed to store an authtoken(max 512) together with the url.
The max size of an URL in older browsers are 2048 so use this as limit.
