### PR TITLE
dnf is default on fedora22, so require it instead of yum-rhn-plugin

### DIFF
--- a/client/rhel/rhn-client-tools/rhn-client-tools.spec
+++ b/client/rhel/rhn-client-tools/rhn-client-tools.spec
@@ -96,7 +96,7 @@ Requires: %{name} = %{version}-%{release}
 %if 0%{?suse_version}
 Requires: zypp-plugin-spacewalk
 %else
-%if 0%{?fedora} > 22
+%if 0%{?fedora} >= 22
 Requires: dnf-plugin-spacewalk >= 2.4.0
 %else
 Requires: yum-rhn-plugin >= 1.6.4-1


### PR DESCRIPTION
bad dependency for fedora 22