### PR TITLE
Fix download/generation of kickstart profile for cobbler

### DIFF
--- a/selinux/spacewalk-selinux/spacewalk.te
+++ b/selinux/spacewalk-selinux/spacewalk.te
@@ -116,3 +116,11 @@ optional_policy(`
         allow httpd_t postgresql_var_run_t:dir search;
         allow httpd_t postgresql_var_run_t:sock_file write;
 ')
+
+optional_policy(`
+        gen_require(`
+                type cobbler_var_log_t;
+        ')
+        allow httpd_t cobbler_var_log_t:dir { search };
+')
+


### PR DESCRIPTION
Allow httpd_t to access cobbler_var_log_t. This fixes the following AVC:

type=SYSCALL msg=audit(1420626530.090:8154): arch=c000003e syscall=2 success=no exit=-13 a0=7f07b415a5c0 a1=441 a2=1b6 a3=0 items=0 ppid=1484 pid=63896 auid=4294967295 uid=48 gid=48 euid=48 suid=48 fsuid=48 egid=48 sgid=48 fsgid=48 tty=(none) ses=4294967295 comm="/usr/sbin/httpd" exe="/usr/sbin/httpd" subj=system_u:system_r:httpd_t:s0 key=(null)
type=AVC msg=audit(1420626530.090:8154): avc:  denied  { search } for  pid=63896 comm="/usr/sbin/httpd" name="cobbler" dev="dm-1" ino=35577855 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:cobbler_var_log_t:s0 tclass=dir

and the corresponding error in apache log:

mod_wsgi (pid=63892): Target WSGI script '/var/www/cobbler/svc/services.wsgi' cannot be loaded as Python module.
mod_wsgi (pid=63892): Exception occurred processing WSGI script '/var/www/cobbler/svc/services.wsgi'.
Traceback (most recent call last):
  File "/var/www/cobbler/svc/services.wsgi", line 26, in <module>
    from cobbler.services import CobblerSvc
  File "/usr/lib/python2.7/site-packages/cobbler/services.py", line 36, in <module>
    import remote
  File "/usr/lib/python2.7/site-packages/cobbler/remote.py", line 45, in <module>
    import api as cobbler_api
  File "/usr/lib/python2.7/site-packages/cobbler/api.py", line 26, in <module>
    import config
  File "/usr/lib/python2.7/site-packages/cobbler/config.py", line 30, in <module>
    import item_distro as distro
  File "/usr/lib/python2.7/site-packages/cobbler/item_distro.py", line 25, in <module>
    import utils
  File "/usr/lib/python2.7/site-packages/cobbler/utils.py", line 116, in <module>
    main_logger = clogger.Logger()
  File "/usr/lib/python2.7/site-packages/cobbler/clogger.py", line 43, in __init__
    self.logfile = open(logfile, "a")
IOError: [Errno 13] Permission denied: '/var/log/cobbler/cobbler.log'