### PR TITLE
Bugfix: Binary upload crash and custom incoming file size calculations (bnc#901927)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigFileForm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigFileForm.java
@@ -35,6 +35,7 @@ import com.redhat.rhn.manager.configuration.file.ConfigFileData;
 import com.redhat.rhn.manager.configuration.file.DirectoryData;
 import com.redhat.rhn.manager.configuration.file.SymlinkData;
 import com.redhat.rhn.manager.configuration.file.TextFileData;
+import java.io.BufferedInputStream;
 
 import org.apache.struts.upload.FormFile;
 
@@ -290,7 +291,7 @@ public class ConfigFileForm extends ScrubbingDynaActionForm {
             if (isUpload()) {
                 FormFile file = (FormFile) get(REV_UPLOAD);
                 try {
-                    data = new BinaryFileData(file.getInputStream(),
+                    data = new BinaryFileData(new BufferedInputStream(file.getInputStream()),
                                                         file.getFileSize());
                 }
                 catch (IOException e) {

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDetailsAction.java
@@ -14,19 +14,10 @@
  */
 package com.redhat.rhn.frontend.action.configuration.files;
 
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.struts.action.ActionForm;
-import org.apache.struts.action.ActionForward;
-import org.apache.struts.action.ActionMapping;
-
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.common.validator.ValidatorException;
+import com.redhat.rhn.domain.config.ConfigFile;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.configuration.ConfigActionHelper;
@@ -37,6 +28,15 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.manager.configuration.ConfigFileBuilder;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  *
@@ -94,6 +94,7 @@ public class FileDetailsAction extends RhnAction {
         cff.updateFromRevision(request, cr);
         setupRequestParams(context, cr);
         request.setAttribute("form", cff);
+        request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
 
         return getStrutsDelegate().forwardParams(
                 mapping.findForward(RhnHelper.DEFAULT_FORWARD), params);
@@ -115,9 +116,7 @@ public class FileDetailsAction extends RhnAction {
             request.getSession().getAttribute("csrf_token"));
 
         request.setAttribute(MAX_SIZE,
-                StringUtil.displayFileSize(
-                        Config.get().getInt(ConfigDefaults.CONFIG_REVISION_MAX_SIZE,
-                                ConfigDefaults.DEFAULT_CONFIG_REVISION_MAX_SIZE)));
+                 StringUtil.displayFileSize(ConfigFile.getMaxFileSize()));
         request.setAttribute(MAX_EDIT_SIZE,
                 StringUtil.displayFileSize(ConfigFileForm.MAX_EDITABLE_SIZE));
         if (cr.isFile()) {

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/ManageRevisionSetup.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/ManageRevisionSetup.java
@@ -14,8 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.configuration.files;
 
-import com.redhat.rhn.common.conf.Config;
-import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.config.ConfigFile;
@@ -34,6 +32,7 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 public class ManageRevisionSetup extends BaseSetListAction {
 
     public static final String CSRF_TOKEN = "csrfToken";
+    public static final String MAX_SIZE = "max_size";
 
     /**
      * {@inheritDoc}
@@ -43,11 +42,8 @@ public class ManageRevisionSetup extends BaseSetListAction {
     }
 
     protected void processRequestAttributes(RequestContext rctxIn) {
-        int max = Config.get().getInt(ConfigDefaults.CONFIG_REVISION_MAX_SIZE,
-                ConfigDefaults.DEFAULT_CONFIG_REVISION_MAX_SIZE);
-
-        rctxIn.getRequest().setAttribute("max_size",
-                StringUtil.displayFileSize(max));
+        rctxIn.getRequest().setAttribute(ManageRevisionSetup.MAX_SIZE,
+                 StringUtil.displayFileSize(ConfigFile.getMaxFileSize()));
         rctxIn.getRequest().setAttribute(CSRF_TOKEN,
             rctxIn.getRequest().getSession().getAttribute("csrf_token"));
         ConfigActionHelper.processRequestAttributes(rctxIn);


### PR DESCRIPTION
We found that in SUSE Manager ISE happens when one is trying to upload a binary file, because ``mark(int limit)`` method is not always supported (hence ``markSupported()`` boolean). To overcome this, the stream needs to be wrapped into a buffered stream, which has support.

Additionally, we found that the file size is calculated on JSP actions by their own, instead of calling ``ConfigFile.getMaxFileSize()`` and if one would like to have hard limit in this method (i.e. ``rhn.conf`` can specify anything, but limit is up to fixed top), then JSP would display wrong number.

Hope this helps.