### PR TITLE
OSAD: log error stanzas

### DIFF
--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -979,7 +979,17 @@ class JabberClient(jabber.Client, object):
                 'subscription'  : subscription,
                 'ask'           : 'subscribe',
             }
-            self._subscribe_to_presence(jid)
+
+            # subscribe this node to the jid's presence
+            log_debug(4, jid)
+            stripped_jid = self._strip_resource(jid)
+            presence_node = JabberPresenceNode(to=stripped_jid, type="subscribe")
+            presence_node.setID("presence-%s" % self.get_unique_id())
+            sig = self._create_signature(jid, NS_RHN_PRESENCE_SUBSCRIBE)
+            if sig:
+                presence_node.insertNode(sig)
+            log_debug(5, "Sending presence subscription request", presence_node)
+            self.send(presence_node)
 
         # XXX Here we should clean up everybody that is no longer online, but
         # this is more difficult
@@ -1258,18 +1268,6 @@ class JabberClient(jabber.Client, object):
 
     def _strip_resource(self, jid):
         return strip_resource(jid)
-
-    def _subscribe_to_presence(self, full_jid):
-        """Subscribes this node to the jid's presence"""
-        log_debug(4, full_jid)
-        jid = self._strip_resource(full_jid)
-        presence_node = JabberPresenceNode(to=jid, type="subscribe")
-        presence_node.setID("presence-%s" % self.get_unique_id())
-        sig = self._create_signature(full_jid, NS_RHN_PRESENCE_SUBSCRIBE)
-        if sig:
-            presence_node.insertNode(sig)
-        log_debug(5, "Sending presence subscription request", presence_node)
-        self.send(presence_node)
 
     def _create_signature(self, jid, action):
         return None

--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -943,28 +943,24 @@ class JabberClient(jabber.Client, object):
             jid = str(jid)
             if subscribed_both.has_key(jid):
                 log_debug(4, "Already subscribed to the presence of node", jid)
-                del subscribed_both[jid]
                 continue
             # If to or from subscription for this node, we still send the
             # subscription request, but we shouldn't drop the subscription, so
             # we take the jid out of the respective hash
             if subscribed_to.has_key(jid):
                 log_debug(4, "Subscribed to")
-                del subscribed_to[jid]
                 continue
             if subscribed_none.has_key(jid):
                 ent = subscribed_none[jid]
                 if ent.has_key('ask') and ent['ask'] == 'subscribe':
                     log_debug(4, "Subscribed none + ask=subscribe")
                     # We already asked for a subscription
-                    del subscribed_none[jid]
                     continue
             if subscribed_from.has_key(jid):
                 ent = subscribed_from[jid]
                 if ent.has_key('ask') and ent['ask'] == 'subscribe':
                     log_debug(4, "Subscribed from + ask=subscribe")
                     # We already asked for a subscription
-                    del subscribed_from[jid]
                     continue
 
             # Make sure we update the roster ourselves, to avoid sending

--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -289,6 +289,7 @@ class Runner:
         # Register callbacks
         c.custom_handler.register_callback(c._presence_callback, 'presence')
         c.custom_handler.register_callback(c._message_callback, 'message')
+        c.custom_handler.register_callback(self._error_callback, 'error')
         return c
 
     def _get_jabber_client(self, jabber_server):
@@ -319,6 +320,10 @@ class Runner:
         c.add_trusted_cert(self.ssl_cert)
         c.connect()
         return c
+
+    def _error_callback(self, client, stanza):
+        """Logs error stanza messages for diagnostic purposes"""
+        log_error("Received an error stanza: ", stanza)
 
 class InvalidCertError(SSL.SSL.Error):
     def __str__(self):
@@ -543,6 +548,7 @@ class JabberClient(jabber.Client, object):
         self.registerProtocol('iq', JabberIqNode)
         self.registerProtocol('message', JabberMessageNode)
         self.registerProtocol('presence', JabberPresenceNode)
+        self.registerProtocol('error', JabberProtocolNode)
 
         self.registerHandler('iq', self._expectedIqHandler, system=True)
         self.registerHandler('iq', self._IqRegisterResult, 'result',
@@ -553,6 +559,7 @@ class JabberClient(jabber.Client, object):
         self.registerHandler('presence', h.dispatch)
         self.registerHandler('iq', h.dispatch)
         self.registerHandler('message', h.dispatch)
+        self.registerHandler('error', h.dispatch)
 
         self._non_ssl_sock = None
         self._roster = Roster()

--- a/client/tools/osad/src/rhn_log.py
+++ b/client/tools/osad/src/rhn_log.py
@@ -57,6 +57,7 @@ class Logger:
         return "%s.%s" % (module_file, module[2])
 
     def log_error(self, *args):
+        log_debug(self, 0, *args)
         line = map(str, args)
         sys.stderr.write(string.join(line))
         sys.stderr.write("\n")


### PR DESCRIPTION
This PR has two refactoring commits, which are only about removing cruft, and two commits to enable better logging in case of errors.

We had a customer reporting random failures in applying actions to a large number of OSAD clients. Turned out that OSAD requires all clients to have different credentials in /etc/sysconfig/rhn/osad-auth.conf, in fact as soon as two clients have the same file they will conflict but unfortunately, that would not be reported clearly by the logs.

By XMPP specification, in fact, server sends clients a special "conflict" stanza and closes the connection of one of the clients with the same JID (http://xmpp.org/rfcs/rfc3921.html#session):

"If there is already an active resource of the same name, the server MUST either (1) terminate the active resource and allow the newly-requested session, or (2) disallow the newly-requested session and maintain the active resource. Which of these the server does is up to the implementation, although it is RECOMMENDED to implement case #1. In case #1, the server SHOULD send a <conflict/> stream error to the active resource, terminate the XML stream and underlying TCP connection for the active resource"

(Jabberd actually implements case #1)

Solution was simply to regenerate /etc/sysconfig/rhn/osad-auth.conf by deleting it, I just want to make sure such problems are more clearly visible next time!