### PR TITLE
Open suse 13.2 for spacewalk common channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -932,6 +932,50 @@ gpgkey_id = A0E46E11
 gpgkey_fingerprint = 68D3 3874 9967 0AEB D988  2DB3 2ABF A143 A0E4 6E11
 yumrepo_url = http://download.opensuse.org/repositories/systemsmanagement:/spacewalk:/2.1/openSUSE_13.1/
 
+[opensuse13_2]
+checksum = sha256
+archs    = i586, x86_64
+name     = openSUSE 13.2 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/distribution/13.2/repo/oss/suse/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+yumrepo_url = http://download.opensuse.org/distribution/13.2/repo/oss/suse/
+dist_map_release = 13.2
+
+[opensuse13_2-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 13.2 non oss (%(arch)s)
+archs    = i586, x86_64
+checksum = sha256
+base_channels = opensuse13_2-%(arch)s
+yumrepo_url = http://download.opensuse.org/distribution/13.2/repo/non-oss/suse/
+
+[opensuse13_2-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE 13.2 Updates (%(arch)s)
+archs    = i586, x86_64
+checksum = sha256
+base_channels = opensuse13_2-%(arch)s
+yumrepo_url = http://download.opensuse.org/update/13.2/
+
+[opensuse13_2-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE 13.2 non oss Updates (%(arch)s)
+archs    = i586, x86_64
+checksum = sha256
+base_channels = opensuse13_2-%(arch)s
+yumrepo_url = http://download.opensuse.org/update/13.2-non-oss/
+
+[spacewalk22-client-opensuse13_2]
+name     = Spacewalk Client 2.2 %(base_channel_name)s
+archs    = i586, x86_64
+base_channels = opensuse13_2-%(arch)s
+checksum = sha256
+gpgkey_url = http://download.opensuse.org/repositories/systemsmanagement:/spacewalk:/2.2/openSUSE_13.2/repodata/repomd.xml.key
+gpgkey_id = A0E46E11
+gpgkey_fingerprint = 68D3 3874 9967 0AEB D988  2DB3 2ABF A143 A0E4 6E11
+yumrepo_url = http://download.opensuse.org/repositories/systemsmanagement:/spacewalk:/2.2/openSUSE_13.2/
+
 [oraclelinux6]
 archs    = %(_x86_archs)s
 name     = Oracle Linux 6 (%(arch)s)

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -854,40 +854,6 @@ gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
 yumrepo_url = http://yum.spacewalkproject.org/nightly-client/RHEL/6/%(arch)s/
 #---
 
-[opensuse12_3]
-checksum = sha256
-archs    = i586, x86_64
-name     = openSUSE 12.3 (%(arch)s)
-gpgkey_url = http://download.opensuse.org/distribution/12.3/repo/oss/suse/repodata/repomd.xml.key
-gpgkey_id = 3DBDC284
-gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-yumrepo_url = http://download.opensuse.org/distribution/12.3/repo/oss/suse/
-dist_map_release = 12.3
-
-[opensuse12_3-non-oss]
-label    = %(base_channel)s-non-oss
-name     = openSUSE 12.3 non oss (%(arch)s)
-archs    = i586, x86_64
-checksum = sha256
-base_channels = opensuse12_3-%(arch)s
-yumrepo_url = http://download.opensuse.org/distribution/12.3/repo/non-oss/suse/
-
-[opensuse12_3-updates]
-label    = %(base_channel)s-updates
-name     = openSUSE 12.3 Updates (%(arch)s)
-archs    = i586, x86_64
-checksum = sha256
-base_channels = opensuse12_3-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/12.3/
-
-[opensuse12_3-non-oss-updates]
-label    = %(base_channel)s-non-oss-updates
-name     = openSUSE 12.3 non oss Updates (%(arch)s)
-archs    = i586, x86_64
-checksum = sha256
-base_channels = opensuse12_3-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/12.3-non-oss/
-
 [opensuse13_1]
 checksum = sha256
 archs    = i586, x86_64


### PR DESCRIPTION
Add openSUSE 13.2 and remove openSUSE 12.3 repos from spacewalk-common-channels
