### PR TITLE
Improvements for the errata-cache taskomatic job

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -617,10 +617,10 @@ where snc.errata_id = :errata_id
 </write-mode>
 
 <write-mode name="insert_into_task_queue">
-        <query params="org_id, task_data, cid, earliest">
+        <query params="org_id, task_name, task_data, earliest">
         INSERT INTO rhnTaskQueue
        (org_id, task_name, task_data, priority, earliest)
-                VALUES (:org_id, :task_data, :cid, 0, :earliest)
+                VALUES (:org_id, :task_name, :task_data, 0, :earliest)
         </query>
 </write-mode>
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1746,8 +1746,8 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
             inParams = new HashMap<String, Object>();
             inParams.put("org_id", org.getId());
-            inParams.put("cid", channel.getId());
-            inParams.put("task_data", "update_errata_cache_by_channel");
+            inParams.put("task_name", "update_errata_cache_by_channel");
+            inParams.put("task_data", channel.getId());
             inParams.put("earliest", new Timestamp(System.currentTimeMillis() + delay));
 
             w.executeUpdate(inParams);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheDriver.java
@@ -47,12 +47,12 @@ public class ErrataCacheDriver implements QueueDriver {
      *
      * {@inheritDoc}
      */
-    public List getCandidates() {
+    public List<Map<String, Object>> getCandidates() {
         List<Task> tasks = TaskFactory.getTaskListByNameLike(ErrataCacheWorker.BY_CHANNEL);
         tasks.addAll(TaskFactory.getTaskListByNameLike(ErrataCacheWorker.FOR_SERVER));
-        List retval = new LinkedList();
+        List<Map<String, Object>> retval = new LinkedList<Map<String, Object>>();
         for (Task current : tasks) {
-            Map item = new HashMap();
+            Map<String, Object> item = new HashMap<String, Object>();
             item.put("task", current);
             item.put("orgId", current.getOrg().getId());
             retval.add(item);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheWorker.java
@@ -56,7 +56,7 @@ class ErrataCacheWorker implements QueueWorker {
     public void run() {
         try {
             Date d = new Date(System.currentTimeMillis());
-            removeTask();
+            removeTask(task);
             HibernateFactory.commitTransaction();
             HibernateFactory.closeSession();
             parentQueue.workerStarting();
@@ -91,10 +91,15 @@ class ErrataCacheWorker implements QueueWorker {
         parentQueue = queue;
     }
 
-    private void removeTask() {
+    /**
+     * Remove a given task from the database via mode query.
+     *
+     * @param task task to remove
+     */
+    protected static void removeTask(Task task) {
         WriteMode mode = ModeFactory.getWriteMode("Task_queries", "delete_task");
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("org_id", orgId);
+        params.put("org_id", task.getOrg().getId());
         params.put("name", task.getName());
         params.put("task_data", task.getData());
         params.put("priority", new Integer(task.getPriority()));

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ErrataCacheDriverTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ErrataCacheDriverTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.taskomatic.task.test;
+
+import com.redhat.rhn.common.db.datasource.ModeFactory;
+import com.redhat.rhn.common.db.datasource.WriteMode;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.taskomatic.task.TaskConstants;
+import com.redhat.rhn.taskomatic.task.errata.ErrataCacheDriver;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import org.apache.log4j.Logger;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for ErrataCacheDriver class.
+ */
+public class ErrataCacheDriverTest extends BaseTestCaseWithUser {
+
+    /**
+     * Test the consolidation of tasks in getCandidates().
+     *
+     * @throws Exception in case of a problem
+     */
+    public void testGetCandidates() throws Exception {
+        Server server = ServerFactoryTest.createTestServer(user);
+        insertErrataCacheTask(server);
+        insertErrataCacheTask(server);
+        insertErrataCacheTask(server);
+        insertErrataCacheTask(server);
+
+        // Get the candidates and verify
+        ErrataCacheDriver driver = new ErrataCacheDriver();
+        driver.setLogger(Logger.getLogger(ErrataCacheDriverTest.class));
+        assertEquals(1, driver.getCandidates().size());
+    }
+
+    /**
+     * Insert an errata cache task for a given server.
+     *
+     * @param server the server
+     */
+    private void insertErrataCacheTask(Server server) {
+        WriteMode mode = ModeFactory.getWriteMode(TaskConstants.MODE_NAME,
+                "insert_into_task_queue");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("org_id", server.getOrg().getId());
+        params.put("task_name", "update_server_errata_cache");
+        params.put("task_data", server.getId());
+        params.put("earliest", new Timestamp(System.currentTimeMillis()));
+        mode.executeUpdate(params);
+    }
+}


### PR DESCRIPTION
This is a patch about improving the errata cache taskomatic job by consolidating the list of tasks returned by `getCandidates()` in a way that only **one** cache update is scheduled per server. This might help to overcome performance problems in large installations where many systems are being managed, i.e. reduce the time needed to process a long queue.

For instance if you update the package list of a server twice in between two runs of the `errata-cache` job, taskomatic will afterwards schedule the cache update twice for the same server. If you register a system, a cache update will even be scheduled 9 times (in my tests) for a single server! When this patch is installed a cache update will only be done once per server for every run of the job.

To see relevant log output you might want to add this to the taskomatic log4j.properties:
    
    log4j.logger.com.redhat.rhn.taskomatic.task.ErrataCacheTask=DEBUG
    log4j.logger.com.redhat.rhn.manager.errata.cache.UpdateErrataCacheCommand=DEBUG
