### PR TITLE
ErrataManager: fix stack update case

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1754,7 +1754,6 @@ public class ErrataManager extends BaseManager {
                         "errata.swstack", args));
                 Action action = ActionManager.storeAction(errataAction);
                 actionIds.add(action.getId());
-                ActionManager.storeAction(errataAction);
             }
         }
 

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1730,37 +1730,33 @@ public class ErrataManager extends BaseManager {
             }
         }
 
-        // Schedule updates to the software update stack first
-        List<ErrataAction> stackUpdates = null;
+        // Divide stack updates from regular errata
+        List<Errata> stackUpdates = new ArrayList<Errata>();
         List<Errata> errata = new ArrayList<Errata>();
         for (Long errataId : serversForErrata.keySet()) {
             Errata erratum = ErrataManager.lookupErrata(errataId, user);
             if (erratum.hasKeyword("restart_suggested")) {
-                if (stackUpdates == null) {
-                    stackUpdates = createErrataActions(user, erratum,
-                        earliest, actionChain, serversForErrata.get(errataId));
-                }
-                else {
-                    for (ErrataAction stackUpdate : stackUpdates) {
-                        stackUpdate.addErrata(erratum);
-                    }
-                }
+                stackUpdates.add(erratum);
             }
             else {
                 errata.add(erratum);
             }
         }
 
-        if (stackUpdates != null) {
-            for (ErrataAction stackUpdate : stackUpdates) {
-                Object[] args = new Object[]{stackUpdate.getErrata().size()};
-                stackUpdate.setName(LocalizationService.getInstance().getMessage(
-                        "errata.swstack", args));
-                ActionManager.storeAction(stackUpdate);
+        // Schedule updates to the software update stack first
+        List<Long> actionIds = new ArrayList<Long>();
+        for (Errata stackUpdate : stackUpdates) {
+            List<ErrataAction> errataActions =
+                    createErrataActions(user, stackUpdate, earliest, actionChain, serversForErrata.get(stackUpdate.getId()));
+            for (ErrataAction errataAction : errataActions) {
+                Object[] args = new Object[] {errataAction.getErrata().size()};
+                errataAction.setName(LocalizationService.getInstance().getMessage("errata.swstack", args));
+                Action action = ActionManager.storeAction(errataAction);
+                actionIds.add(action.getId());
+                ActionManager.storeAction(errataAction);
             }
         }
 
-        List<Long> actionIds = new ArrayList<Long>();
         // Schedule remaining errata actions
         for (Errata e : errata) {
             List<ErrataAction> errataActions = createErrataActions(user, e, earliest,

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1746,11 +1746,12 @@ public class ErrataManager extends BaseManager {
         // Schedule updates to the software update stack first
         List<Long> actionIds = new ArrayList<Long>();
         for (Errata stackUpdate : stackUpdates) {
-            List<ErrataAction> errataActions =
-                    createErrataActions(user, stackUpdate, earliest, actionChain, serversForErrata.get(stackUpdate.getId()));
+            List<ErrataAction> errataActions = createErrataActions(user, stackUpdate,
+                    earliest, actionChain, serversForErrata.get(stackUpdate.getId()));
             for (ErrataAction errataAction : errataActions) {
                 Object[] args = new Object[] {errataAction.getErrata().size()};
-                errataAction.setName(LocalizationService.getInstance().getMessage("errata.swstack", args));
+                errataAction.setName(LocalizationService.getInstance().getMessage(
+                        "errata.swstack", args));
                 Action action = ActionManager.storeAction(errataAction);
                 actionIds.add(action.getId());
                 ActionManager.storeAction(errataAction);


### PR DESCRIPTION
In the case of multiple systems with different stack update erratas, previous code would apply all erratas to all systems which is not correct.

This lead to the failure of the following testcase:

com.redhat.rhn.manager.errata.test.ErrataManagerTest.testPackageManagerErratas()

This patch treats stack updates as normal errata (apart from the ordering), which makes the test pass.

AFAIU this is a regression from the commit:

https://github.com/spacewalkproject/spacewalk/commit/eec22d4bd2db70a1dd1f569cf53fdbb99724f854
