### PR TITLE
Drop code used by the Perl stack to 'trickle' OSAD

### DIFF
--- a/schema/spacewalk/common/tables/rhnPushDispatcher.sql
+++ b/schema/spacewalk/common/tables/rhnPushDispatcher.sql
@@ -24,7 +24,6 @@ CREATE TABLE rhnPushDispatcher
     last_checkin  timestamp with local time zone
                       DEFAULT (current_timestamp) NOT NULL,
     hostname      VARCHAR2(256) NOT NULL,
-    port          NUMBER NOT NULL,
     created       timestamp with local time zone
                       DEFAULT (current_timestamp) NOT NULL,
     modified      timestamp with local time zone

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.3-to-spacewalk-schema-2.4/002-rhnPushDispatcher-drop-port.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.3-to-spacewalk-schema-2.4/002-rhnPushDispatcher-drop-port.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rhnPushDispatcher DROP COLUMN port;


### PR DESCRIPTION
This was a hack to begin with, Perl side was removed, this patch removes the Python side as well.

See the following code to see where it was used (I could not find any other references):

https://github.com/spacewalkproject/spacewalk/blob/SPACEWALK-2.1/web/modules/rhn/RHN/DB/Scheduler.pm#L40
