### PR TITLE
Port of the advanced kickstart options to TB3

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -9784,25 +9784,25 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondname.jsp.label">
-        <source>Name</source>
+        <source>Bond interface name</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondinterfaces.jsp.label">
-        <source>Interfaces</source>
+        <source>Bond interfaces:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondoptions.jsp.label">
-        <source>Options</source>
+        <source>Bond interface options</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondoptionstip.jsp.label">
-        <source>Options is a space-separated list of any valid "bonding" kernel module options. Common options include mode=[0,1,2] (0 is round-robin, 1 is active-backup, 2 is balance-xor) and miimon=100</source>
+        <source>You can input a space-separated list of any valid "bonding" kernel module options. Common options include mode=[0,1,2] (0 is round-robin, 1 is active-backup, 2 is balance-xor) and miimon=100</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
@@ -9814,19 +9814,19 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondaddress.jsp.label">
-        <source>IP address:</source>
+        <source>IP address</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondnetmask.jsp.label">
-        <source>Netmask:</source>
+        <source>Netmask</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bondgateway.jsp.label">
-        <source>Gateway:</source>
+        <source>Gateway</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
@@ -9838,7 +9838,7 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.postnetconn.bonddescription.jsp.label">
-        <source>Configure the bond:</source>
+        <source>Bond interface configuration</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/KickstartSystemDetailsEdit</context>
         </context-group>
@@ -16561,16 +16561,16 @@ the &lt;a href="/rhn/kickstart/ActivationKeysList.do?ksid={0}"&gt;Activation Key
           <source>Advanced Kickstart Configuration</source>
         </trans-unit>
         <trans-unit id="kickstart.schedule.kernel.options.distro">
-          <source>&lt;strong&gt;As specified by Kickstart Distribution&lt;/strong&gt;</source>
+          <source>As specified by Kickstart Distribution</source>
         </trans-unit>
         <trans-unit id="kickstart.schedule.kernel.options.profile">
-          <source>&lt;strong&gt;As specified by Kickstart Profile&lt;/strong&gt;</source>
+          <source>As specified by Kickstart Profile</source>
         </trans-unit>
         <trans-unit id="kickstart.schedule.kernel.options.custom.tip">
           <source>If you would not like any kernel options, select '{0}' and leave the form field blank.</source>
         </trans-unit>
         <trans-unit id="kickstart.schedule.sync.pkg.profile.jsp">
-          <source>Sync Package&lt;br /&gt;Profile</source>
+          <source>Sync Package Profile</source>
         </trans-unit>
         <trans-unit id="kickstart.schedule.sync.pkg.profile.option1.jsp">
           <source>With system's existing package profile</source>
@@ -17334,7 +17334,7 @@ The Tree Path, Kickstart RPM, Base Channel, and Installer Generation should alwa
         </context-group>
       </trans-unit>
       <trans-unit id="virtualization.provision.first.jsp.virt_bridge.example">
-        <source>(ex. xenbr0)</source>
+        <source>Example: xenbr0</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
@@ -17352,31 +17352,31 @@ The Tree Path, Kickstart RPM, Base Channel, and Installer Generation should alwa
         </context-group>
       </trans-unit>
       <trans-unit id="virtualization.provision.first.jsp.memory_allocation.header">
-        <source>Memory Allocation:</source>
+        <source>Memory Allocation</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="virtualization.provision.first.jsp.memory_allocation.message2">
-        <source>megabytes of {0} megabytes total memory on &lt;img src="/img/rhn-listicon-system.gif"&gt; &lt;a href="/rhn/systems/details/Overview.do?sid={1}"&gt;{2}&lt;/a&gt;</source>
+      <trans-unit id="virtualization.provision.first.jsp.memory_allocation.message">
+        <source>Size in megabytes out of {0} total megabytes available on {1}</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="virtualization.provision.first.jsp.virtual_cpus.header">
-        <source>Virtual CPUs:</source>
+        <source>Virtual CPUs</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="virtualization.provision.first.jsp.virtual_cpus.tip1">
-        <source>&lt;strong&gt;Tip:&lt;/strong&gt; You may have up to {0} virtual CPUs on a virtual system.</source>
+      <trans-unit id="virtualization.provision.first.jsp.virtual_cpus.message">
+        <source>Number of virtual CPUs, up to {0}.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="virtualization.provision.first.jsp.storage">
-        <source>Storage:</source>
+        <source>Storage</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
@@ -17387,14 +17387,8 @@ The Tree Path, Kickstart RPM, Base Channel, and Installer Generation should alwa
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="virtualization.provision.first.jsp.storage.local.message1">
-        <source>Use the virtual host system's disk space: </source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="virtualization.provision.first.jsp.storage.local.gigabytes">
-        <source>gigabytes.</source>
+      <trans-unit id="virtualization.provision.first.jsp.storage.local.message">
+        <source>Size in gigabytes from the virtual host's disk space.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/advanced.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/advanced.jspf
@@ -1,93 +1,102 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
-
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 
 <html>
 
-  <head>
-    <meta http-equiv="Pragma" content="no-cache">
+<head>
+<meta http-equiv="Pragma" content="no-cache">
 
-    <script language="javascript">
-function moveNext() {
-   var form = document.getElementsByName("kickstartScheduleWizardForm")[0];
-   form.submit();
-}
+<script language="javascript">
+  function moveNext() {
+    var form = document.getElementsByName("kickstartScheduleWizardForm")[0];
+    form.submit();
+  }
 
-function setStep(stepName) {
-	var field = document.getElementById("wizard-step");
-	field.value = stepName;
-}
+  function setStep(stepName) {
+    var field = document.getElementById("wizard-step");
+    field.value = stepName;
+  }
 
