### PR TITLE
Fix upgrade path by obsoleting spacewalk-grail and spacewalk-sniglets

### DIFF
--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -52,6 +52,8 @@ Requires: perl(Params::Validate)
 Requires: perl(URI)
 Requires: perl(XML::LibXML)
 Obsoletes: rhn-base < 5.3.0
+Obsoletes: spacewalk-grail < %{version}
+Obsoletes: spacewalk-sniglets < %{version}
 Provides: rhn-base = 5.3.0
 
 


### PR DESCRIPTION
When updating spacewalk-web the following dependency error is shown:

--> Finished Dependency Resolution
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::Checkbox)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::Checkbox)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::DataSource::User)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::DataSource::User)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::ServerGroup)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::ServerGroup)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Set)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Set)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::SearchTypes)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::SearchTypes)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::DataSource::ContactMethod)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::DataSource::ContactMethod)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::DataSource::Scout)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::DataSource::Scout)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::ParsedForm)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::ParsedForm)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::DataSource::CustomInfo)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::DataSource::CustomInfo)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::DataSource::Probe)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::DataSource::Probe)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Token)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Token)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Kickstart::Session)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Kickstart::Session)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::ContactGroup)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::ContactGroup)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::Literal)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::Literal)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::ContactMethod)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::ContactMethod)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Utils)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Utils)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::Submit)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::Submit)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::CheckboxGroup)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::CheckboxGroup)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::Select)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::Select)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::ServerActions)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::ServerActions)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::RadiobuttonGroup)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::RadiobuttonGroup)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
Error: Package: spacewalk-sniglets-2.3.36-1.el7.noarch (@spacewalk-nightly)
           Requires: perl(RHN::Form::Widget::Hidden)
           Removing: spacewalk-base-2.3.36-1.el7.noarch (@spacewalk-nightly)
               perl(RHN::Form::Widget::Hidden)
           Updated By: spacewalk-base-2.3.46-1.el7.noarch (spacewalk-nightly)
               Not found
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest

Adding proper obsoletes fixes the upgrade path.