### PR TITLE
Apidoc fixes (regarding DocBook XML generation)

### DIFF
--- a/java/buildconf/apidoc/docbook/api_index_hdr.txt
+++ b/java/buildconf/apidoc/docbook/api_index_hdr.txt
@@ -6,7 +6,7 @@
   <bookinfo>
     <pubdate><?dbtimestamp?></pubdate>
     <productname>Spacewalk</productname>
-    <productnumber>1.7</productnumber>
+    <productnumber>2.2</productnumber>
     <bibliosource class="uri">https://fedorahosted.org/spacewalk</bibliosource>
     <abstract>
       <para>
@@ -16,7 +16,7 @@
     </abstract>
     <legalnotice>
     <title>Legal Notice</title>
-    <para>Copyright (c) 2012 Red Hat, Inc.
+    <para>Copyright (c) 2014 Red Hat, Inc.
       This software is licensed to you under the GNU General Public License, version 2 (GPLv2). There is
       NO WARRANTY for this software, express or implied, including the implied warranties of MERCHANTABILITY
       or FITNESS FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2 along with this software;

--- a/java/buildconf/apidoc/docbook/macros.txt
+++ b/java/buildconf/apidoc/docbook/macros.txt
@@ -14,7 +14,7 @@
 <listitem>
   <para>array "$key"</para>
   <itemizedlist spacing="compact">
-    <listitem><para>$type $desc</para></listitem>
+    <listitem><para>$type - $desc</para></listitem>
   </itemizedlist>
 </listitem>
 #end

--- a/java/buildconf/apidoc/docbook/scripts.txt
+++ b/java/buildconf/apidoc/docbook/scripts.txt
@@ -44,5 +44,45 @@ for user in list:
   print user.get('login')
 
 client.auth.logout(key)</programlisting>
+    <para>The following code shows how to use date-time parameters. This code will schedule immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with id 1000000001.</para>
+    <programlisting>#!/usr/bin/python
+from datetime import datetime
+import time
+import xmlrpclib
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = xmlrpclib.Server(MANAGER_URL, verbose=0)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+today = datetime.today()
+earliest_occurrence = xmlrpclib.DateTime(today)
+client.system.schedulePackageInstall(key, 1000000001, package_list[0]['id'], earliest_occurrence)
+
+client.auth.logout(key)</programlisting>
+</example>
+
+<example>
+    <title>Ruby Example</title>
+    <para>Below is an example of the <function>channel.listAllChannels</function> API call. List of channel labels is printed.</para>
+    <programlisting>#!/usr/bin/env ruby
+require "xmlrpc/client"
+
+@MANAGER_URL = "http://manager.example.com/rpc/api"
+@MANAGER_LOGIN = "username"
+@MANAGER_PASSWORD = "password"
+
+@client = XMLRPC::Client.new2(@MANAGER_URL)
+
+@key = @client.call('auth.login', @MANAGER_LOGIN, @MANAGER_PASSWORD)
+channels = @client.call('channel.listAllChannels', @key)
+for channel in channels do
+   p channel["label"]
+end
+
+@client.call('auth.logout', @key)</programlisting>
 </example>
 </preface>

--- a/java/buildconf/apidoc/html/scripts.txt
+++ b/java/buildconf/apidoc/html/scripts.txt
@@ -52,8 +52,8 @@ for user in list:<br />
 client.auth.logout(key)<br />
 </code>
 <p />
-Following code show how to use date-time parameters. This code will schedule
-immediatelly installation of package rhnlib-2.5.22.9.el6.noarch to system with
+The following code shows how to use date-time parameters. This code will schedule
+immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with
 id 1000000001.
 <p />
 
@@ -82,7 +82,7 @@ client.auth.logout(key)<br />
 
 <p />
 <h3>Ruby example:</h3><br />
-Below is an example of the channel.listAllChannels API call. List of channal labels is printed.
+Below is an example of the channel.listAllChannels API call. List of channel labels is printed.
 <p />
 
 <code>

--- a/java/buildconf/apidoc/jsp/scripts.txt
+++ b/java/buildconf/apidoc/jsp/scripts.txt
@@ -57,8 +57,8 @@ for user in list:<br />
 client.auth.logout(key)<br />
 </code>
 <p />
-Following code show how to use date-time parameters. This code will schedule
-immediatelly installation of package rhnlib-2.5.22.9.el6.noarch to system with
+The following code shows how to use date-time parameters. This code will schedule
+immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with
 id 1000000001.
 <p />
 
@@ -88,7 +88,7 @@ client.auth.logout(key)<br />
 
 <p />
 <h3>Ruby example:</h3><br />
-Below is an example of the channel.listAllChannels API call. List of channal labels is printed.
+Below is an example of the channel.listAllChannels API call. List of channel labels is printed.
 <p />
 
 <code>

--- a/java/buildconf/apidoc/singlepage/scripts.txt
+++ b/java/buildconf/apidoc/singlepage/scripts.txt
@@ -52,8 +52,8 @@ for user in list:<br />
 client.auth.logout(key)<br />
 </code>
 <p />
-Following code show how to use date-time parameters. This code will schedule
-immediatelly installation of package rhnlib-2.5.22.9.el6.noarch to system with
+The following code shows how to use date-time parameters. This code will schedule
+immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with
 id 1000000001.
 <p />
 
@@ -82,7 +82,7 @@ client.auth.logout(key)<br />
 
 <p />
 <h3>Ruby example:</h3><br />
-Below is an example of the channel.listAllChannels API call. List of channal labels is printed.
+Below is an example of the channel.listAllChannels API call. List of channel labels is printed.
 <p />
 
 <code>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3576,7 +3576,9 @@ public class SystemHandler extends BaseHandler {
      *          #prop_desc("string" "run_as_user" "Run as user")
      *          #prop_desc("string" "run_as_group" "Run as group")
      *          #prop_desc("int" "timeout" "Timeout in seconds")
-     *          #array_single("$ScriptResultSerializer", "result")
+     *          #array()
+     *              $ScriptResultSerializer
+     *          #array_end()
      *      #struct_end()
      */
     public Map<String, Object> getScriptActionDetails(User loggedInUser, Integer actionId) {
@@ -5352,7 +5354,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.returntype
      *     #array()
-     *         #struct()
+     *         #struct("system")
      *             #prop_desc("int", "id", "System ID")
      *             #prop_desc("string", "name", "System profile name")
      *             #prop_desc("int", "extra_pkg_count", "Extra packages count")


### PR DESCRIPTION
Here is some changes about generating apidocs as DocBook xml, we use that for making a PDF file. In order to produce valid XML it was necessary to adjust the xmlrpc.doc comments in SystemHandler.java a little. Apart from that there is some typos and grammar fixed also for the jsp and html verisons of the apidocs.