### PR TITLE
remove unused dependency

### DIFF
--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -9,7 +9,7 @@ License: GPLv2
 Group: Applications/Internet
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires: spacewalk-base
-Requires: perl-URI, perl(MIME::Base64)
+Requires: perl(MIME::Base64)
 Requires: lsof
 BuildRequires: /usr/bin/pod2man
 %if 0%{?fedora}

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -9,7 +9,6 @@ Group: Applications/System
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Buildarch: noarch
 Requires: perl(Satcon)
-Requires: perl(Apache::DBI)
 Obsoletes: rhn-satellite-config < 5.3.0
 Provides: rhn-satellite-config = 5.3.0
 Requires(post): chkconfig

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -43,7 +43,6 @@ Requires: /usr/bin/sudo
 Requires: webserver
 Requires:  perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 Requires: perl(Params::Validate)
-Requires: perl(URI)
 Requires: perl(XML::LibXML)
 Obsoletes: rhn-base < 5.3.0
 Obsoletes: spacewalk-grail < %{version}


### PR DESCRIPTION
Apache::DBI was used in spacewalk/config/etc/rhn/satellite-httpd/conf/rhn/rhn_monitoring.conf which gots removed
