### PR TITLE
Make rhn-proxy command use systemd

### DIFF
--- a/proxy/proxy/rhn-proxy
+++ b/proxy/proxy/rhn-proxy
@@ -10,7 +10,7 @@ forward_services() {
     ACTION="$1"
 
     for service in $SERVICES; do
-	if [ -e /etc/rc.d/init.d/$service ]; then
+	if [ -e /etc/rc.d/init.d/$service -o -e /lib/systemd/system/$service.service ]; then
 	    /sbin/service $service $ACTION
 	    let RETVAL=$RETVAL+$?
 	fi
@@ -24,7 +24,7 @@ reverse_services() {
     ACTION="$1"
 
     for service in $(echo $SERVICES | tac -s" "); do
-	if [ -e /etc/rc.d/init.d/$service ]; then
+	if [ -e /etc/rc.d/init.d/$service -o -e /lib/systemd/system/$service.service ]; then
 	    /sbin/service $service $ACTION
             let RETVAL=$RETVAL+$?
         fi


### PR DESCRIPTION
Make rhn-proxy command use systemd in the same way as spacewalk-service does