### PR TITLE
Modify Oracle channel names to fit into the 64 character limit.

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -915,7 +915,7 @@ yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/addons/%(arch)s/
 [oraclelinux7-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
-name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 7 (%(arch)s)
+name     = Latest UEK R3 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/UEKR3/%(arch)s/
 
@@ -961,14 +961,14 @@ yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/addons/%(arch)s/
 [oraclelinux6-uek]
 label    = %(base_channel)s-uek
 archs    = %(_x86_archs)s
-name     = Latest Unbreakable Enterprise Kernel Release 2 for Oracle Linux 6 (%(arch)s)
+name     = Latest UEK R2 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/%(arch)s/
 
 [oraclelinux6-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
-name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 6 (%(arch)s)
+name     = Latest UEK R3 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/%(arch)s/
 
@@ -1034,14 +1034,14 @@ yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/oracle_addon
 [oraclelinux5-unsupported]
 label    = %(base_channel)s-unsupported
 archs    = %(_x86_archs)s
-name     = Productivity Applications for Oracle Linux 5 (%(arch)s)
+name     = Productivity Apps for Oracle Linux 5 (%(arch)s
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/unsupported/%(arch)s/
 
 [oraclelinux5-uek]
 label    = %(base_channel)s-uek
 archs    = %(_x86_archs)s
-name     = Latest Unbreakable Enterprise Kernel for Oracle Linux 5 (%(arch)s)
+name     = Latest UEK R2 for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/UEK/latest/%(arch)s/
 


### PR DESCRIPTION
Reported via the Spacewalk mailing list.