### PR TITLE
1194418 - API call channel.software.clone does not work as expected for child channels.

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1953,12 +1953,6 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
         Channel originalChan = lookupChannelByLabel(loggedInUser.getOrg(), originalLabel);
 
-        Channel parent = null;
-        if (parentLabel != null) {
-            parent = lookupChannelByLabel(loggedInUser.getOrg(), parentLabel);
-
-        }
-
         ChannelArch arch = null;
         if (archLabel != null && archLabel.length() > 0) {
 
@@ -2014,6 +2008,9 @@ public class ChannelSoftwareHandler extends BaseHandler {
         helper.setGpgKeyId(gpgId);
         helper.setGpgKeyUrl(gpgUrl);
         helper.setLabel(label);
+        if (parentLabel != null) {
+            helper.setParentLabel(parentLabel);
+        }
         helper.setUser(loggedInUser);
         helper.setSummary(summary);
 


### PR DESCRIPTION
API call channel.software.clone does not takes in account the 'parent_label' parameter any longer and always the result channel is a Parent/Base channel instead of Child one.

The Regression was caused by code refactoring and in particular by
SW commit: 2984025c0b3e0c4f044eafe9f363fe1b2bd3d585
    Port Errata Clone page from perl -> java
    Make nav link to java channel clone and errata clone pages
    Also make various clone errata jsps share common list