### PR TITLE
Explain snapshot/rollback behavior better

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -12303,11 +12303,14 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
         <trans-unit id="system.history.snapshot.summary2">
           <source>Below are a list of snapshots of your system.  To rollback to a previous configuration, or to view the changes that would have if you rolled back, click the desired snapshot below.</source>
         </trans-unit>
+        <trans-unit id="system.history.snapshot.summary3">
+          <source>Note that snapshots are recorded after each change is performed. To undo the effects of an action, please click on a snapshot before the corresponding one in the list below.</source>
+        </trans-unit>
         <trans-unit id="system.history.snapshot.nosnapshot">
           <source>No system snapshots.</source>
         </trans-unit>
         <trans-unit id="system.history.snapshot.reason">
-          <source>Reason</source>
+          <source>Recorded after</source>
         </trans-unit>
         <trans-unit id="system.history.snapshot.timetaken">
           <source>Time Taken</source>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/history/snapshots/index.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/history/snapshots/index.jsp
@@ -15,6 +15,7 @@
 <div class="page-summary">
   <p><bean:message key="system.history.snapshot.summary1" /></p>
   <p><bean:message key="system.history.snapshot.summary2" /></p>
+  <p><bean:message key="system.history.snapshot.summary3" /></p>
 </div>
 
 <rl:listset name="eventSet" legend="system-history">


### PR DESCRIPTION
Some SUSE Manager users reported they were confused about the snapshot/rollback UI, specifically when deciding which snapshot to use to revert a certain action (eg. assigning different channels to a host). We decided to reword the page slightly in order to make it clear that, when "reverting" a certain action, you should refer to the previous snapshot (rather than the snapshot that has that action itself in the description).

Before:
![before](https://cloud.githubusercontent.com/assets/250541/5166153/ddb05a34-73ed-11e4-8425-9f046c27d720.png)

After:
![after](https://cloud.githubusercontent.com/assets/250541/5166155/e281fdb0-73ed-11e4-8a19-80f88dbdcab9.png)
