### PR TITLE
Added Oracle RDBMS 12.1.0 to the list of allowed database versions.

### DIFF
--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -1393,7 +1393,7 @@ EOQ
     $dbh->disconnect();
 
     my $version = join('.', (split(/\./, $v))[0 .. 2]);
-    my @allowed_db_versions = qw/11.2.0 11.1.0 10.2.0/;
+    my @allowed_db_versions = qw/12.1.0 11.2.0 11.1.0 10.2.0/;
 
     unless (grep { $version eq $_ } @allowed_db_versions) {
         die "Version [$version] is not supported (does not match "


### PR DESCRIPTION
This change allows Spacewalk to install with an Oracle RDBMS 12c external database. The SQL query syntax for Oracle is unchanged from 11.2 to 12.1, so no further changes are required. Likewise, no installation changes are required as the user/tablespace requirements are also unchanged.

Oracle has tested basic Spacewalk functionality: installation, channel/repository creation, package sync, errata sync, system registration, system patching, system provisioning. No issues were detected.