### PR TITLE
Remove "Add Selected to SSM" button where it makes little sense

### DIFF
--- a/java/code/webapp/WEB-INF/pages/ssm/systems/list.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/systems/list.jsp
@@ -15,6 +15,7 @@
 <c:set var="notSelectable" value="true"/>
 <c:set var="showLastCheckin" value="true"/>
 <c:set var="noMonitoring" value="true"/>
+<c:set var="noAddToSsm" value="true"/>
 
 <rl:listset name="systemListSet" legend="system">
     <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>

--- a/java/code/webapp/WEB-INF/pages/systems/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/overview.jsp
@@ -20,6 +20,7 @@
     <rhn:submitted />
 	<c:if test="${not groups}">
     <a href="/rhn/systems/Overview.do?showgroups=true"> <div class="btn btn-default spacewalk-btn-margin-vertical"> <rhn:icon type="header-system-groups" /> <bean:message key="overview.jsp.systems"/> </div> </a>
+        <c:set var="noAddToSsm" value="1" />
 	      <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>
 	</c:if>
 


### PR DESCRIPTION
On the system overview page as well as on SSM system listing the "Add Selected to SSM" button (at the bottom of the list) makes little sense. Simply selecting the systems in the system overview adds them to SSM anyways, while inside the SSM systems listing it obviously makes even less sense to have that button.

As far as I could see we actually want to have this button **only** on the Patches -> Affected Systems page. Somehow it now comes with every system listing though, while we need to explicitly hide it using the `noAddToSsm` variable on most of them (see 4b79a4145751a85b90715ae6a01e677ae301aa5b).

This patch removes "Add Selected to SSM" from System Overview and SSM system listing in the way introduced by the mentioned patch. A better fix IMO would be to add that `AddToSsmDecorator` only where it is needed making `noAddToSsm` obsolete.