### PR TITLE
osad to execute rhn_check without blocking the callback

### DIFF
--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -525,7 +525,7 @@ class JabberQualifiedError(JabberError):
 
     __str__ = __repr__
 
-class JabberClient(jabber.Client):
+class JabberClient(jabber.Client, object):
     _seq = 0
     BLOCK_SIZE = jabber.xmlstream.BLOCK_SIZE
 
@@ -1022,6 +1022,9 @@ class JabberClient(jabber.Client):
             self.disconnected(self)
         return received
 
+    def process_loop_hook(self):
+        pass
+
     def process(self, timeout=None):
         log_debug(3, timeout)
         self._incoming_node_queue = []
@@ -1038,6 +1041,7 @@ class JabberClient(jabber.Client):
             else:
                 tm = None
 
+            self.process_loop_hook()
             # tm is the number of seconds we have to wait (or None)
             log_debug(5, "before select(); timeout", tm)
             rfds, wfds, exfds = select.select([fileno], [], [], tm)

--- a/client/tools/osad/src/osad.py
+++ b/client/tools/osad/src/osad.py
@@ -247,7 +247,11 @@ class Runner(jabber_lib.Runner):
             config = self.read_config()
             raise jabber_lib.NeedRestart
 
-        client.process(timeout=180)
+        # if rhn_check is running or the last one failed, check more often
+        if (client._rhn_check_process is None) and (client._rhn_check_fail_count < 1):
+            client.process(timeout=180)
+        else:
+            client.process(timeout=5)
 
     def read_config(self):
         ret = {}

--- a/client/tools/osad/src/osad_client.py
+++ b/client/tools/osad/src/osad_client.py
@@ -16,11 +16,14 @@
 import os
 import time
 import string
-
+from subprocess import Popen, PIPE, STDOUT
 import jabber_lib
 from rhn_log import log_debug
 
 class Client(jabber_lib.JabberClient):
+
+    RHN_CHECK_CMD = '/usr/sbin/rhn_check'
+
     def __init__(self, *args, **kwargs):
         apply(jabber_lib.JabberClient.__init__, (self, ) + args, kwargs)
         self.username = None
@@ -31,6 +34,8 @@ class Client(jabber_lib.JabberClient):
         self.time_drift = 0
         self._dispatchers = []
         self._config = {}
+        self._rhn_check_process = None
+        self._rhn_check_fail_count = 0
 
     def set_config_options(self, config):
         self._config = config
@@ -180,36 +185,62 @@ class Client(jabber_lib.JabberClient):
         self.send_message(stanza.getFrom(),
             jabber_lib.NS_RHN_MESSAGE_RESPONSE_CHECKIN)
 
-        command = self._config.get('rhn_check_command')
-        # rhn_check now checks for multiple instances,
-        # lets use that directly
-        if command is None:
-            args = [ "/usr/sbin/rhn_check" ]
-        else:
-            # XXX should find a better way to get the list of args
-            args = string.split(command)
-
-        log_debug(3, "About to execute:", args)
-
         # Checkin
         run_check = self._config.get('run_rhn_check')
         log_debug(3, "run_rhn_check:", run_check)
 
         if not self._config.get('run_rhn_check'):
-            log_debug(0, "Pretend that rhn_check just ran")
+            log_debug(0, "Pretend that command just ran")
         else:
-            # We have to redirect stdout and stderr to /dev/null or else
-            # initlog will make rhn_check break, for some reason
-            pid = os.fork()
-            if pid == 0:
-                # In the child
-                fd = os.open("/dev/null", os.O_WRONLY)
-                os.close(1)
-                os.close(2)
-                os.dup(fd)
-                os.dup(fd)
-                os.umask(os.umask(0077) | 0022)
-                os.execv(args[0], args)
-                # Never reached
-            # Wait for the child to finish
-            os.waitpid(pid, 0)
+            self.run_rhn_check_async()
+
+    def process_loop_hook(self):
+        # if rhn_check process exists, check it last
+        # status
+        if self._rhn_check_process is not None:
+            retcode = self._rhn_check_process.poll()
+            if retcode is not None:
+                log_debug(3, "rhn_check exited with status %d" % retcode)
+                if retcode != 0:
+                    self._rhn_check_fail_count += 1
+                else:
+                    self._rhn_check_fail_count = 0
+                self._rhn_check_process = None
+            else:
+                log_debug(3, "rhn_check is still running...")
+        else:
+            # rhn_check is not running but last one failed
+            # we force a check even if the server does not
+            # contact us. The idea is to exhaust the number of
+            # times we can pick up the action until the server fails
+            # it.
+            if self._rhn_check_fail_count > 0:
+                log_debug(3, "rhn_check failed last time, trying again")
+                self.run_rhn_check_async()
+
+    def run_rhn_check_async(self):
+        """Runs rhn_check and keeps a handle that it is monitored
+        during the event loop
+        """
+        command = self._config.get('rhn_check_command')
+        # rhn_check now checks for multiple instances,
+        # lets use that directly
+        if command is None:
+            args = [self.RHN_CHECK_CMD]
+        else:
+            # XXX should find a better way to get the list of args
+            args = string.split(command)
+
+        # if rhn_check process already exists
+        if self._rhn_check_process is not None:
+            retcode = self._rhn_check_process.poll()
+            if retcode is None:
+                log_debug(3, "rhn_check is still running, ignoring notification...")
+                return
+
+        log_debug(3, "About to execute:", args)
+        oldumask = os.umask(0077)
+        os.umask(oldumask | 0022)
+        self._rhn_check_process = Popen(args, stdout=PIPE, stderr=STDOUT)
+        os.umask(oldumask)
+        log_debug(0, "executed %s with pid %d" % (args[0], self._rhn_check_process.pid))

