### PR TITLE
NameError: global name 'CHANNELS_DISABLED' is not defined

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+++ b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
@@ -40,6 +40,7 @@ STORED_CHANNELS_NAME = '_spacewalk.json'
 PLUGIN_CONF = 'spacewalk.conf'
 
 RHN_DISABLED    = _("Spacewalk based repositories will be disabled.")
+CHANNELS_DISABLED = _("RHN channel support will be disabled.")
 COMMUNICATION_ERROR  = _("There was an error communicating with Spacewalk server.")
 NOT_REGISTERED_ERROR = _("This system is not registered with Spacewalk server.")
 NOT_SUBSCRIBED_ERROR = _("This system is not subscribed to any channels.")


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/dnf", line 36, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 185, in user_main
    errcode = main(args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 84, in main
    return _main(base, args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 115, in _main
    cli.configure(map(ucd, args))
  File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 1016, in configure
    self.base.plugins.run_config()
  File "/usr/lib/python2.7/site-packages/dnf/plugin.py", line 82, in fn
    dnf.util.mapall(operator.methodcaller(method), self.plugins)
  File "/usr/lib/python2.7/site-packages/dnf/util.py", line 157, in mapall
    return list(map(fn, *seq))
  File "/usr/lib/python2.7/site-packages/dnf-plugins/spacewalk.py", line 74, in config
    self.activate_channels(self.cli.demands.sack_activation)
  File "/usr/lib/python2.7/site-packages/dnf-plugins/spacewalk.py", line 112, in activate_channels
    logger.error("%s\n%s", NOT_SUBSCRIBED_ERROR, CHANNELS_DISABLED)
NameError: global name 'CHANNELS_DISABLED' is not defined