### PR TITLE
Fix wrong package dependency using yum without priorities

### DIFF
--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -18,7 +18,7 @@ BuildRequires:  python
 BuildRequires: /usr/bin/pod2man
 %if 0%{?fedora} || 0%{?rhel} > 5
 # pylint check
-BuildRequires:  spacewalk-pylint
+BuildRequires:  spacewalk-pylint >= 2.2
 BuildRequires:  yum
 BuildRequires:  spacewalk-config
 BuildRequires:  spacewalk-backend >= 1.7.24


### PR DESCRIPTION
It is the same as pulled a short time ago on the spacewalk-backend package. Yum would install the spacewalk-pylint package from the epel-release. There its version 0.5 and it produces errors on the package build with tito.