### PR TITLE
Unify profile creation/update with one submit button instead of two.

### DIFF
--- a/branding/css/spacewalk-fixes.less
+++ b/branding/css/spacewalk-fixes.less
@@ -12,3 +12,7 @@
         margin-bottom: 0;
         padding-top: 7px;
 }
+
+input[type="file"].form-control {
+    height: 100%;
+}

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/AdvancedModeDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/AdvancedModeDetailsAction.java
@@ -312,6 +312,11 @@ public class AdvancedModeDetailsAction extends RhnAction {
             throw new ValidatorException(result);
         }
 
+        FormFile file = (FormFile) form.get(FILE_UPLOAD);
+        String contents = form.getString(CONTENTS);
+        if (!file.getFileName().equals("") && !contents.equals("")) {
+            ValidatorException.raiseException("kickstart.details.duplicatefile");
+        }
 
         KickstartableTree tree =  KickstartFactory.lookupKickstartTreeByIdAndOrg(
                 (Long) form.get(KSTREE_ID_PARAM),
@@ -328,12 +333,18 @@ public class AdvancedModeDetailsAction extends RhnAction {
     }
 
     private String getData(RequestContext context, DynaActionForm form) {
-        if (context.wasDispatched(UPLOAD_KEY)) {
+        FormFile file = (FormFile) form.get(FILE_UPLOAD);
+        String contents = form.getString(CONTENTS);
+        if (!file.getFileName().equals("")) {
             StrutsDelegate delegate = getStrutsDelegate();
-            FormFile file = (FormFile) form.get(FILE_UPLOAD);
             return delegate.extractString(file);
         }
-        return StringUtil.webToLinux(form.getString(CONTENTS));
+        else if (!contents.equals("")) {
+            return StringUtil.webToLinux(contents);
+        }
+        else {
+            return null;
+        }
     }
 
     private KickstartRawData getKsData(RequestContext context) {

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -1909,6 +1909,12 @@ available for this kickstart profile to function properly.
           <context context-type="sourcefile">/rhn/kickstart/KickstartDetailsEdit</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="kickstart.details.duplicatefile">
+        <source>Please specify only file contents or a file to upload but not both.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/kickstart/KickstartDetailsEdit</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="kickstart.details.nolabel">
         <source>Kickstart profile label is required.</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/advanced/details.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/advanced/details.jspf
@@ -131,14 +131,7 @@
             <bean:message key="kickstart.advanced.jsp.uploadtab"/>
         </label>
         <div class="col-lg-6">
-            <div class="input-group">
-                <html:file property="fileUpload" size="30" styleClass="form-control"/>
-                <span class="input-group-btn">
-                    <html:submit property="dispatch" styleClass="btn btn-success">
-                        <bean:message key="${requestScope.uploadKey}"/>
-                    </html:submit>
-                </span>
-            </div>
+            <html:file property="fileUpload" size="30" styleClass="form-control"/>
         </div>
     </div>
     <div class="form-group">

--- a/java/code/webapp/WEB-INF/pages/keys/key-form.jspf
+++ b/java/code/webapp/WEB-INF/pages/keys/key-form.jspf
@@ -40,7 +40,7 @@
         </c:choose>
     </label>
     <div class="col-lg-6">
-        <html:file property="contents" styleClass="file-control"/>
+        <html:file property="contents" styleClass="form-control"/>
     </div>
 </div>
 


### PR DESCRIPTION
This removes the `Upload File` button on the `Create/Update Kickstart Profile` page which does the same thing as the `Create` or `Update` button but uses the file input instead of the textbox. With this patch the `Create` and `Update` button will use either the file input or the textbox depending on which one is provided. If both are provided it will show an error telling the user to only provide one of the two.

#### Before
![before_ff](https://cloud.githubusercontent.com/assets/688888/7811729/dda7b402-03ac-11e5-8a37-f8d050e15662.png)

#### After
![after_ff](https://cloud.githubusercontent.com/assets/688888/7811731/dee7e012-03ac-11e5-9249-51457d387f56.png)
