### PR TITLE
Update 021-rhnServerNetwork-trigger.sql.oracle

### DIFF
--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/021-rhnServerNetwork-trigger.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/021-rhnServerNetwork-trigger.sql.oracle
@@ -13,7 +13,16 @@
 -- in this software or its documentation. 
 --
 
-drop trigger if exists rhn_servnet_ipaddr_mon_trig;
+declare
+        e exception;
+        pragma exception_init(e,-4080);
+begin
+        execute immediate 'drop trigger rhn_servnet_ipaddr_mon_trig';
+exception
+        when e then
+                null;
+end;
+/
 
 create or replace trigger
 rhn_servernetwork_mod_trig


### PR DESCRIPTION
This permanently fixes https://bugzilla.redhat.com/show_bug.cgi?id=1215151 in a proper way. 1. it does not "IF EXIST" the trigger, since that does not exist in oracle. 2. it does indeed check if the trigger exists, and if so, removes it, otherwise just continues, as the trigger does not exist anymore.