### PR TITLE
Fix spacecmd schedule listing for negative deltas

### DIFF
--- a/spacecmd/src/lib/schedule.py
+++ b/spacecmd/src/lib/schedule.py
@@ -35,7 +35,7 @@ from spacecmd.utils import *
 import xmlrpclib
 
 def print_schedule_summary(self, action_type, args):
-    (args, _options) = parse_arguments(args)
+    args = args.split() or []
 
     if len(args) > 0:
         begin_date = parse_time_input(args[0])


### PR DESCRIPTION
  Negative timedeltas were detected as unknown options by the parser,
  which caused the listing to fail