### PR TITLE
Catch NumberFormatException and send error to the client instead

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -314,9 +314,18 @@ public class DownloadFile extends DownloadAction {
 
         String type = getNextValue(it);
         String hash = getNextValue(it);
-        Long expire = new Long(getNextValue(it));
-        Long userId = new Long(getNextValue(it));
-        Long fileId = new Long(getNextValue(it));
+        Long expire = null;
+        Long userId = null;
+        Long fileId = null;
+        try {
+            expire = new Long(getNextValue(it));
+            userId = new Long(getNextValue(it));
+            fileId = new Long(getNextValue(it));
+        }
+        catch (NumberFormatException e) {
+            log.error("Error parsing file download url: " + url);
+            return mapping.findForward("error");
+        }
         String filename = getNextValue(it);
 
         params.put(TYPE, type);


### PR DESCRIPTION
This fix prevents the webapp from crashing with an ISE which in turn can lead to a mail storm when security scanners are sending fake requests to the server (e.g. Qualys). Can be reproduced using the following URL:

- https://\<spacewalk-server\>/rhn/common/DownloadFile.do?url=/a/b/c

See also the closed #187 that was about fixing similar issues.