### PR TITLE
Fix adding user roles: make sure that ORG admin is added last

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/code/src/com/redhat/rhn/manager/user/UserManager.java
@@ -330,6 +330,11 @@ public class UserManager extends BaseManager {
             }
         }
 
+        // ORG admin role needs to be added last so that others don't get skipped
+        if (rolesToAdd.remove(ORG_ADMIN_LABEL)) {
+            rolesToAdd.add(ORG_ADMIN_LABEL);
+        }
+
         for (String removeLabel : rolesToRemove) {
             Role removeMe = RoleFactory.lookupByLabel(removeLabel);
             log.debug("Removing role: " + removeMe.getName());


### PR DESCRIPTION
This patch makes sure that the ORG admin role is always added last by moving it to the end of the list of roles to add. Otherwise all other roles to be added are skipped as soon as the ORG admin role was added, since ORG admin *implies* them all.

For testing the bug just edit a user and start with no roles:
- Add org admin as well as all the other roles below and save the user
- Remove only the org admin role, save the user and see what is left
- It should be all the other roles but it's not (for me it was only activation key manager, since it was accidentally before org admin in the list)
