### PR TITLE
Fix Debian packages file

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -43,7 +43,7 @@ public class DebPackageWriter {
     private static Logger log = Logger.getLogger(DebPackageWriter.class);
     private String filenamePackages = "";
     private String channelLabel = "";
-    private Pattern versionRegex = Pattern.compile("^([<>=]+)\s*(.*)$");
+    private Pattern versionRegex = Pattern.compile("^([<>=]+)\\s*(.*)$");
 
     /**
      *

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -43,7 +43,7 @@ public class DebPackageWriter {
     private static Logger log = Logger.getLogger(DebPackageWriter.class);
     private String filenamePackages = "";
     private String channelLabel = "";
-    private Pattern versionRegex = Pattern.compile("^([<>=]+)(.*)$");
+    private Pattern versionRegex = Pattern.compile("^([<>=]+)\s*(.*)$");
 
     /**
      *

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -238,8 +238,7 @@ public class DebPackageWriter {
                     if (m.matches()) {
                         out.write(" (" + m.group(1) + " " + m.group(2) + ")");
                     }
-                    else
-                    {
+                    else {
                         out.write(" (" + versions[iIndex] + ")");
                     }
                 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -237,7 +237,9 @@ public class DebPackageWriter {
                     Matcher m = versionRegex.matcher(versions[iIndex]);
                     if (m.matches()) {
                         out.write(" (" + m.group(1) + " " + m.group(2) + ")");
-                    } else {
+                    }
+                    else
+                    {
                         out.write(" (" + versions[iIndex] + ")");
                     }
                 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -30,6 +30,8 @@ import java.io.FileWriter;
 import java.io.BufferedWriter;
 import java.util.Collection;
 import java.util.zip.GZIPOutputStream;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 /**
  *
@@ -41,6 +43,7 @@ public class DebPackageWriter {
     private static Logger log = Logger.getLogger(DebPackageWriter.class);
     private String filenamePackages = "";
     private String channelLabel = "";
+    private Pattern versionRegex = Pattern.compile("^([<>=]+)(.*)$");
 
     /**
      *
@@ -228,7 +231,15 @@ public class DebPackageWriter {
                 }
                 out.write(names[iIndex]);
                 if (versions[iIndex] != null && !versions[iIndex].isEmpty()) {
-                    out.write(" (" + versions[iIndex] + ")");
+                    /* check if the version contains operators. If so, split them
+                       up with a space
+                    */
+                    Matcher m = versionRegex.matcher(versions[iIndex]);
+                    if (m.matches()) {
+                        out.write(" (" + m.group(1) + " " + m.group(2) + ")");
+                    } else {
+                        out.write(" (" + versions[iIndex] + ")");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1226329
If the version is preceeded with operators, add an extra space between operator and version to be parseable.

I have to tell, that I was not able to fully test this (in spacewalk), but made a small test script. It should work, to change a version line (e.g. "<<1.3.4-5" to "<< 1.3.4-5")