--- a/client/tools/osad/src/osad_client.py
+++ b/client/tools/osad/src/osad_client.py
@@ -215,7 +215,8 @@ class Client(jabber_lib.JabberClient):
             # times we can pick up the action until the server fails
             # it.
             if self._rhn_check_fail_count > 0:
-                log_debug(3, "rhn_check failed last time, trying again")
+                log_debug(3, "rhn_check failed last time, " \
+                          "force retry (fail count %d)" % self._rhn_check_fail_count)
                 self.run_rhn_check_async()
 
     def run_rhn_check_async(self):
@@ -235,8 +236,11 @@ class Client(jabber_lib.JabberClient):
         if self._rhn_check_process is not None:
             retcode = self._rhn_check_process.poll()
             if retcode is None:
-                log_debug(3, "rhn_check is still running, ignoring notification...")
+                log_debug(3, "rhn_check is still running, not running again...")
                 return
+
+        if self._rhn_check_fail_count > 0:
+            log_debug(3, "rhn_check failed last time (fail count %d)" % self._rhn_check_fail_count)
 
         log_debug(3, "About to execute:", args)
         oldumask = os.umask(0077)

--- a/client/tools/osad/src/osad_client.py
+++ b/client/tools/osad/src/osad_client.py
@@ -245,6 +245,6 @@ class Client(jabber_lib.JabberClient):
         log_debug(3, "About to execute:", args)
         oldumask = os.umask(0077)
         os.umask(oldumask | 0022)
-        self._rhn_check_process = Popen(args, stdout=PIPE, stderr=STDOUT)
+        self._rhn_check_process = Popen(args)
         os.umask(oldumask)
         log_debug(0, "executed %s with pid %d" % (args[0], self._rhn_check_process.pid))


### PR DESCRIPTION
osad does a fork and waitpid() inside the _message_callback, which can block for long time. During that time the server continues to notify and those messages get accumulated. Once rhn_check returns, all messages are processed without any context and tons of rhn_check calls are fired back to the server.
Also I observed time ago that blocking for a very long task timeouts the connection.

This changes the way rhn_check is executed. We use a subprocess handle to have always a handle to the process. We don't block and can react to _message_callback while the process is running.
When rhn_check is running, we change the select() timeout from 180 to 5 in order to monitor the process.

If the process fails (rhn_check crashes), then in case the server is not talking to us, _process_hook knows that we are in failed state and forces rhn_check in order to exhaust the remaining_tries or hope that it executes correctly, so that the action gets failed at the server side or completed.

Once the rhn_check finishes correctly, we go back to the 180s poll interval. Whether to use 5 also for the case of (no rhn_check running, last one failed) can be discussed. For (rhn_check running) case we definitely need a shorter interval to monitor the process.

How to test this?

I sent 3 one after another remote execution scripts with "sleep 10", and then a fourth one with "sleep 10; killall rhn_check"

When the process is started, you should see it,a nd also you should see that it changes the poll interval to monitor the process:

```
2015-03-04 09:09:08 osad_client.run_rhn_check_async: About to execute: ['/usr/sbin/rhn_check']
2015-03-04 09:09:08 osad_client.run_rhn_check_async: executed /usr/sbin/rhn_check with pid 16469
2015-03-04 09:09:16 jabber_lib.process: 5
```

When more messages come, while rhn_check is running, the message is still processed:

```
2015-03-04 09:09:16 osad_client.run_rhn_check_async: rhn_check is still running, ignoring notification...
```

When rhn_check is killed, it will realize it and rhn_check will be called either at the next message callback or in the process_hook even if the server does not message us.

```
2015-03-04 09:10:04 osad_client.process_loop_hook: rhn_check exited with status -15
```

```
2015-03-04 09:10:04 osad_client.run_rhn_check_async: rhn_check failed last time (fail count 2)
2015-03-04 09:10:04 osad_client.run_rhn_check_async: About to execute: ['/usr/sbin/rhn_check']
```

After about 9 retries the action would fail at the server and osad will return to normal and to the 180 interval.

