### PR TITLE
When creating a channel, use x86_64 as the default architecture

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -671,6 +671,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
             request.setAttribute(CHANNEL_NAME, channelName);
             form.set(ORG_SHARING, "private");
             form.set(SUBSCRIPTIONS, "all");
+            form.set(ARCH, "channel-x86_64");
             form.set(CHECKSUM, "sha1");
         }
     }


### PR DESCRIPTION
Most users will have to click on IA-32 just to change it to x86_64.

For the future: At some point it would be useful to evaluate if checksum should be set to something higher than sha1. As the page automatically changes the checksum to the parent channel, setting the default would not affect older distros.