-function getCheckedValue(radioObj) {
-    if(!radioObj)
-        return "";
+  function getCheckedValue(radioObj) {
+    if (!radioObj)
+      return "";
     var radioLength = radioObj.length;
-    if(radioLength == undefined)
-        if(radioObj.checked)
-            return radioObj.value;
-        else
-            return "";
-    for(var i = 0; i < radioLength; i++) {
-        if(radioObj[i].checked) {
-            return radioObj[i].value;
-        }
+    if (radioLength == undefined)
+      if (radioObj.checked)
+        return radioObj.value;
+      else
+        return "";
+    for (var i = 0; i < radioLength; i++) {
+      if (radioObj[i].checked) {
+        return radioObj[i].value;
+      }
     }
     return "";
-}
+  }
 
-function enableBondStaticIpAddress() {
+  function enableBondStaticIpAddress() {
     var staticBond = document.getElementsByName("kickstartScheduleWizardForm")[0].bondStatic
     if (getCheckedValue(staticBond) == 'true') {
-        document.getElementById("bondAddress").disabled = false
-        document.getElementById("bondNetmask").disabled = false
-        document.getElementById("bondGateway").disabled = false
+      document.getElementById("bondAddress").disabled = false
+      document.getElementById("bondNetmask").disabled = false
+      document.getElementById("bondGateway").disabled = false
     }
-}
-    </script>
-  </head>
-  <body>
-<%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
+  }
+</script>
+</head>
 
-<h2><rhn:icon type="header-kickstart" /><bean:message key="kickstart.schedule.heading4.jsp" /></h2>
-<c:set var="form" value="${kickstartScheduleWizardForm.map}"/>
-<html:form method="POST" action="${actionUrl}">
-<rhn:csrf />
-<rhn:submitted />
-<c:if test="${empty regularKS}">
-	<c:set var="noStatic" value="true"/>
-</c:if>
-    <html:hidden property="wizardStep" value="third" styleId="wizard-step" />
-    <html:hidden property="scheduleAsap" />
-    <%@ include file="/WEB-INF/pages/common/fragments/date-picker-hidden.jspf" %>
-    <html:hidden property="cobbler_id" />
-    <html:hidden property="sid" />
-    <html:hidden property="guestName" />
-    <html:hidden property="proxyHost" />
-    <table class="details">
-        <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/network-options.jspf" %>
-        <c:if test="${!empty regularKS}">
-            <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/post-network-options.jspf" %>
+<body>
+    <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf"%>
+
+    <c:set var="form" value="${kickstartScheduleWizardForm.map}" />
+    <html:form method="POST" action="${actionUrl}" styleClass="form-horizontal">
+        <rhn:csrf />
+        <rhn:submitted />
+        <c:if test="${empty regularKS}">
+            <c:set var="noStatic" value="true" />
         </c:if>
-        <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf" %>
-        <c:if test="${empty requestScope.cobblerOnlyProfile}" >
-	        <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/profile-sync.jspf" %>
+        <%@ include file="/WEB-INF/pages/common/fragments/date-picker-hidden.jspf"%>
+        <html:hidden property="wizardStep" value="third" styleId="wizard-step" />
+        <html:hidden property="scheduleAsap" />
+        <html:hidden property="cobbler_id" />
+        <html:hidden property="sid" />
+        <html:hidden property="guestName" />
+        <html:hidden property="proxyHost" />
+
+        <div class="panel panel-default">
+            <div class="panel-heading"><h4><bean:message key="kickstart.schedule.heading4.jsp" /></h4></div>
+            <div class="panel-body">
+                <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/network-options.jspf"%>
+                <c:if test="${!empty regularKS}">
+                    <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/post-network-options.jspf"%>
+                </c:if>
+                <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf"%>
+                <c:if test="${empty requestScope.cobblerOnlyProfile}">
+                    <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/profile-sync.jspf"%>
+                </c:if>
+            </div>
+        </div>
+
+        <c:if test="${empty regularKS}">
+            <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/virt-options.jspf"%>
         </c:if>
-    </table>
-	<c:if test="${empty regularKS}">
-    	<%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/virt-options.jspf" %>
-    </c:if>
-    <hr/>
-	<table width="100%">
-	  <tr>
-	    <td align="right">
-	      <input type="button" class="btn btn-default" value="<bean:message key='kickstart.schedule.button3.jsp'/>" onclick="setStep('first');moveNext();" />
-              <input type="button" class="btn btn-default" value="<bean:message key='kickstart.schedule.button2.jsp'/>" onclick="setStep('third');moveNext();" />
-	    </td>
-	  </tr>
-	</table>
-</html:form>
-</div>
+
+        <div class="panel">
+            <div class="row">
+                <div class="col-sm-offset-3 col-sm-9">
+                    <input type="button" class="btn btn-default"
+                        value="<bean:message key='kickstart.schedule.button3.jsp'/>"
+                        onclick="setStep('first');moveNext();"
+                    />
+                    <input type="button" class="btn btn-success"
+                        value="<bean:message key='kickstart.schedule.button2.jsp'/>"
+                        onclick="setStep('third');moveNext();"
+                    />
+                </div>
+            </div>
+        </div>
+    </html:form>
 </body>
 </html>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf
@@ -1,66 +1,146 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 
-      <tr>
-        <th width="10%"><bean:message key="kickstartdetails.jsp.kernel_options" />:</th>
-        <td>
-		<c:set var="profile_url">(<a href="/rhn/kickstart/KickstartDetailsEdit.do?ksid=${requestScope.profile.id}">${requestScope.profile.label}</a>)</c:set>
-        	<c:choose>
-        		<c:when test = "${not requestScope.distro.rhnTree}">
-				<c:set var="distro_url">(<a href="/rhn/kickstart/TreeEdit.do?kstid=${requestScope.distro.id}">${requestScope.distro.label}</a>)</c:set>
-        		</c:when>
-        		<c:otherwise>
-				<c:set var="distro_url">(${requestScope.distro.label})</c:set>
-        		</c:otherwise>
-        	</c:choose>
+<c:set var="profile_url">(<a href="/rhn/kickstart/KickstartDetailsEdit.do?ksid=${requestScope.profile.id}">${requestScope.profile.label}</a>)</c:set>
+<c:choose>
+    <c:when test="${not requestScope.distro.rhnTree}">
+        <c:set var="distro_url">(<a href="/rhn/kickstart/TreeEdit.do?kstid=${requestScope.distro.id}">${requestScope.distro.label}</a>)</c:set>
+    </c:when>
+    <c:otherwise>
+        <c:set var="distro_url">(${requestScope.distro.label})</c:set>
+    </c:otherwise>
+</c:choose>
 
-		  <html:radio value="distro" property="kernelParamsType" onclick="form.kernelParamsId.disabled = true;">
-              <bean:message key="kickstart.schedule.kernel.options.distro"/>
-          </html:radio> ${distro_url}:<br/>
-          <c:choose> <c:when test = "${not empty requestScope.distro_kernel_params}"> ${requestScope.distro_kernel_params}</c:when>
-          			<c:otherwise>(<bean:message key="none specified"/>)</c:otherwise>
-          </c:choose>
+<div class="form-group">
+    <label for="kernelParamsType" class="col-sm-3 control-label"><bean:message key="kickstartdetails.jsp.kernel_options" /></label>
+    <div class="col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="kernelParamsType" value="distro" onclick="form.kernelParamsId.disabled = true;"
+                  <c:if test="${form.kernelParamsType == 'distro'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.schedule.kernel.options.distro" />
+                ${distro_url}:
+            </label>
+        </div>
+        <p class="form-control-static help-block">
+            <c:choose>
+                <c:when test="${not empty requestScope.distro_kernel_params}">
+                  ${requestScope.distro_kernel_params}
+                </c:when>
+                <c:otherwise>
+                  (<bean:message key="none specified" />)
+                </c:otherwise>
+            </c:choose>
+        </p>
+    </div>
 
-        <br /><br />
-		  <html:radio value="profile" property="kernelParamsType" onclick="form.kernelParamsId.disabled = true;">
-              <bean:message key="kickstart.schedule.kernel.options.profile"/>
-		 </html:radio> ${profile_url}:<br/>
-          <c:choose> <c:when test = "${not empty requestScope.profile_kernel_params}"> ${requestScope.profile_kernel_params}</c:when>
-          			<c:otherwise>(<bean:message key="none specified"/>)</c:otherwise>
-          </c:choose>
-          <br /><br />
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="kernelParamsType" value="profile" onclick="form.kernelParamsId.disabled = true;"
+                  <c:if test="${form.kernelParamsType == 'profile'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.schedule.kernel.options.profile" />
+                ${profile_url}:
+            </label>
+        </div>
+        <p class="form-control-static help-block">
+            <c:choose>
+                <c:when test="${not empty requestScope.profile_kernel_params}">
+                  ${requestScope.profile_kernel_params}
+                </c:when>
+                <c:otherwise>
+                  (<bean:message key="none specified" />)
+                </c:otherwise>
+            </c:choose>
+        </p>
+    </div>
 
-		  <html:radio value="custom" property="kernelParamsType" onclick="form.kernelParamsId.disabled = false;">
-              <strong><bean:message key="Custom" /></strong>
-          </html:radio>: &nbsp;&nbsp;<html:text styleId = "kernelParamsId" property="kernelParams" onkeydown="return blockEnter(event)" disabled= "${form.kernelParamsType ne &quot;custom&quot;}" /><br /><br />
-          <rhn:tooltip><bean:message key="kickstart.schedule.kernel.options.custom.tip" arg0="${rhn:localize('Custom')}"/></rhn:tooltip>
-        </td>
-      </tr>
-      <tr>
-        <th width="10%"><bean:message key="kickstartdetails.jsp.post_kernel_options" />:</th>
-        <td>
-		  <html:radio value="distro" property="postKernelParamsType" onclick="form.postKernelParamsId.disabled = true;">
-				<bean:message key="kickstart.schedule.kernel.options.distro"/>
-          </html:radio> ${distro_url}:<br/>
-          <c:choose> <c:when test = "${not empty requestScope.distro_post_kernel_params}"> ${requestScope.distro_post_kernel_params}</c:when>
-          			<c:otherwise>(<bean:message key="none specified"/>)</c:otherwise>
-          </c:choose><br /><br />
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="kernelParamsType" value="custom" onclick="form.kernelParamsId.disabled = false;"
+                  <c:if test="${form.kernelParamsType == 'custom'}">checked="checked"</c:if>
+                />
+                <bean:message key="Custom" />
+            </label>
+        </div>
+    </div>
+    <div class="col-sm-offset-3 col-sm-9">
+        <html:text styleId="kernelParamsId" property="kernelParams" onkeydown="return blockEnter(event)" styleClass="form-control"
+            disabled="${form.kernelParamsType ne &quot;custom&quot;}"
+        />
+        <rhn:tooltip>
+            <bean:message key="kickstart.schedule.kernel.options.custom.tip" arg0="${rhn:localize('Custom')}" />
+        </rhn:tooltip>
+    </div>
+</div>
 
-		  <html:radio value="profile" property="postKernelParamsType" onclick="form.postKernelParamsId.disabled = true;">
-              <bean:message key="kickstart.schedule.kernel.options.profile"/>
-		 </html:radio> ${profile_url}:<br/>
-          <c:choose> <c:when test = "${not empty requestScope.profile_post_kernel_params}"> ${requestScope.profile_post_kernel_params}</c:when>
-          			<c:otherwise>(<bean:message key="none specified"/>)</c:otherwise>
-          </c:choose><br /><br />
+<div class="form-group">
+    <label for="postKernelParamsType" class="col-sm-3 control-label"><bean:message key="kickstartdetails.jsp.post_kernel_options" /></label>
+    <div class="col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="postKernelParamsType" value="distro" onclick="form.postKernelParamsId.disabled = true;"
+                  <c:if test="${form.postKernelParamsType == 'distro'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.schedule.kernel.options.distro" />
+                ${distro_url}:
+            </label>
+        </div>
+        <p class="form-control-static help-block">
+            <c:choose>
+                <c:when test="${not empty requestScope.distro_kernel_params}">
+                  ${requestScope.distro_kernel_params}
+                </c:when>
+                <c:otherwise>
+                  (<bean:message key="none specified" />)
+                </c:otherwise>
+            </c:choose>
+        </p>
+    </div>
 
-		  <html:radio value="custom" property="postKernelParamsType" onclick="form.postKernelParamsId.disabled = false;">
-              <strong><bean:message key="Custom" /></strong>
-          </html:radio>: &nbsp;&nbsp;<html:text styleId = "postKernelParamsId"
-			property="postKernelParams"
-			onkeydown="return blockEnter(event)" disabled= "${form.postKernelParamsType ne &quot;custom&quot;}"/><br /><br />
-           <rhn:tooltip><bean:message key="kickstart.schedule.kernel.options.custom.tip" arg0="${rhn:localize('Custom')}"/></rhn:tooltip>
-        </td>
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="postKernelParamsType" value="profile" onclick="form.postKernelParamsId.disabled = true;"
+                  <c:if test="${form.postKernelParamsType == 'profile'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.schedule.kernel.options.profile" />
+                ${profile_url}:
+            </label>
+        </div>
+        <p class="form-control-static help-block">
+            <c:choose>
+                <c:when test="${not empty requestScope.profile_kernel_params}">
+                  ${requestScope.profile_kernel_params}
+                </c:when>
+                <c:otherwise>
+                  (<bean:message key="none specified" />)
+                </c:otherwise>
+            </c:choose>
+        </p>
+    </div>
 
-      </tr>
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="postKernelParamsType" value="custom" onclick="form.postKernelParamsId.disabled = false;"
+                  <c:if test="${form.postKernelParamsType == 'custom'}">checked="checked"</c:if>
+                />
+                <bean:message key="Custom" />
+            </label>
+        </div>
+    </div>
+    <div class="col-sm-offset-3 col-sm-9">
+        <html:text styleId="postKernelParamsId" property="postKernelParams" onkeydown="return blockEnter(event)" styleClass="form-control"
+            disabled="${form.postKernelParamsType ne &quot;custom&quot;}"
+        />
+        <rhn:tooltip>
+            <bean:message key="kickstart.schedule.kernel.options.custom.tip" arg0="${rhn:localize('Custom')}" />
+        </rhn:tooltip>
+    </div>
+</div>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/network-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/network-options.jspf
@@ -1,68 +1,88 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
-      <tr>
-        <th><bean:message key="kickstart.netconn.jsp.label" />:</th>
-        <td>
-		<input type="radio" name="networkType" value="dhcp"
-				onclick="form.dhcpNetworkId.disabled = false; form.staticNetworkId.disabled = true; form.useIpv6Gateway.disabled = true;"
-				<c:if test="${form.networkType == 'dhcp'}">checked="checked"</c:if>
-				  />
-              <bean:message key="kickstart.netconn.dhcp.jsp.label"/>&nbsp;
-		<c:choose>
-		<c:when test="${empty requestScope.networkInterfaces}">
-        <input type="text" name="networkInterface" id="dhcpNetworkId" size="4" maxlength="10"
-			<c:if test="${form.networkType ne 'dhcp'}">disabled="true"</c:if>
-			 value="${form.networkInterface}"/>
-		</c:when>
-		<c:otherwise>
-		<select name="networkInterface" id="dhcpNetworkId"
-			<c:if test="${form.networkType ne 'dhcp'}">disabled="true"</c:if>
-			>
-			<c:forEach var="nic" items="${requestScope.networkInterfaces}">
-				<option
-				<c:if test="${nic.name == form.networkInterface}">selected="selected"</c:if>
-				value='${nic.name}'>${nic.name}</option>
-			</c:forEach>
-		</select>
-		</c:otherwise>
-		</c:choose>
-		<br />
-		<c:if test="${empty noStatic}">
-		<input type="radio" name="networkType" value="static"
-				onclick="form.staticNetworkId.disabled = false; form.dhcpNetworkId.disabled = true; form.useIpv6Gateway.disabled = false;"
-				<c:if test="${not form.networkType}">checked="checked"</c:if>
-				  />
-              <bean:message key="kickstart.netconn.static.jsp.label"/>&nbsp;
-		<c:choose>
-		<c:when test="${empty requestScope.networkInterfaces}">
-        <input type="text" name="networkInterface" id="staticNetworkId" size="4" maxlength="10"
-                       <c:if test="${form.networkType ne 'static'}">disabled="true"</c:if>
-                        value="${form.networkInterface}"/>
-		</c:when>
-		<c:otherwise>
-		<select name="networkInterface" id="staticNetworkId"
-			<c:if test="${form.networkType ne 'static'}">disabled="true"</c:if>
-			>
-			<c:forEach var="nic" items="${requestScope.networkInterfaces}">
-				<option
-				<c:if test="${nic.name == form.networkInterface}">selected="selected"</c:if>
-				value='${nic.name}'>${nic.name}</option>
-			</c:forEach>
-		</select>
-		</c:otherwise>
-		</c:choose>
-		<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" name="useIpv6Gateway" value="1"
-        <c:if test="${form.networkType ne 'static'}">disabled="true"</c:if>/>
-        <bean:message key="kickstart.netconn.static.useipv6gw.jsp.label"/>&nbsp;
-        <br />
-		</c:if>
-		<input type="radio" name="networkType" value="link"
-				onclick="form.staticNetworkId.disabled = true;form.dhcpNetworkId.disabled = true; form.useIpv6Gateway.disabled = true;"
-				<c:if test="${form.networkType == 'link' or empty form.networkType}">checked="checked"</c:if>
-				  />
-              <bean:message key="kickstart.netconn.dhcp.jsp.link"/>&nbsp;
-        </td>
-      </tr>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
+
+<div class="form-group">
+    <label for="networkType" class="col-sm-3 control-label"><bean:message key="kickstart.netconn.jsp.label" /></label>
+    <div class="col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="networkType" value="dhcp"
+                    onclick="form.dhcpNetworkId.disabled = false; form.staticNetworkId.disabled = true; form.useIpv6Gateway.disabled = true;"
+                    <c:if test="${form.networkType == 'dhcp'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.netconn.dhcp.jsp.label" />
+            </label>
+        </div>
+
+        <c:choose>
+            <c:when test="${empty requestScope.networkInterfaces}">
+                <input type="text" name="networkInterface" id="dhcpNetworkId" size="4" maxlength="10"
+                    <c:if test="${form.networkType ne 'dhcp'}">disabled="true"</c:if> value="${form.networkInterface}"
+                />
+            </c:when>
+            <c:otherwise>
+                <select name="networkInterface" id="dhcpNetworkId" <c:if test="${form.networkType ne 'dhcp'}">disabled="true"</c:if>>
+                    <c:forEach var="nic" items="${requestScope.networkInterfaces}">
+                        <option <c:if test="${nic.name == form.networkInterface}">selected="selected"</c:if> value='${nic.name}'>${nic.name}</option>
+                    </c:forEach>
+                </select>
+            </c:otherwise>
+        </c:choose>
+    </div>
+</div>
+
+<c:if test="${empty noStatic}">
+    <div class="form-group">
+        <div class="col-sm-offset-3 col-sm-9">
+            <div class="radio">
+                <label>
+                    <input type="radio" name="networkType" value="static"
+                        onclick="form.staticNetworkId.disabled = false; form.dhcpNetworkId.disabled = true; form.useIpv6Gateway.disabled = false;"
+                        <c:if test="${not form.networkType}">checked="checked"</c:if>
+                    />
+                <bean:message key="kickstart.netconn.static.jsp.label" />
+                </label>
+            </div>
+
+            <c:choose>
+                <c:when test="${empty requestScope.networkInterfaces}">
+                    <input type="text" name="networkInterface" id="staticNetworkId" size="4" maxlength="10"
+                        <c:if test="${form.networkType ne 'static'}">disabled="true"</c:if> value="${form.networkInterface}"
+                    />
+                </c:when>
+                <c:otherwise>
+                    <select name="networkInterface" id="staticNetworkId" <c:if test="${form.networkType ne 'static'}">disabled="true"</c:if>>
+                        <c:forEach var="nic" items="${requestScope.networkInterfaces}">
+                            <option <c:if test="${nic.name == form.networkInterface}">selected="selected"</c:if> value='${nic.name}'>${nic.name}</option>
+                        </c:forEach>
+                    </select>
+                </c:otherwise>
+            </c:choose>
+
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="useIpv6Gateway" value="1"
+                      <c:if test="${form.networkType ne 'static'}">disabled="true"</c:if>
+                    />
+                    <bean:message key="kickstart.netconn.static.useipv6gw.jsp.label" />
+                </label>
+            </div>
+        </div>
+    </div>
+</c:if>
+
+<div class="form-group">
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="networkType" value="link"
+                onclick="form.staticNetworkId.disabled = true;form.dhcpNetworkId.disabled = true; form.useIpv6Gateway.disabled = true;"
+                    <c:if test="${form.networkType == 'link' or empty form.networkType}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.netconn.dhcp.jsp.link" />
+            </label>
+        </div>
+    </div>
+</div>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/post-network-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/post-network-options.jspf
@@ -1,72 +1,112 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
-      <tr>
-        <th><bean:message key="kickstart.postnetconn.jsp.label" />:</th>
-        <td>
-        <input type="radio" name="bondType" value="none"
-              onclick="form.masterInterfaceName.disabled = true; form.slaveInterfaceNames.disabled = true; form.bondingInterfaceOptions.disabled = true;
-              form.bondStaticTrue.disabled = true; form.bondStaticFalse.disabled = true; form.bondAddress.disabled = true; form.bondNetmask.disabled = true; form.bondGateway.disabled = true;"
-              <c:if test="${form.bondType == null || form.bondType == 'none'}">checked="checked"</c:if>
-              />
-        <bean:message key="kickstart.postnetconn.none.jsp.label"/>&nbsp;
-        <br />
-        <input type="radio" name="bondType" value="bonding"
-                onclick="form.masterInterfaceName.disabled = false; form.slaveInterfaceNames.disabled = false; form.bondingInterfaceOptions.disabled = false;
-                form.bondStaticTrue.disabled = false; form.bondStaticFalse.disabled = false; enableBondStaticIpAddress();"
-                <c:if test="${form.bondType == 'bonding'}">checked="checked"</c:if>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
+
+<div class="form-group">
+    <label for="bondType" class="col-sm-3 control-label"><bean:message key="kickstart.postnetconn.jsp.label" /></label>
+    <div class="col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="bondType" value="none"
+                    onclick="form.masterInterfaceName.disabled = true; form.slaveInterfaceNames.disabled = true; form.bondingInterfaceOptions.disabled = true;
+                          form.bondStaticTrue.disabled = true; form.bondStaticFalse.disabled = true; form.bondAddress.disabled = true; form.bondNetmask.disabled = true; form.bondGateway.disabled = true;"
+                    <c:if test="${form.bondType == null || form.bondType == 'none'}">checked="checked"</c:if>
                 />
-        <bean:message key="kickstart.postnetconn.bonding.jsp.label" />&nbsp;
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="radio" name="bondStatic" id="bondStaticTrue" value="true"
-              onclick="form.bondAddress.disabled = false; form.bondNetmask.disabled = false; form.bondGateway.disabled = false;"
-              <c:if test="${form.bondStatic == null || form.bondStatic != 'false'}">checked="checked"</c:if>
-              <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>/>
-        <bean:message key="kickstart.postnetconn.bondstatic.jsp.label" />
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bondaddress.jsp.label" />&nbsp;
-        <input type="test" name="bondAddress" id="bondAddress" size="15" Maxlength="39"
-              <c:if test="${form.bondType ne 'bonding' && form.bondStatic ne 'true'}">disabled="true"</c:if>
-              value="${form.bondAddress}"/>
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bondnetmask.jsp.label" />&nbsp;
-        <input type="test" name="bondNetmask" id="bondNetmask" size="15" Maxlength="39"
-              <c:if test="${form.bondType ne 'bonding' && form.bondStatic ne 'true'}">disabled="true"</c:if>
-              value="${form.bondNetmask}"/>
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bondgateway.jsp.label" />&nbsp;
-        <input type="test" name="bondGateway" id="bondGateway" size="15" Maxlength="39"
-              <c:if test="${form.bondType ne 'bonding' && form.bondStatic ne 'true'}">disabled="true"</c:if>
-              value="${form.bondGateway}"/>
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="radio" name="bondStatic" id="bondStaticFalse" value="false"
-              onclick="form.bondAddress.disabled = true; form.bondNetmask.disabled = true; form.bondGateway.disabled = true;"
-              <c:if test="${form.bondStatic == 'false'}">checked="checked"</c:if>
-              <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>/>
-        <bean:message key="kickstart.postnetconn.bonddhcp.jsp.label" />&nbsp;
-        <br />
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bonddescription.jsp.label" />
-        <br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bondname.jsp.label" />:&nbsp;
+                <bean:message key="kickstart.postnetconn.none.jsp.label" />
+            </label>
+        </div>
+    </div>
+
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="bondType" value="bonding"
+                    onclick="form.masterInterfaceName.disabled = false; form.slaveInterfaceNames.disabled = false; form.bondingInterfaceOptions.disabled = false;
+                            form.bondStaticTrue.disabled = false; form.bondStaticFalse.disabled = false; enableBondStaticIpAddress();"
+                    <c:if test="${form.bondType == 'bonding'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.postnetconn.bonding.jsp.label" />
+            </label>
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="bondStatic" class="col-sm-3 control-label"><bean:message key="kickstart.postnetconn.bonddescription.jsp.label" /></label>
+    <div class="col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="bondStatic" id="bondStaticTrue" value="true"
+                    onclick="form.bondAddress.disabled = false; form.bondNetmask.disabled = false; form.bondGateway.disabled = false;"
+                    <c:if test="${form.bondStatic == null || form.bondStatic != 'false'}">checked="checked"</c:if>
+                    <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>
+                />
+                <bean:message key="kickstart.postnetconn.bondstatic.jsp.label" />
+            </label>
+        </div>
+
+        <input type="text" name="bondAddress" id="bondAddress" size="15" Maxlength="39"
+            placeholder="<bean:message key="kickstart.postnetconn.bondaddress.jsp.label" />"
+            <c:if test="${form.bondType ne 'bonding' && form.bondStatic ne 'true'}">disabled="true"</c:if> value="${form.bondAddress}"
+        />
+
+        <input type="text" name="bondNetmask" id="bondNetmask" size="15" Maxlength="39"
+            placeholder="<bean:message key="kickstart.postnetconn.bondnetmask.jsp.label" />"
+            <c:if test="${form.bondType ne 'bonding' && form.bondStatic ne 'true'}">disabled="true"</c:if> value="${form.bondNetmask}"
+        />
+
+        <input type="text" name="bondGateway" id="bondGateway" size="15" Maxlength="39"
+            placeholder="<bean:message key="kickstart.postnetconn.bondgateway.jsp.label" />"
+            <c:if test="${form.bondType ne 'bonding' && form.bondStatic ne 'true'}">disabled="true"</c:if> value="${form.bondGateway}"
+        />
+    </div>
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="bondStatic" id="bondStaticFalse" value="false"
+                    onclick="form.bondAddress.disabled = true; form.bondNetmask.disabled = true; form.bondGateway.disabled = true;"
+                    <c:if test="${form.bondStatic == 'false'}">checked="checked"</c:if>
+                    <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>
+                />
+                <bean:message key="kickstart.postnetconn.bonddhcp.jsp.label" />
+            </label>
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="col-sm-offset-3 col-sm-9">
         <input type="text" name="bondInterface" id="masterInterfaceName" size="5" Maxlength="10"
-                <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>
-                value="${form.bondInterface}"/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bondinterfaces.jsp.label" />:&nbsp;
-        <select name="bondSlaveInterfaces" id="slaveInterfaceNames" multiple="multiple"
+               value="${form.bondInterface}" class="form-control" placeholder="<bean:message key="kickstart.postnetconn.bondname.jsp.label" />"
             <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>
-            >
+        />
+    </div>
+    <div class="col-sm-offset-3 col-sm-9">
+        <p class="form-control-static">
+            <bean:message key="kickstart.postnetconn.bondinterfaces.jsp.label" />
+        </p>
+        <select name="bondSlaveInterfaces"
+            id="slaveInterfaceNames" multiple="multiple"
+            <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>
+        >
             <c:forEach var="nic" items="${requestScope.allNetworkInterfaces}">
-                <option
-                <c:if test="${rhn:arrayContains(form.bondSlaveInterfaces, nic.name)}">selected="selected"</c:if>
-                value='${nic.name}'>${nic.name}</option>
+                <option <c:if test="${rhn:arrayContains(form.bondSlaveInterfaces, nic.name)}">selected="selected"</c:if> value='${nic.name}'>${nic.name}</option>
             </c:forEach>
         </select>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<bean:message key="kickstart.postnetconn.bondoptions.jsp.label" />:&nbsp;
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="col-sm-offset-3 col-sm-9">
         <input type="text" name="bondOptions" id="bondingInterfaceOptions" size="10" Maxlength="125"
+            value="${form.bondOptions}" class="form-control" placeholder="<bean:message key="kickstart.postnetconn.bondoptions.jsp.label" />"
             <c:if test="${form.bondType ne 'bonding'}">disabled="true"</c:if>
-            value="${form.bondOptions}"/>
-        <rhn:tooltip><bean:message key="kickstart.postnetconn.bondoptionstip.jsp.label" /></rhn:tooltip>
-        </td>
-      </tr>
+        />
+    </div>
+    <div class="col-sm-offset-3 col-sm-9">
+        <rhn:tooltip>
+            <bean:message key="kickstart.postnetconn.bondoptionstip.jsp.label" />
+        </rhn:tooltip>
+    </div>
+</div>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/profile-sync.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/profile-sync.jspf
@@ -1,67 +1,87 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 
-      <tr>
-        <th width="10%"><bean:message key="kickstart.schedule.sync.pkg.profile.jsp" />:</th>
-        <td>
-        <c:if test="${not empty regularKS}">
-			<input type="radio" name="targetProfileType" value="existing"
-				onclick="form.syncPackageSelect.disabled = true; form.syncSystemSelect.disabled = true;"
-				id="syncExisting"
-				<c:if test="${form.targetProfileType == 'existing'}">checked="checked"</c:if>
-				 />
-              <bean:message key="kickstart.schedule.sync.pkg.profile.option1.jsp" />
-          <br /><br />
-          </c:if>
+<div class="form-group">
+    <label for="targetProfileType" class="col-sm-3 control-label"><bean:message key="kickstart.schedule.sync.pkg.profile.jsp" /></label>
+    <c:if test="${not empty regularKS}">
+        <div class="col-sm-9">
+            <div class="radio">
+                <label>
+                    <input type="radio" name="targetProfileType" value="existing" id="syncExisting"
+                        onclick="form.syncPackageSelect.disabled = true; form.syncSystemSelect.disabled = true;"
+                        <c:if test="${form.targetProfileType == 'existing'}">checked="checked"</c:if>
+                    />
+                    <bean:message key="kickstart.schedule.sync.pkg.profile.option1.jsp" />
+                </label>
+            </div>
+        </div>
+    </c:if>
+</div>
 
-		<input type="radio" name="targetProfileType" value="package"
-				onclick="form.syncPackageSelect.disabled = false; form.syncSystemSelect.disabled = true;"
-				 id="syncPackage"
-				<c:if test="${form.targetProfileType == 'package'}">checked="checked"</c:if>
-				<c:if test="${syncPackageDisabled or empty form.syncPackages}">disabled="true"</c:if>
-				  />
-              <bean:message key="kickstart.schedule.sync.pkg.profile.option2.jsp" />:&nbsp;&nbsp;
+<div class="form-group">
+    <div class="<c:if test="${not empty regularKS}">col-sm-offset-3</c:if> col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="targetProfileType" value="package" id="syncPackage"
+                    onclick="form.syncPackageSelect.disabled = false; form.syncSystemSelect.disabled = true;"
+                    <c:if test="${form.targetProfileType == 'package'}">checked="checked"</c:if>
+                    <c:if test="${syncPackageDisabled or empty form.syncPackages}">disabled="true"</c:if>
+                />
+                <bean:message key="kickstart.schedule.sync.pkg.profile.option2.jsp" />
+            </label>
+        </div>
 
         <select name="targetProfile" id="syncPackageSelect"
-			<c:if test="${form.targetProfileType ne 'package' or empty form.syncPackages}">disabled="true"</c:if>
-			>
-			<c:forEach var="packagex" items="${form.syncPackages}">
-				<option
-				<c:if test="${packagex.id == form.targetProfile}">selected="selected"</c:if>
-				value='${packagex.id}'>${packagex.name}</option>
-			</c:forEach>
-		</select>
-          <br /><br />
-          <c:if test="${empty noSystemProfile}">
-          <!--- System profile sync-->
-		<input type="radio" name="targetProfileType" value="system"
-				onclick="form.syncPackageSelect.disabled = true; form.syncSystemSelect.disabled = false;"
-				 id="syncSystem"
-				<c:if test="${form.targetProfileType == 'system'}">checked="checked"</c:if>
-				<c:if test="${syncSystemDisabled or empty form.syncSystems}">disabled="true"</c:if>
-				  />
-<bean:message key="kickstart.schedule.sync.pkg.profile.option3.jsp" />:&nbsp;&nbsp;
+            <c:if test="${empty form.syncPackages}">hidden="true"</c:if>
+            <c:if test="${form.targetProfileType ne 'package'}">disabled="true"</c:if>
+        >
+            <c:forEach var="packagex" items="${form.syncPackages}">
+                <option <c:if test="${packagex.id == form.targetProfile}">selected="selected"</c:if> value='${packagex.id}'>${packagex.name}</option>
+            </c:forEach>
+        </select>
+    </div>
+</div>
 
-        <select name="targetServerProfile" id="syncSystemSelect"
-			<c:if test="${form.targetProfileType ne 'system' or empty form.syncSystems}">disabled="true"</c:if>
-			>
-			<c:forEach var="system" items="${form.syncSystems}">
-				<option
-				    <c:if test="${system.id == form.targetServerProfile}">selected="selected"</c:if>
-				    value='${system.id}'>
-                    <c:out value="${system.name}" escapeXml="true"/>
-                </option>
-			</c:forEach>
-		</select>
-            <br /><br />
-		</c:if>
-		<input type="radio" name="targetProfileType" value="none"
-				onclick="form.syncPackageSelect.disabled = true; form.syncSystemSelect.disabled = true;"
-				 id="syncNone"
-				<c:if test="${empty form.targetProfileType or form.targetProfileType == 'none'}">checked="checked"</c:if>
-				  />
-<bean:message key="kickstart.schedule.sync.pkg.profile.option4.jsp" /><br />
-        </td>
-      </tr>
+<div class="form-group">
+    <c:if test="${empty noSystemProfile}">
+        <div class="col-sm-offset-3 col-sm-9">
+            <div class="radio">
+                <label>
+                    <input type="radio" name="targetProfileType" value="system"
+                        onclick="form.syncPackageSelect.disabled = true; form.syncSystemSelect.disabled = false;" id="syncSystem"
+                        <c:if test="${form.targetProfileType == 'system'}">checked="checked"</c:if>
+                        <c:if test="${syncSystemDisabled or empty form.syncSystems}">disabled="true"</c:if>
+                    />
+                    <bean:message key="kickstart.schedule.sync.pkg.profile.option3.jsp" />
+                </label>
+            </div>
+
+            <select name="targetServerProfile" id="syncSystemSelect"
+                <c:if test="${form.targetProfileType ne 'system' or empty form.syncSystems}">disabled="true"</c:if>
+            >
+                <c:forEach var="system" items="${form.syncSystems}">
+                    <option <c:if test="${system.id == form.targetServerProfile}">selected="selected"</c:if> value='${system.id}'>
+                        <c:out value="${system.name}" escapeXml="true" />
+                    </option>
+                </c:forEach>
+            </select>
+        </div>
+    </c:if>
+</div>
+
+<div class="form-group">
+    <div class="col-sm-offset-3 col-sm-9">
+        <div class="radio">
+            <label>
+                <input type="radio" name="targetProfileType" value="none" id="syncNone"
+                    onclick="form.syncPackageSelect.disabled = true; form.syncSystemSelect.disabled = true;"
+                    <c:if test="${empty form.targetProfileType or form.targetProfileType == 'none'}">checked="checked"</c:if>
+                />
+                <bean:message key="kickstart.schedule.sync.pkg.profile.option4.jsp" />
+            </label>
+        </div>
+    </div>
+</div>
+

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/virt-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/virt-options.jspf
@@ -1,61 +1,87 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 
-    <h2><bean:message key="virtualization.provision.first.jsp.header3" /></h2>
-    	<bean:message key="virtualization.provision.override.jsp.message" />
-    	<br/><br/>
-    <table class="details">
-      <tr>
-        <th><bean:message key="virtualization.provision.first.jsp.memory_allocation.header"/></th>
-        <td>
-          <html:text property="memoryAllocation" maxlength="12" size="6" styleId="memoryAllocationId"/>
-          <bean:message key="virtualization.provision.first.jsp.memory_allocation.message2"
-          						arg0="${system.ramString}" arg1="${system.id}" arg2="${system.name}"/>
-        </td>
-      </tr>
-      <tr>
-        <th><bean:message key="virtualization.provision.first.jsp.virtual_cpus.header" /></th>
-        <td>
-          <html:text property="virtualCpus" maxlength="2" size="2" styleId="virtualCpusId"/>
-          <br/>
-          <bean:message key="virtualization.provision.first.jsp.virtual_cpus.tip1" arg0="32"/>
-        </td>
-      </tr>
-      <tr>
-        <th><bean:message key="virtualization.provision.first.jsp.storage"/></th>
-        <td>
-            <bean:message key="virtualization.provision.first.jsp.storage.local.message1"/>
-            <html:text styleId="localStorageGigabytesId" property="localStorageGigabytes"
-            					maxlength="20" size="6"/>
-            <bean:message key="virtualization.provision.first.jsp.storage.local.gigabytes"/>
-        </td>
-      </tr>
-      <tr>
-        <th><bean:message key="kickstartdetails.jsp.virt_bridge"/>:</th>
-        <td>
-            <html:text  property="virtBridge" maxlength="20" size="6" styleId="virtBridgeId"/>
-            <bean:message key="virtualization.provision.first.jsp.virt_bridge.example"/>
+<div class="panel panel-default">
+    <div class="panel-heading"><h4><bean:message key="virtualization.provision.first.jsp.header3" /></h4></div>
+    <div class="panel-body">
+        <div class="form-group">
+            <div class="col-sm-12">
+              <bean:message key="virtualization.provision.override.jsp.message" />
+            </div>
+        </div>
 
-        </td>
-      </tr>
-      <tr>
-        <th><bean:message key="kickstartdetails.jsp.virt_disk_path"/>:</th>
-        <td>
-            <html:text  property="diskPath" maxlength="64" size="20" styleId="diskPathId"/>
-            <br/>
-            <bean:message key="kickstartdetails.jsp.virt_disk_path.tip"/>
-            <br/><br/>
-        </td>
-      </tr>
-      <tr>
-        <th><bean:message key="kickstartdetails.jsp.mac_address"/>:</th>
-        <td>
-            <html:text  property="macAddress" maxlength="17" size="17" styleId="macAddressId"/>
-            <br/>
-            <bean:message key="kickstartdetails.jsp.mac_address.tip"/>
-            <br/><br/>
-        </td>
-      </tr>
-    </table>
+        <div class="form-group">
+            <label for="memoryAllocation" class="col-sm-3 control-label"><bean:message key="virtualization.provision.first.jsp.memory_allocation.header" /></label>
+
+            <div class="col-sm-9">
+                <input name="memoryAllocation" maxlength="12" size="6" value="" id="memoryAllocationId" type="text" class="form-control"
+                    placeholder="<bean:message key="virtualization.provision.first.jsp.memory_allocation.message" arg0="${system.ramString}" arg1="${system.name}" />"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="panel-body">
+        <div class="form-group">
+            <label for="virtualCpus" class="col-sm-3 control-label"><bean:message key="virtualization.provision.first.jsp.virtual_cpus.header" /></label>
+
+            <div class="col-sm-9">
+                <input name="virtualCpus" maxlength="2" size="2" value="" id="virtualCpusId" type="text" class="form-control"
+                    placeholder="<bean:message key="virtualization.provision.first.jsp.virtual_cpus.message" arg0="32" />"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="panel-body">
+        <div class="form-group">
+            <label for="localStorageGigabytesId" class="col-sm-3 control-label"><bean:message key="virtualization.provision.first.jsp.storage" /></label>
+
+            <div class="col-sm-9">
+                <input name="localStorageGigabytes" maxlength="20" size="6" value="" id="localStorageGigabytesId" type="text" class="form-control"
+                    placeholder="<bean:message key="virtualization.provision.first.jsp.storage.local.message" />"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="panel-body">
+        <div class="form-group">
+            <label for="virtBridge" class="col-sm-3 control-label"><bean:message key="kickstartdetails.jsp.virt_bridge" /></label>
+
+            <div class="col-sm-9">
+                <input name="virtBridge" maxlength="20" size="6" value="" id="virtBridgeId" type="text" class="form-control"
+                    placeholder="<bean:message key="virtualization.provision.first.jsp.virt_bridge.example" />"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="panel-body">
+        <div class="form-group">
+            <label for="diskPath" class="col-sm-3 control-label"><bean:message key="kickstartdetails.jsp.virt_disk_path" /></label>
+
+            <div class="col-sm-9">
+                <html:text property="diskPath" maxlength="64" size="20" styleId="diskPathId" styleClass="form-control" />
+            </div>
+            <div class="col-sm-offset-3 col-sm-9">
+                <bean:message key="kickstartdetails.jsp.virt_disk_path.tip" />
+            </div>
+        </div>
+    </div>
+
+    <div class="panel-body">
+        <div class="form-group">
+            <label for="macAddress" class="col-sm-3 control-label"><bean:message key="kickstartdetails.jsp.mac_address" /></label>
+
+            <div class="col-sm-9">
+                <html:text property="macAddress" maxlength="17" size="17" styleId="macAddressId" styleClass="form-control" />
+            </div>
+            <div class="col-sm-offset-3 col-sm-9">
+                <bean:message key="kickstartdetails.jsp.mac_address.tip" />
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Fixes some usability problems of the unported page, as we had a bug report about misplaced labels.

Before:

![before](https://cloud.githubusercontent.com/assets/250541/5226457/36625ec6-76ef-11e4-8240-238485a05362.png)

After:

![after-fullwidth](https://cloud.githubusercontent.com/assets/250541/5228630/1b0aff52-770d-11e4-8b4f-09c9be5598f0.png)

It will still not win any beauty context (result-wise and code-wise), but usability should be up one notch or two, and code is at least more readable now.
