### PR TITLE
Fix ipa configuration of tomcat-service for CentOS7.

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup-ipa-authentication
+++ b/spacewalk/setup/bin/spacewalk-setup-ipa-authentication
@@ -331,7 +331,7 @@ EOF
 
 my $tomcat_service;
 for my $tomcat_conf (glob "/etc/tomcat*/tomcat*.conf") {
-	($tomcat_service) = ($tomcat_conf =~ m!^/etc/(tomcat.+?)/!);
+	($tomcat_service) = ($tomcat_conf =~ m!^/etc/(tomcat.*)/!);
 	my $content;
 	local * FILE;
 	my $server_xml_file = "/etc/$tomcat_service/server.xml";


### PR DESCRIPTION
Tomcat7 on CentOS7 uses /etc/tomcat/server.xml. Adjust regex to match.

This fixes:
Use of uninitialized value $tomcat_service in concatenation (.) or string at /bin/spacewalk-setup-ipa-authentication line 337.