### PR TITLE
tuple assignment should be list in client_config_update.py

### DIFF
--- a/spacewalk/certs-tools/client_config_update.py
+++ b/spacewalk/certs-tools/client_config_update.py
@@ -90,7 +90,7 @@ def _parseConfigLine(line):
 
     if len(kv) > 2:
         # '=' is part of the value, need to rejoin it.
-        kv = kv[0], string.join(kv[1:], '=')
+        kv = [kv[0], string.join(kv[1:], '=')]
 
     if string.find(kv[0], '[comment]') > 0:
         # comment; not a setting


### PR DESCRIPTION
When an = is encountered in a config file value, client_config_update.py
joins the = separated portions together and reassigns to kv, but it makes
this assignment as a tuple rather than as a list, as a result, the line
kv[0] = string.strip(kv[0]) fails due to tuples being immutable.

Fixed by enclosing the assignment in [] to make it a list.