### PR TITLE
Check for reboot type

### DIFF
--- a/backend/server/handlers/xmlrpc/queue.py
+++ b/backend/server/handlers/xmlrpc/queue.py
@@ -576,6 +576,7 @@ class Queue(rhnHandler):
               join rhnAction a on sa.action_id = a.id
               join rhnActionType at on a.action_type = at.id
              where sa.server_id = :server_id
+               and at.label = 'reboot.reboot'
                and sa.status = 1 -- Picked Up
         """)
         h.execute(server_id=self.server_id)

--- a/client/tools/osad/src/osa_dispatcher.py
+++ b/client/tools/osad/src/osa_dispatcher.py
@@ -424,6 +424,7 @@ def reboot_in_progress(server_id):
           join rhnAction a on sa.action_id = a.id
           join rhnActionType at on a.action_type = at.id
          where sa.server_id = :server_id
+           and at.label = 'reboot.reboot'
            and sa.status = 1 -- Picked Up
     """)
     h.execute(server_id = server_id)


### PR DESCRIPTION
functions named "reboot_in_progress" should check for reboot type only.

This could fix https://bugzilla.redhat.com/show_bug.cgi?id=1187358
