### PR TITLE
fix --ca-chain option for rhnpush (bsc#931503, bsc#895869)

### DIFF
--- a/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/rhnserver.py
+++ b/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/rhnserver.py
@@ -161,8 +161,8 @@ class RhnServer(object):
     level exceptions
     """
 
-    def __init__(self):
-        self._server = rpcServer.getServer()
+    def __init__(self, caChain=None):
+        self._server = rpcServer.getServer(caChain=caChain)
         self._capabilities = None
 
     def __get_capabilities(self):

--- a/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/rpcServer.py
+++ b/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/rpcServer.py
@@ -105,18 +105,21 @@ class ServerList:
         self.index = 0
 
 
-def getServer(refreshCallback=None):
+def getServer(refreshCallback=None, caChain=None):
     log = up2dateLog.initLog()
     cfg = config.initUp2dateConfig()
 
-    # Where do we keep the CA certificate for RHNS?
-    # The servers we're talking to need to have their certs
-    # signed by one of these CA.
-    ca = cfg["sslCACert"]
+    if caChain:
+        ca = caChain
+    else:
+        # Where do we keep the CA certificate for RHNS?
+        # The servers we're talking to need to have their certs
+        # signed by one of these CA.
+        ca = cfg["sslCACert"]
     if isinstance(ca, basestring):
         ca = [ca]
-
     rhns_ca_certs = ca or ["/usr/share/rhn/RHNS-CA-CERT"]
+
     if cfg["enableProxy"]:
         proxyHost = config.getProxySetting()
     else:

--- a/client/rhel/rhn-client-tools/src/up2date_client/rhnserver.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/rhnserver.py
@@ -166,9 +166,9 @@ class RhnServer(object):
     level exceptions
     """
 
-    def __init__(self, serverOverride=None, timeout=None):
+    def __init__(self, serverOverride=None, timeout=None, caChain=None):
         self._server = rpcServer.getServer(serverOverride=serverOverride,
-                timeout=timeout)
+                timeout=timeout, caChain=caChain)
         self._capabilities = None
 
     def __get_capabilities(self):

--- a/client/rhel/rhn-client-tools/src/up2date_client/rpcServer.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/rpcServer.py
@@ -106,18 +106,21 @@ class ServerList:
         self.index = 0
 
 
-def getServer(refreshCallback=None, serverOverride=None, timeout=None):
+def getServer(refreshCallback=None, serverOverride=None, timeout=None, caChain=None):
     log = up2dateLog.initLog()
     cfg = config.initUp2dateConfig()
 
-    # Where do we keep the CA certificate for RHNS?
-    # The servers we're talking to need to have their certs
-    # signed by one of these CA.
-    ca = cfg["sslCACert"]
+    if caChain:
+        ca = caChain
+    else:
+        # Where do we keep the CA certificate for RHNS?
+        # The servers we're talking to need to have their certs
+        # signed by one of these CA.
+        ca = cfg["sslCACert"]
     if isinstance(ca, basestring):
         ca = [ca]
-
     rhns_ca_certs = ca or ["/usr/share/rhn/RHNS-CA-CERT"]
+
     if cfg["enableProxy"]:
         proxyHost = config.getProxySetting()
     else:

--- a/client/tools/rhnpush/rhnpush.py
+++ b/client/tools/rhnpush/rhnpush.py
@@ -536,7 +536,7 @@ class UploadClass(uploadLib.UploadClass):
             # computing checksum and other info is expensive process and session
             # could have expired.Make sure its re-authenticated.
             self.authenticate()
-            if uploadLib.exists_getPackageChecksumBySession(self.server):
+            if uploadLib.exists_getPackageChecksumBySession(self.server, self.ca_chain):
                 checksum_data = uploadLib.getPackageChecksumBySession(self.server,
                                                                       self.session.getSessionString(), info)
             else:
@@ -547,7 +547,7 @@ class UploadClass(uploadLib.UploadClass):
             # computing checksum and other info is expensive process and session
             # could have expired.Make sure its re-authenticated.
             self.authenticate()
-            if uploadLib.exists_getPackageChecksumBySession(self.server):
+            if uploadLib.exists_getPackageChecksumBySession(self.server, self.ca_chain):
                 checksum_data = uploadLib.getSourcePackageChecksumBySession(self.server,
                                                                             self.session.getSessionString(), info)
             else:

--- a/client/tools/rhnpush/uploadLib.py
+++ b/client/tools/rhnpush/uploadLib.py
@@ -497,7 +497,7 @@ class UploadClass:
 
         # set whether we should use checksum paths or not (if upstream supports
         # it we should).
-        self.use_checksum_paths = hasChannelChecksumCapability(self.server)
+        self.use_checksum_paths = hasChannelChecksumCapability(self.server, self.ca_chain)
 
     @staticmethod
     def _processFile(filename, relativeDir=None, source=None, nosig=None):
@@ -734,20 +734,20 @@ def getServer(uri, proxy=None, username=None, password=None, ca_chain=None):
     return s
 
 
-def hasChannelChecksumCapability(rpc_server):
+def hasChannelChecksumCapability(rpc_server, caChain=None):
     """ check whether server supports getPackageChecksumBySession function"""
-    server = rhnserver.RhnServer()
+    server = rhnserver.RhnServer(caChain=caChain)
     # pylint: disable=W0212
     server._server = rpc_server
     return server.capabilities.hasCapability('xmlrpc.packages.checksums')
 
 
-def exists_getPackageChecksumBySession(rpc_server):
+def exists_getPackageChecksumBySession(rpc_server, caChain=None):
     """ check whether server supports getPackageChecksumBySession function"""
     # unfortunatelly we do not have capability for getPackageChecksumBySession function,
     # but extended_profile in version 2 has been created just 2 months before
     # getPackageChecksumBySession lets use it instead
-    server = rhnserver.RhnServer()
+    server = rhnserver.RhnServer(caChain=caChain)
     # pylint: disable=W0212
     server._server = rpc_server
     result = server.capabilities.hasCapability('xmlrpc.packages.extended_profile', 2)


### PR DESCRIPTION
option --ca-chain was not passed down to routines from up2date
