### PR TITLE
Set cobbler hostname variable when calling system.createSystemRecord

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -331,6 +331,12 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
             ksmeta.put(KickstartFormatter.KS_DISTRO, this.ksDistro);
         }
         rec.setKsMeta(ksmeta);
+        if (getServer().getHostname() != null) {
+            rec.setHostName(getServer().getHostname());
+        }
+        else if (getServer().getName() != null) {
+            rec.setHostName(getServer().getName());
+        }
         rec.setKernelOptions(kernelOptions);
         rec.setKernelPostOptions(postKernelOptions);
         try {


### PR DESCRIPTION
When adding a record for a non-registered system, there is no way to change the
hostname variable which is used in the autoinstallation profiles.
So we set it from the server hostname or name, depending which one is available.