### PR TITLE
Added new public Oracle Linux channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -744,6 +744,15 @@ gpgkey_id = %(_spacewalk_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
 yumrepo_url = http://yum.spacewalkproject.org/2.2-client/RHEL/6/%(arch)s/
 
+[spacewalk22-client-oraclelinux7]
+name     = Spacewalk Client (N) for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = oraclelinux7-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/2.2-client/RHEL/7/%(arch)s/
+
 [spacewalk-nightly-server-centos5]
 name     = Spacewalk Server (N) for %(base_channel_name)s
 archs    = %(_x86_archs)s
@@ -990,35 +999,35 @@ dist_map_release = 7
 [oraclelinux7-optional]
 label    = %(base_channel)s-optional
 archs    = x86_64
-name     = Oracle Linux 7 Optional Packages (%(arch)s)
+name     = Optional Packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/optional/latest/%(arch)s/
 
 [oraclelinux7-addons]
 label    = %(base_channel)s-addons
 archs    = x86_64
-name     = Oracle Linux 7 Addons (%(arch)s)
+name     = Addons for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/addons/%(arch)s/
 
 [oraclelinux7-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
-name     = Oracle Linux 7 UEK Release 3 (%(arch)s)
+name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/UEKR3/%(arch)s/
 
 [oraclelinux7-mysql55]
 label    = %(base_channel)s-mysql55
 archs    = x86_64
-name     = Oracle Linux 7 MySQL 5.5 (%(arch)s)
+name     = MySQL 5.5 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/MySQL55/%(arch)s/
 
 [oraclelinux7-mysql56]
 label    = %(base_channel)s-mysql56
 archs    = x86_64
-name     = Oracle Linux 7 MySQL 5.6 (%(arch)s)
+name     = MySQL 5.6 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/MySQL56/%(arch)s/
 
@@ -1043,35 +1052,42 @@ dist_map_release = 6
 [oraclelinux6-addons]
 label    = %(base_channel)s-addons
 archs    = %(_x86_archs)s
-name     = Oracle Linux 6 Addons (%(arch)s)
+name     = Addons for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/addons/%(arch)s/
 
 [oraclelinux6-uek]
 label    = %(base_channel)s-uek
 archs    = %(_x86_archs)s
-name     = Oracle Linux 6 UEK (%(arch)s)
+name     = Latest Unbreakable Enterprise Kernel Release 2 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/%(arch)s/
 
 [oraclelinux6-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
-name     = Oracle Linux 6 UEK Release 3 (%(arch)s)
+name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/%(arch)s/
 
-[oraclelinux6-mysql]
+[oraclelinux6-mysql55]
 label    = %(base_channel)s-mysql
 archs    = %(_x86_archs)s
-name     = Oracle Linux 6 MySQL (%(arch)s)
+name     = MySQL 5.5 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/MySQL/%(arch)s/
+
+[oraclelinux6-mysql56]
+label    = %(base_channel)s-mysql
+archs    = %(_x86_archs)s
+name     = MySQL 5.6 for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux6-%(arch)s
+yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/MySQL56/%(arch)s/
 
 [oraclelinux6-playground]
 label    = %(base_channel)s-playground
 archs    = x86_64
-name     = Oracle Linux 6 Playground (%(arch)s)
+name     = Playground (Mainline) Kernels for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/playground/latest/%(arch)s/
 
@@ -1089,6 +1105,21 @@ name     = Spacewalk 2.0 Client for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/spacewalk20/client/%(arch)s/
 
+[oraclelinux6-spacewalk22-server]
+label    = %(base_channel)s-spacewalk22-server
+archs    = x86_64
+name     = Spacewalk 2.2 Server for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux6-%(arch)s
+yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/server/%(arch)s/
+
+[oraclelinux6-spacewalk22-client]
+label    = %(base_channel)s-spacewalk22-client
+archs    = %(_x86_archs)s
+name     = Spacewalk 2.2 Client for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux6-%(arch)s
+yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(arch)s/
+
+
 [oraclelinux5]
 archs    = %(_x86_archs)s
 name     = Oracle Linux 5 (%(arch)s)
@@ -1101,28 +1132,28 @@ dist_map_release = 5
 [oraclelinux5-addons]
 label    = %(base_channel)s-addons
 archs    = %(_x86_archs)s
-name     = Oracle Linux 5 Addons (%(arch)s)
+name     = Addons for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/addons/%(arch)s/
 
 [oraclelinux5-oracle-addons]
 label    = %(base_channel)s-oracle-addons
 archs    = %(_x86_archs)s
-name     = Oracle Linux 5 Oracle Addons (%(arch)s)
+name     = Oracle software addons for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/oracle_addons/%(arch)s/
 
 [oraclelinux5-unsupported]
 label    = %(base_channel)s-unsupported
 archs    = %(_x86_archs)s
-name     = Oracle Linux 5 Unsupported (%(arch)s)
+name     = Productivity Applications for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/unsupported/%(arch)s/
 
 [oraclelinux5-uek]
 label    = %(base_channel)s-uek
 archs    = %(_x86_archs)s
-name     = Oracle Linux 5 UEK (%(arch)s)
+name     = Latest Unbreakable Enterprise Kernel for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/UEK/latest/%(arch)s/
 
@@ -1132,3 +1163,11 @@ archs    = %(_x86_archs)s
 name     = Spacewalk 2.0 Client for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/spacewalk20/client/%(arch)s/
+
+[oraclelinux5-spacewalk22-client]
+label    = %(base_channel)s-spacewalk22-client
+archs    = %(_x86_archs)s
+name     = Spacewalk 2.2 Client for Oracle Linux 5 (%(arch)s)
+base_channels = oraclelinux5-%(arch)s
+yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/spacewalk22/client/%(arch)s/
+


### PR DESCRIPTION
This adds new/missing channels to spacewalk-common-channels.ini and fixes up the Software Channel names to match the ULN/public-yum descriptions.