### PR TITLE
Forward to a "raw mode" edit page in case of uploaded kickstart profiles

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeAction.java
@@ -125,6 +125,13 @@ public class KickstartIpRangeAction extends RhnAction {
         }
         // display the ranges (if any), and allow user to add ranges (dynaform)
         else {
+            // Forward to the raw mode edit page in case this is an uploaded profile
+            if (ksData.isRawData() &&
+                    !mapping.getPath().equals("/kickstart/KickstartIpRangeEditAdvanced")) {
+                return getStrutsDelegate().forwardParam(mapping.findForward("raw_mode"),
+                        RequestContext.KICKSTART_ID, ksData.getId().toString());
+            }
+
             setupFormValues(form);
         }
 

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -6524,6 +6524,8 @@
         <set-property property="postRequiredIfSubmitted" value="true" />
         <forward name="default"
                  path="/WEB-INF/pages/kickstart/kickstartips.jsp"/>
+        <forward name="raw_mode"
+                 path="/kickstart/KickstartIpRangeEditAdvanced.do" redirect="true"/>
     </action>
 
     <action path="/kickstart/KickstartIpRangeDelete"


### PR DESCRIPTION
In the UI, when going via Bare Metal IP ranges to an **uploaded** kickstart profile:

    Kickstart -> Bare Metal -> [klick on IP range of *uploaded* profile]

You should go here:

    kickstart/KickstartIpRangeEditAdvanced.do

Instead you get here:

    kickstart/KickstartIpRangeEdit.do

The attached patch adds a redirect to struts-config.xml and lets the action class perform a check similar to the one in [KickstartDetailsEditAction.java, line 89] (https://github.com/spacewalkproject/spacewalk/blob/caf00fb26caee9642a554b770119d1892cfd9f4c/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartDetailsEditAction.java#L89).

I don't like too much that comparison I am doing with the path, but it was needed for differentiation since both pages are using the same action class. Let me know if you have a better idea here, or if you'd prefer to somehow refactor action classes in order to avoid such path comparison.