### PR TITLE
Fix various exceptions causing ISEs on GET /rhn/common/DownloadFile.do

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -193,32 +193,32 @@ public class DownloadFile extends DownloadAction {
         }
 
         String[] split = url.split("/");
-        if (split.length < 3) {
-            return null;
-        }
 
+        try {
+            int labelPos = 2;
+            if (split[2].equals("org")) {
+                ret.put("orgId",  split[3]);
+                labelPos = 4;
+            }
+            else if (split[2].equals("session")) {
+                ret.put("session", split[3]);
+                labelPos = 4;
+            }
+            else if (split[2].equals("child")) {
+                ret.put("child", split[3]);
+                labelPos = 4;
+            }
 
-        int labelPos = 2;
-        if (split[2].equals("org")) {
-            ret.put("orgId",  split[3]);
-            labelPos = 4;
+            ret.put("label", split[labelPos]);
+            String path = "";
+            for (int i = labelPos + 1; i < split.length; i++) {
+                path += "/" + split[i];
+            }
+            ret.put("path", path);
         }
-        else if (split[2].equals("session")) {
-            ret.put("session", split[3]);
-            labelPos = 4;
+        catch (ArrayIndexOutOfBoundsException e) {
+            // Just return what we have so far
         }
-        else if (split[2].equals("child")) {
-            ret.put("child", split[3]);
-            labelPos = 4;
-        }
-
-        ret.put("label", split[labelPos]);
-        String path = "";
-        for (int i = labelPos + 1; i < split.length; i++) {
-            path += "/" + split[i];
-        }
-        ret.put("path", path);
-
         return ret;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.KickstartSession;
 import com.redhat.rhn.domain.kickstart.KickstartSessionState;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
+import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
@@ -261,11 +262,12 @@ public class DownloadFile extends DownloadAction {
             log.debug("Tree label to lookup: " + label);
         }
 
-        KickstartableTree tree;
+        KickstartableTree tree = null;
         if (orgId != null) {
-            tree = KickstartFactory.lookupKickstartTreeByLabel(label,
-                    OrgFactory.lookupById(orgId));
-
+            Org org = OrgFactory.lookupById(orgId);
+            if (org != null) {
+                tree = KickstartFactory.lookupKickstartTreeByLabel(label, org);
+            }
         }
         else if (ksession != null) {
             tree = ksession.getKstree();

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -241,7 +241,12 @@ public class DownloadFile extends DownloadAction {
         String label = map.get("label");
         Long orgId = null;
         if (map.containsKey("orgId")) {
-            orgId = Long.parseLong(map.get("orgId"));
+            try {
+                orgId = Long.parseLong(map.get("orgId"));
+            }
+            catch (NumberFormatException e) {
+                // Do nothing
+            }
         }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -111,6 +111,9 @@ public class DownloadFile extends DownloadAction {
             HttpServletResponse response) throws Exception {
 
         String url = RhnHelper.getParameterWithSpecialCharacters(request, "url");
+        if (url == null) {
+            return mapping.findForward("error");
+        }
         if (log.isDebugEnabled()) {
             log.debug("url : [" + url + "]");
         }


### PR DESCRIPTION
This patch fixes various exceptions that are otherwise causing ISEs when receiving requests to `/rhn/common/DownloadFile.do` (which can happen with e.g. Qualys security scanners).