### PR TITLE
Get rid of IE7 compatibility mode enforcement

### DIFF
--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -6,10 +6,6 @@
     <c:if test="${pageContext.request.requestURI == '/rhn/Load.do'}">
       <meta http-equiv="refresh" content="0; url=<c:out value="${param.return_url}" />" />
     </c:if>
-    <c:if test="${pageContext.request.requestURI == '/rhn/kickstart/cobbler/CobblerSnippetView.do' || pageContext.request.requestURI == '/rhn/kickstart/cobbler/CobblerSnippetCreate.do' || pageContext.request.requestURI == '/rhn/kickstart/cobbler/CobblerSnippetEdit.do' || pageContext.request.requestURI == '/rhn/kickstart/KickstartScriptCreate.do' || pageContext.request.requestURI == '/rhn/kickstart/KickstartScriptEdit.do' || pageContext.request.requestURI == '/rhn/kickstart/KickstartScriptCreate.do' || pageContext.request.requestURI == '/rhn/kickstart/AdvancedModeEdit.do' || pageContext.request.requestURI == '/rhn/kickstart/AdvancedModeCreate.do' || pageContext.request.requestURI == '/rhn/configuration/file/FileDetails.do' || pageContext.request.requestURI == '/rhn/configuration/file/FileDownload.do' || pageContext.request.requestURI == '/rhn/systems/details/configuration/addfiles/CreateFile.do' || pageContext.request.requestURI == '/rhn/configuration/ChannelCreateFiles.do' || pageContext.request.requestURI == '/rhn/admin/Catalina.do'}">
-      <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7"/>
-      <!-- If we are loading a page that uses editarea, tell IE to use IE7 Compatability mode. This has to be the first thing in head if its gonna work. Only necessary for IE, but doesnt hurt other browsers. Conditional comments are going away in IE 10, so not including them here so this will continue to work. -->
-    </c:if>
     <meta http-equiv="content-type" content="text/html;charset=UTF-8"/>
     <title>
       <bean:message key="layout.jsp.productname"/>


### PR DESCRIPTION
This was needed because of 'editarea' component which is no longer used (replaced by ace editor in [here]). The IE7 compatibility mode is however incompatible with [bootstrap] which results in broken layout on pages which enforce it (see pictures).

### Screenshot of an affected screen before:
![with_ie7_compat](https://cloud.githubusercontent.com/assets/1412268/7808009/23cd04ea-0390-11e5-80ba-8770d88d6875.png)
### and after:
![wo_ie7_compat](https://cloud.githubusercontent.com/assets/1412268/7808011/28afa9f4-0390-11e5-957e-1fe46c27440e.png)

[here]: https://github.com/spacewalkproject/spacewalk/commit/7373be07f67933f784e322a2b168dbabdaf0f967
[bootstrap]: http://getbootstrap.com/getting-started/#support-ie-compatibility-modes