### PR TITLE
Kickstart: install the latest available koan package, not the first one found

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1100,11 +1100,8 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
      */
     public Map<String, Long> findKickstartPackageToInstall(Server server, Collection<Long> channelIds) {
         for (Long cid : channelIds) {
-            log.debug("    Checking on:" + cid + " for: " +
-                    getKickstartPackageName());
-            List<Map<String, Object>> result =
-                    ChannelManager.listLatestPackagesEqual(cid,
-                    getKickstartPackageName());
+            log.debug("    Checking on:" + cid + " for: " + getKickstartPackageName());
+            List<Map<String, Object>> result = ChannelManager.listLatestPackagesEqual(cid, getKickstartPackageName());
             log.debug("    size: " + result.size());
 
             if (result.size() > 0) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1055,7 +1055,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         }
 
         // check for package among channels the server is subscribed to. If one is found, return
-        Map<String, Object> pkgToInstall = findKickstartPackageToInstall(hostServer, serverChannelIds);
+        Map<String, Long> pkgToInstall = findKickstartPackageToInstall(hostServer, serverChannelIds);
         if (pkgToInstall != null) {
             this.packagesToInstall.add(pkgToInstall);
             log.debug("    packagesToInstall: " + packagesToInstall);
@@ -1070,7 +1070,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         if (pkgToInstall != null) {
             this.packagesToInstall.add(pkgToInstall);
             log.debug("    packagesToInstall: " + packagesToInstall);
-            Long cid = (Long) pkgToInstall.get("channel_id");
+            Long cid = pkgToInstall.get("channel_id");
             log.debug("    Subscribing to: " + cid);
             Channel c = ChannelFactory.lookupById(cid);
             try {
@@ -1098,7 +1098,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
      * @param channelIds channels the server could be subscribed to
      * @return a ValidationError or null
      */
-    public Map<String, Object> findKickstartPackageToInstall(Server server, Collection<Long> channelIds) {
+    public Map<String, Long> findKickstartPackageToInstall(Server server, Collection<Long> channelIds) {
         for (Long cid : channelIds) {
             log.debug("    Checking on:" + cid + " for: " +
                     getKickstartPackageName());
@@ -1110,10 +1110,10 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
             if (result.size() > 0) {
                 Map<String, Object> row = result.get(0);
                 log.debug("    Found the package: " + row);
-                Map<String, Object> pkgToInstall = new HashMap<String, Object>();
-                pkgToInstall.put("name_id", row.get("name_id"));
-                pkgToInstall.put("evr_id", row.get("evr_id"));
-                pkgToInstall.put("arch_id", row.get("package_arch_id"));
+                Map<String, Long> pkgToInstall = new HashMap<String, Long>();
+                pkgToInstall.put("name_id", (Long)row.get("name_id"));
+                pkgToInstall.put("evr_id", (Long)row.get("evr_id"));
+                pkgToInstall.put("arch_id", (Long)row.get("package_arch_id"));
                 pkgToInstall.put("channel_id", cid);
 
                 return pkgToInstall;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1059,6 +1059,19 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         channelIds.addAll(SystemManager.subscribableChannelIds(hostServer.getId(),
                 this.user.getId(), hostServer.getBaseChannel().getId()));
 
+        return ensureKickstartPackageIsInstalled(hostServer, serverChannelIds, channelIds);
+    }
+
+    /**
+     * Looks for the package name among the specified channels and, if it is found,
+     * it adds it to packagesToInstall for server
+     *
+     * @param server the server
+     * @param serverChannelIds channels the server is subscribed to
+     * @param channelIds channels the server could be subscribed to
+     * @return a ValidationError or null
+     */
+    public ValidatorError ensureKickstartPackageIsInstalled(Server server, Set<Long> serverChannelIds, List<Long> channelIds) {
         for (Long cid : channelIds) {
             log.debug("    Checking on:" + cid + " for: " +
                     getKickstartPackageName());
@@ -1082,7 +1095,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
                     log.debug("    Subscribing to: " + cid);
                     Channel c = ChannelFactory.lookupById(cid);
                     try {
-                        SystemManager.subscribeServerToChannel(this.user, hostServer, c);
+                        SystemManager.subscribeServerToChannel(this.user, server, c);
                         log.debug("    Subscribed: " + cid);
                     }
                     catch (PermissionException pe) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1059,9 +1059,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         channelIds.addAll(SystemManager.subscribableChannelIds(hostServer.getId(),
                 this.user.getId(), hostServer.getBaseChannel().getId()));
 
-        Iterator<Long> i2 = channelIds.iterator();
-        while (i2.hasNext()) {
-            Long cid = i2.next();
+        for (Long cid : channelIds) {
             log.debug("    Checking on:" + cid + " for: " +
                     getKickstartPackageName());
             List<Map<String, Object>> result =

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1103,20 +1103,20 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
     public Map<String, Long> findKickstartPackageToInstall(Server server, Collection<Long> channelIds) {
         List<Map<String, Long>> results = new LinkedList<Map<String,Long>>();
 
-        for (Long cid : channelIds) {
-            log.debug("    Checking on:" + cid + " for: " + getKickstartPackageName());
-            List<Map<String, Object>> result = ChannelManager.listLatestPackagesEqual(cid, getKickstartPackageName());
-            log.debug("    size: " + result.size());
+        for (Long chnnelId : channelIds) {
+            log.debug("    Checking on:" + chnnelId + " for: " + getKickstartPackageName());
+            List<Map<String, Object>> packages = ChannelManager.listLatestPackagesEqual(chnnelId, getKickstartPackageName());
+            log.debug("    size: " + packages.size());
 
-            for (Map<String, Object> row : result) {
-                log.debug("    Found the package: " + row);
-                Map<String, Long> pkgToInstall = new HashMap<String, Long>();
-                pkgToInstall.put("name_id", (Long)row.get("name_id"));
-                pkgToInstall.put("evr_id", (Long)row.get("evr_id"));
-                pkgToInstall.put("arch_id", (Long)row.get("package_arch_id"));
-                pkgToInstall.put("channel_id", cid);
+            for (Map<String, Object> aPackage : packages) {
+                log.debug("    Found the package: " + aPackage);
+                Map<String, Long> result = new HashMap<String, Long>();
+                result.put("name_id", (Long)aPackage.get("name_id"));
+                result.put("evr_id", (Long)aPackage.get("evr_id"));
+                result.put("arch_id", (Long)aPackage.get("package_arch_id"));
+                result.put("channel_id", chnnelId);
 
-                results.add(pkgToInstall);
+                results.add(result);
             }
         }
 


### PR DESCRIPTION
`KickstartScheduleCommand` is supposed to install koan on the host as a prerequisite of deploying a new VM. Current code assumes the package is available in one channel at the latest version, and will install the first one that is cound.

At least in some SUSE channels, that is not always wanted as we have, for example, separate "pool" and "updates" channels with different versions of the same package. This PR compares all available versions of the package and chooses the most recent one for installation.

Note to reviewers: "Refactoring" commits are supposed not to alter the semantics of code and have been separated for clarity.