### PR TITLE
Fix spacecmd cli config option nossl

### DIFF
--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -997,7 +997,7 @@ def load_config_section(self, section):
                 pass
 
     # handle the nossl boolean
-    if self.config.has_key('nossl'):
+    if self.config.has_key('nossl') and isinstance(self.config['nossl'], str):
         if re.match('^1|y|true$', self.config['nossl'], re.I):
             self.config['nossl'] = True
         else:


### PR DESCRIPTION
Before the fix it triggered the following error:

spacecmd -s spacewalk.example.com --nossl
Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 132, in <module>
    shell.load_config_section('spacecmd')
  File "/usr/lib/python2.7/site-packages/spacecmd/misc.py", line 1001, in load_config_section
    if re.match('^1|y|true$', self.config['nossl'], re.I):
  File "/usr/lib64/python2.7/re.py", line 137, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or buffer