### PR TITLE
convert empty string to null for DMI values

### DIFF
--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -816,6 +816,8 @@ class DMIInformation(Device):
         Device.__init__(self, fields, dict, mapping)
         # use our own sequence
         self.sequence = "rhn_server_dmi_id_seq"
+        self._autonull = ("vendor", "system", "product", "asset", "board",
+                          "bios_vendor", "bios_version", "bios_release")
         if not dict:
             return
 


### PR DESCRIPTION
Prevent:
IntegrityError: new row for relation "rhnserverdmi" violates
                check constraint "vn_rhnserverdmi_product"
