### PR TITLE
Support for a threshold on the number of clients executing actions

### DIFF
--- a/client/tools/osad/rhn-conf/rhn_osa-dispatcher.conf
+++ b/client/tools/osad/rhn-conf/rhn_osa-dispatcher.conf
@@ -6,3 +6,9 @@ osa_ssl_cert  = /usr/share/rhn/RHNS-OSA-CERT
 jabber_server   = jabberserver.example.org:5234
 
 poll_interval = 5
+
+# to manage the notify threshold add
+# osa-dispatcher.notify_threshold = <num>
+# in rhn.conf
+# current default is unlimited
+#notify_threshold =

--- a/client/tools/osad/rhn-conf/rhn_osa-dispatcher.conf
+++ b/client/tools/osad/rhn-conf/rhn_osa-dispatcher.conf
@@ -7,8 +7,7 @@ jabber_server   = jabberserver.example.org:5234
 
 poll_interval = 5
 
-# to manage the notify threshold add
-# osa-dispatcher.notify_threshold = <num>
-# in rhn.conf
+# number of systems that can run actions until
+# osad-dispatcher stops notifying more clients.
 # current default is unlimited
-#notify_threshold =
+notify_threshold =

--- a/client/tools/osad/src/osa_dispatcher.py
+++ b/client/tools/osad/src/osa_dispatcher.py
@@ -403,6 +403,10 @@ class UpstreamServer(SocketServer.TCPServer):
 
     # We need to drive this query by rhnPushClient since it's substantially
     # smaller than rhnAction
+    # order by status, earliest_action, server_id to get
+    # "Queued" first with earliest_action first. If multiple clients have the
+    # same values, finally order by server_id to get a defined order
+    # important for notify_threshold
     _query_get_pending_clients = rhnSQL.Statement("""
         select a.id, sa.server_id, pc.jabber_id,
                date_diff_in_days(current_timestamp, earliest_action) * 86400 delta
@@ -423,7 +427,7 @@ class UpstreamServer(SocketServer.TCPServer):
                   and sap.action_id = a.prerequisite
                   and sap.status != 2
             )
-         order by earliest_action
+         order by sa.status, earliest_action, sa.server_id
     """)
 
     _query_get_running_clients = rhnSQL.Statement("""


### PR DESCRIPTION
While pull has a randomized interval, if you schedule hundred of actions via osa then you will end with hundred of clients going back to the server at the same time.

This threshold parameter allow to plan for a number of slots according to your server capacity.

Before trying it out, make sure you have 6188430e5c0a4b60c6ac42547934fc3035581c9f
from https://github.com/spacewalkproject/spacewalk/pull/230 which fixes another bug.