### PR TITLE
1070866 - sw-repo-sync fails to sync kickstart.

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -189,7 +189,9 @@ class RepoSync(object):
 
                 if not self.no_errata:
                     self.import_updates(plugin, url)
-                if self.sync_kickstart:
+
+                # only for repos obtained from the DB
+                if self.sync_kickstart and repo_label:
                     try:
                         self.import_kickstart(plugin, url, repo_label)
                     except:

--- a/backend/satellite_tools/spacewalk-repo-sync.sgml
+++ b/backend/satellite_tools/spacewalk-repo-sync.sgml
@@ -170,7 +170,7 @@ Syncs the content from yum repos into Spacewalk or Satellite channels.
     <varlistentry>
         <term>--sync-kickstart</term>
         <listitem>
-            <para>Attempt to create kickstartable tree (distribution) if there is subdirectory images/pxeboot/ under repo's URL.</para>
+            <para>Attempt to create kickstartable tree (distribution) if there is subdirectory images/pxeboot/ under repo's URL. The option is ignored for repositories set from CLI via option [-u|--url].</para>
         </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
[1070866](https://bugzilla.redhat.com/show_bug.cgi?id=1070866) - sw-repo-sync fails to sync kickstart.