### PR TITLE
fix hibernate.NonUniqueObjectException on errata cloning

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
@@ -92,9 +92,8 @@ public class CloneErrataAction
         }
         // Trigger channel repodata re-generation
         if (list.size() > 0) {
-            Channel current = msg.getChan();
-            current.setLastModified(new Date());
-            ChannelFactory.save(current);
+            currChan.setLastModified(new Date());
+            ChannelFactory.save(currChan);
             ChannelManager.queueChannelChange(currChan.getLabel(),
                     "java::cloneErrata", "Errata cloned");
         }


### PR DESCRIPTION
regeneration of metadata after cloning might cause and hibernate exception which cause a rollback.
In the end cloning does not happen/finish.
