### PR TITLE
Change Activation Key Child Channels from multiple select to checkboxes

### DIFF
--- a/java/code/webapp/WEB-INF/pages/activationkeys/childchannels/listeditchannels.jsp
+++ b/java/code/webapp/WEB-INF/pages/activationkeys/childchannels/listeditchannels.jsp
@@ -17,31 +17,24 @@
             </c:if>
             <div class="form-group">
                 <div class="col-md-6">
-                <select multiple="multiple" name="childChannels" size="20" class="form-control">
+                <table class="table">
                     <c:set var="first" scope="session" value="yes"/>
+                    <c:set var="last_parent" scope="session" value=""/>
                     <c:forEach items="${channels}" var="channel" varStatus="loop">
-                        <c:choose>
-                            <c:when test="${first == 'yes'}">
-                                <c:set var="first" scope="session" value="no"/>
-                                <c:set var="last_parent" scope="session" value="${channel.parent}"/>
-                                <c:if test="${empty baseChannel}">
-                                    <optgroup label="${channel.parent}">
-                                </c:if>
-                            </c:when>
-                            <c:otherwise>
-                                <c:if test="${(channel.parent != last_parent) && empty baseChannel}">
-                                    </optgroup>
-                                    <optgroup label="${channel.parent}">
-                                </c:if>
-                            </c:otherwise>
-                        </c:choose>
-                        <option value="${channel.id}" ${channel.s}>${channel.name}</option>
+                        <c:set var="first" scope="session" value="no"/>
+                        <c:if test="${(channel.parent != last_parent || first == 'yes') && empty baseChannel}">
+                            <tr>
+                                <td><h4>${channel.parent}</h4></td>
+                            </tr>
+                        </c:if>
+                        <tr class="${channel.s == 'selected' ? 'success' : ''}">
+                            <td>
+                                <label><input type="checkbox" name="childChannels" value="${channel.id}" ${channel.s == 'selected' ? 'checked' : ''}/> ${channel.name}</label>
+                            </td>
+                        </tr>
                         <c:set var="last_parent" scope="session" value="${channel.parent}"/>
                     </c:forEach>
-                    <c:if test="${empty baseChannel}">
-                        </optgroup>
-                    </c:if>
-                </select>
+                </table>
                 </div>
             </div>
             <div class="form-group text-right">


### PR DESCRIPTION
In the dialog "Update Activation Key" -> tab "Child Channels" the
multiple select box was not really intuitive to use (need for holding
CTRL for multiple selection). This patch replaces it by checkboxes for
child channels as shown on attached screenshots.

![after1](https://cloud.githubusercontent.com/assets/1412268/7589939/1b6dab26-f8c6-11e4-838e-7de8174a4a93.png)
![after2](https://cloud.githubusercontent.com/assets/1412268/7589943/1f8e2244-f8c6-11e4-8efc-e3d01e490935.png)

