### PR TITLE
Have a separate logfile for the web UI instead of logging to catalina.out

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
@@ -27,24 +27,20 @@ import org.apache.struts.action.ActionMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
 /**
- * @author coec
- * @version $Rev$
+ * Struts action class showing logfile in web UI.
  */
 public class CatalinaAction extends RhnAction {
 
     private static final String LOGFILE_PATH = "/var/log/rhn/rhn_web_ui.log";
 
-   /** {@inheritDoc} */
-   public ActionForward execute(ActionMapping mapping,
-                                ActionForm formIn,
-                                HttpServletRequest request,
-                                HttpServletResponse response) {
-       String contents = FileUtils.getTailOfFile(LOGFILE_PATH, 1000);
-       request.setAttribute("logfile_path", LOGFILE_PATH);
-       contents = StringEscapeUtils.escapeHtml(contents);
-       request.setAttribute("contents", contents);
-       return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
-   }
+    /** {@inheritDoc} */
+    public ActionForward execute(ActionMapping mapping, ActionForm formIn,
+            HttpServletRequest request, HttpServletResponse response) {
+        request.setAttribute("logfile_path", LOGFILE_PATH);
+        String contents = FileUtils.getTailOfFile(LOGFILE_PATH, 1000);
+        contents = StringEscapeUtils.escapeHtml(contents);
+        request.setAttribute("contents", contents);
+        return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
@@ -33,13 +33,15 @@ import javax.servlet.http.HttpServletResponse;
  * @version $Rev$
  */
 public class CatalinaAction extends RhnAction {
+
+    private static final String LOGFILE_PATH = "/var/log/rhn/rhn_web_ui.log";
+
    /** {@inheritDoc} */
    public ActionForward execute(ActionMapping mapping,
                                 ActionForm formIn,
                                 HttpServletRequest request,
                                 HttpServletResponse response) {
-       String catalinaBase = System.getProperty("catalina.base");
-       String contents = FileUtils.getTailOfFile(catalinaBase + "/logs/catalina.out", 1000);
+       String contents = FileUtils.getTailOfFile(LOGFILE_PATH, 1000);
        contents = StringEscapeUtils.escapeHtml(contents);
        request.setAttribute("contents", contents);
        return mapping.findForward(RhnHelper.DEFAULT_FORWARD);

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
@@ -42,6 +42,7 @@ public class CatalinaAction extends RhnAction {
                                 HttpServletRequest request,
                                 HttpServletResponse response) {
        String contents = FileUtils.getTailOfFile(LOGFILE_PATH, 1000);
+       request.setAttribute("logfile_path", LOGFILE_PATH);
        contents = StringEscapeUtils.escapeHtml(contents);
        request.setAttribute("contents", contents);
        return mapping.findForward(RhnHelper.DEFAULT_FORWARD);

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_bn_IN.xml
@@ -8533,7 +8533,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_de.xml
@@ -9737,7 +9737,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9754,7 +9754,7 @@ Distributionen für kickstartende Systeme zur Verfügung stehen:
 Bitte überprüfen Sie:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 auf detailliertere Fehler. Wenn Sie die Fehler nicht beheben, wird der

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8065,7 +8065,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_es.xml
@@ -9737,7 +9737,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9754,7 +9754,7 @@ para instalar sistemas con kickstart:
 Por favor revise:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 para obtener más detalles de los errores. Si no resuelve estos errores, el árbol kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_fr.xml
@@ -9739,7 +9739,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9755,7 +9755,7 @@ erreurs doivent être corrigées pour que les distributions puissent être dispo
 {0}
 Veuillez cocher :
 /var/log/rhn/rhn_taskomatic_daemon.log et
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
  pour des erreurs plus détaillées.  Si vous ne pouvez pas résoudre les erreurs de l'arborescence de kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_gu.xml
@@ -8526,7 +8526,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_hi.xml
@@ -8526,7 +8526,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_it.xml
@@ -9736,7 +9736,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9750,7 +9750,7 @@ Di seguito viene riportato un elenco di errori raccolti durante il tentativo di 
 Controllare:
 
 /var/log/rhn/rhn_taskomatic_daemon.log e
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ja.xml
@@ -9737,7 +9737,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9754,7 +9754,7 @@ Spacewalk がキックスタートディストリビューションを Spacewalk
 詳細なエラーについては以下を確認してください。
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 これらのエラーを解決しないと、キックスタートでキックスタートツリーを

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ko.xml
@@ -9680,7 +9680,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9696,7 +9696,7 @@ Spacewalk이 킥스타트 배포판을 Spacewalk에서 Cobbler로
 자세한 오류 내용은 다음을 확인하십시오:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 이러한 오류를 해결하지 않으면 킥스타트 트리를 킥스타트에 

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pa.xml
@@ -8528,7 +8528,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pt_BR.xml
@@ -9724,7 +9724,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9738,7 +9738,7 @@ erros devem ser corrigidos para que distribuições estejam disponíveis em/nsis
 Por favor consulte:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 para maiores detalhes sobre os erros. Caso você não resolva os erros a árvore

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ru.xml
@@ -9732,7 +9732,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9747,7 +9747,7 @@ tree will not be usable for kickstarting.
 Проверьте:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 Исправьте ошибки, чтобы сохранить возможность установки

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ta.xml
@@ -8526,7 +8526,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_CN.xml
@@ -9737,7 +9737,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9754,7 +9754,7 @@ tree will not be usable for kickstarting.
 请检查：
 
 /var/log/rhn/rhn_taskomatic_daemon.log 和
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 里关于错误信息的细节。如果你没有解决这些错误，在 Kickstarging 时

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_TW.xml
@@ -9736,7 +9736,7 @@ kickstarting systems:
 Please check:
 
 /var/log/rhn/rhn_taskomatic_daemon.log and
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 for more detailed errors.  If you don't resolve the errors the kickstart
@@ -9753,7 +9753,7 @@ kickstart 系統：
 請檢查：
 
 /var/log/rhn/rhn_taskomatic_daemon.log 以及
-/var/log/tomcat5/catalina.out
+/var/log/rhn/rhn_web_ui.log
 /var/log/cobbler/cobbler.log
 
 以取得更詳細的錯誤資訊。若您不修正這些錯誤，您將無法

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -8675,11 +8675,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>পুনরায় আরম্ভ করুন</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target/>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -10142,11 +10142,6 @@ Bitte beachten Sie, dass möglicherweise noch einige manuelle Konfigurationen di
         </context-group>
         <target>Neustart</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -7863,10 +7863,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/Restart.do</context>
         </context-group>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -10144,11 +10144,6 @@ Tenga en cuenta que podría ser necesario configurar manualmente estos scripts. 
         </context-group>
         <target>Reiniciar</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -10141,11 +10141,6 @@ Veuillez noter qu'une configuration manuelle de ces scripts peut toujours être 
         </context-group>
         <target>Redémarrer</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -8676,11 +8676,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>પુનઃશરૂ કરો</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target/>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -8676,11 +8676,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>फिर आरंभ करें</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target/>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -10125,11 +10125,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>Riavvia</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -10143,11 +10143,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>再起動</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -9962,11 +9962,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>재시작</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -8675,11 +8675,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>ਮੁੜ-ਚਾਲੂ</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target/>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -10133,11 +10133,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>Reiniciar</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -10128,11 +10128,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>Перезапуск</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -8676,11 +8676,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>மறுதுவக்கம்</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target/>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -10136,11 +10136,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>重启</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -10138,11 +10138,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>重新啟動</target>
       </trans-unit>
-      <!-- Catalina stuff -->
-      <trans-unit id="catalina.jsp.show">
-        <source>catalina.out</source>
-        <target>catalina.out</target>
-      </trans-unit>
       <!-- Cobbler stuff -->
       <group>
         <context-group name="ctx">

--- a/java/code/src/log4j.properties
+++ b/java/code/src/log4j.properties
@@ -1,4 +1,7 @@
-log4j.appender.RootAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.RootAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.RootAppender.File=/var/log/rhn/rhn_web_ui.log
+log4j.appender.RootAppender.MaxFileSize=10MB
+log4j.appender.RootAppender.MaxBackupIndex=5
 log4j.appender.RootAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.RootAppender.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.rootLogger=WARN,RootAppender

--- a/java/code/webapp/WEB-INF/pages/admin/catalina.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/catalina.jsp
@@ -1,5 +1,6 @@
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <html>
     <head>
@@ -12,7 +13,7 @@
             <rhn:csrf />
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <bean:message key="catalina.jsp.show"/>
+                    <c:out value="${logfile_path}"/>
                 </div>
                 <div class="panel-body">
                     <textarea data-editor="text" data-readonly="true" rows="24" class="form-control">${contents}</textarea>


### PR DESCRIPTION
This patch makes the web app log into `/var/log/rhn/rhn_web_ui.log` instead of `catalina.out`. The `catalina.out` file is just meant to be the stdout of the tomcat process redirected and applications are actually supposed to log somewhere else. Feel free to suggest a different name or locations for the logfile if you want.

I didn't setup logrotate for this file, rather I used the RollingFileAppender with `MaxFileSize=10MB`. Further I didn't change the URL of the page where the logfile can be viewed (`/rhn/admin/Catalina.do`), let me know if you would want this to be changed.

Hope this patch is complete apart from that.
