### PR TITLE
Fix a broken link to a .pxt page to point to the ported version of that page

### DIFF
--- a/java/code/webapp/WEB-INF/pages/channel/manage/packagemenu.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/packagemenu.jsp
@@ -29,7 +29,7 @@
       </li>
 
       <li>
-        <a href="/network/software/channels/manage/packages/compare/index.pxt?cid=${channel.id}">
+        <a href="/rhn/channels/manage/ChannelPackagesCompare.do?cid=${channel.id}">
 	  <bean:message key="channel.jsp.package.menu.compare"/>
 	</a>
       </li>


### PR DESCRIPTION
This just fixes that broken .pxt page link to point to the ported version of that page.
