### PR TITLE
Fix generation of pre-requires (pre="1") in rpmmd metadata with newer rpms

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -393,8 +393,20 @@ public class PrimaryXmlWriter extends RepomdWriter {
     }
 
     /**
+     * Checks if a sense flag indicate a pre-requirement
+     *
+     * The flags that are taken into account are:
+     *
+     * RPMSENSE_PREREQ (1 << 6)
+     * RPMSENSE_SCRIPT_PRE (1 << 9)
+     * RPMSENSE_SCRIPT_POST (1 << 10)
+     * RPMSENSE_RPMLIB (1 << 24)
+     *
+     * (from rpmds.h)
+     *
      * @param senseIn package sense
-     * @return true in case the pre flag is set, otherwise false
+     * @return true in case any of the sense flags that indicate a pre-requirement
+     *         are enabled, otherwise false.
      */
     private boolean hasPreFlag(long senseIn) {
         return (senseIn & ((1 << 6) | (1 << 9) | (1 << 10) | (1 << 24))) > 0;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -397,6 +397,6 @@ public class PrimaryXmlWriter extends RepomdWriter {
      * @return true in case the pre flag is set, otherwise false
      */
     private boolean hasPreFlag(long senseIn) {
-        return ((senseIn & (1 << 6)) > 0) ? true : false;
+        return (senseIn & ((1 << 6) | (1 << 9) | (1 << 10) | (1 << 24))) > 0;
     }
 }


### PR DESCRIPTION
Nowadays not all pre-requires come from the RPMSENSE_PREREQ sense flag. "requires" dependencies related to rpmlibs may be represented using RPMSENSE_RPMLIB in newer distros (eg. SLES-12).

At the end all maps to pre="1", but we need to recognize all of them.