### PR TITLE
Make cobbler20 require syslinux

### DIFF
--- a/spec-tree/cobbler20/cobbler20.spec
+++ b/spec-tree/cobbler20/cobbler20.spec
@@ -40,6 +40,7 @@ Requires: tftp-server
 %endif
 
 Requires: mod_wsgi
+Requires: syslinux
 
 Requires: createrepo
 %if 0%{?fedora}


### PR DESCRIPTION
Make cobbler20 require syslinux. Upstream versions require it, too. This fixes BZ#988329