### PR TITLE
Remove "Select All" button from system currency report

### DIFF
--- a/java/code/webapp/WEB-INF/pages/systems/systemcurrency.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/systemcurrency.jsp
@@ -22,7 +22,6 @@
 	<rl:list
 		dataset="pageList"
 		name="systemCurrencyList"
-		decorator="SelectableDecorator"
 		emptykey="nosystems.message"
 		alphabarcolumn="name"
 		filter="com.redhat.rhn.frontend.taglibs.list.filters.SystemCurrencyFilter"


### PR DESCRIPTION
This commit removes the "Select All" button from the system currency report. It makes sense since nothing will actually be selected when you click it. Find this page at:

https://\<hostname\>/rhn/systems/SystemCurrency.do