### PR TITLE
missing value PIDFile for systemd

### DIFF
--- a/search-server/spacewalk-search/src/config/rhn-search.service
+++ b/search-server/spacewalk-search/src/config/rhn-search.service
@@ -6,6 +6,7 @@ After=local-fs.target network.target httpd.service
 Type=forking
 ExecStart=/usr/sbin/rhn-search start
 ExecStop=/usr/sbin/rhn-search stop
+PIDFile=/var/run/rhn-search.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Missing value PIDFile=/var/run/rhn-search.pid

Command "systemctl status rhn-search" returns exit code 3
Active: inactive (dead) since St 2015-02-25 17:30:07 CET; 26min ago

I add PIDFile and systemctl return 1. When I run "systemctl enable rhn-search" and then I reload systemctl, the systemctl status is 0.
