### PR TITLE
Added a bit more documentation to softwarechannel_setsyncschedule

### DIFF
--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -1974,6 +1974,10 @@ def help_softwarechannel_setsyncschedule(self):
     print 'Sets the repo sync schedule for a software channel'
     print
     print 'usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>'
+    print
+    print 'The schedule is specified in Quartz CronTrigger format without enclosing quotes.'
+    print 'For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ? *'
+    print
 
 
 def complete_softwarechannel_setsyncschedule(self, text, line, beg, end):

--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -1976,7 +1976,7 @@ def help_softwarechannel_setsyncschedule(self):
     print 'usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>'
     print
     print 'The schedule is specified in Quartz CronTrigger format without enclosing quotes.'
-    print 'For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * *'
+    print 'For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ?'
     print
 
 

--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -1976,7 +1976,7 @@ def help_softwarechannel_setsyncschedule(self):
     print 'usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>'
     print
     print 'The schedule is specified in Quartz CronTrigger format without enclosing quotes.'
-    print 'For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ? *'
+    print 'For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * *'
     print
 
 


### PR DESCRIPTION
This at least tells end-users what to search for to find the appropriate schedule format when adding a repo sync schedule.