### PR TITLE
Fix rhn channel newest package after cloning

### DIFF
--- a/web/modules/rhn/RHN/DB/ChannelEditor.pm
+++ b/web/modules/rhn/RHN/DB/ChannelEditor.pm
@@ -745,32 +745,5 @@ EOQ
   return $exists;
 }
 
-sub clone_newest_package {
-  my $class = shift;
-  my %attr = validate(@_, {from_cid => 1, to_cid => 1});
-
-  my $dbh = RHN::DB->connect;
-
-  my $sth = $dbh->prepare(<<EOQ);
-DELETE FROM rhnChannelNewestPackage
-    WHERE channel_id = :to_cid
-EOQ
-
-  $sth->execute_h(to_cid => $attr{to_cid});
-
-  $sth = $dbh->prepare(<<EOQ);
-INSERT INTO rhnChannelNewestPackage
-    ( channel_id, name_id, evr_id, package_id, package_arch_id )
-    ( SELECT :to_cid, name_id, evr_id, package_id, package_arch_id
-        FROM rhnChannelNewestPackage
-        WHERE channel_id = :from_cid
-    )
-EOQ
-
-  $sth->execute_h(from_cid => $attr{from_cid}, to_cid => $attr{to_cid});
-
-  return 1;
-}
-
 1;
 

--- a/web/modules/sniglets/Sniglets/ChannelEditor.pm
+++ b/web/modules/sniglets/Sniglets/ChannelEditor.pm
@@ -277,7 +277,7 @@ sub channel_edit_cb {
       $channel->adopt_into_family(\@cf_ids);
 
       $cid = $channel->id;
-      RHN::ChannelEditor->clone_newest_package(-from_cid => $clone_from, -to_cid => $cid);
+      RHN::Channel->refresh_newest_package_cache($cid, 'web.channel_created');
       #load packes from cloned channel, if any
     }
 

--- a/web/modules/sniglets/Sniglets/ListView/ErrataList.pm
+++ b/web/modules/sniglets/Sniglets/ListView/ErrataList.pm
@@ -542,7 +542,7 @@ sub potential_for_cloned_channel_cb {
     }
 
     RHN::ChannelEditor->schedule_errata_cache_update($pxt->user->org_id, $cid, 0);
-    RHN::ChannelEditor->clone_newest_package(-from_cid => $cloned_from, -to_cid => $cid);
+    RHN::Channel->refresh_newest_package_cache($cid, 'web.channel_manager');
 
     $transaction->nested_commit;
 


### PR DESCRIPTION
fix rhnChannelNewestPackage table by using refresh_newest_package function again

How to reproduce:
    \* clone a channel with "select errata" so that some packages are missing in the cloned channel.

```
* Now compare packages of these two channels.

Result => no difference, because the compare query uses rhnChannelNewestPackage table
```
