### PR TITLE
BZ 1194790 regenerate errata cache asynchronously when subscribing server to channel

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -752,7 +752,7 @@ ORDER BY UPPER(C.name)
 
 <callable-mode name="subscribe_server_to_channel">
   <query params="server_id, channel_id, user_id">
-      {call rhn_channel.subscribe_server(:server_id, :channel_id, 1, :user_id)}
+      {call rhn_channel.subscribe_server(:server_id, :channel_id, 0, :user_id)}
   </query>
 </callable-mode>
 


### PR DESCRIPTION
BZ 1194790 regenerate errata cache asynchronously when subscribing server to channel
https://bugzilla.redhat.com/show_bug.cgi?id=1194790