### PR TITLE
Fix 403 error in apache 2.4 on access to momentjs

### DIFF
--- a/spec-tree/momentjs/httpd-momentjs.conf
+++ b/spec-tree/momentjs/httpd-momentjs.conf
@@ -1,8 +1,6 @@
 alias /javascript/momentjs /usr/share/momentjs
-
-alias /bootstrap/less /usr/share/bootstrap/less
 <IfVersion >= 2.4>
-  <Directory /usr/share/bootstrap/less>
+  <Directory /usr/share/momentjs>
     Require all granted
   </Directory>
 </IfVersion>


### PR DESCRIPTION
Fix copy&paste error in httpd config. This fixes the following 403 errors on access of proxy pages in apache 2.4:

192.168.245.75 - - [18/Dec/2014:16:01:39 +0100] "GET /javascript/momentjs/moment-with-langs.min.js HTTP/1.1" 403 3401
192.168.245.75 - - [18/Dec/2014:16:01:43 +0100] "GET /javascript/momentjs/moment.min.js HTTP/1.1" 403 3401
