### PR TITLE
Version parsed like Spacewalk server

### DIFF
--- a/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/debUtils.py
+++ b/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/debUtils.py
@@ -25,14 +25,15 @@ def verifyPackages(packages):
 
 def parseVRE(version):
     epoch = ''
-    release = '0'
-    if version.find(':') != -1:
-        epoch, version = version.split(':')
-    if version.find('-') != -1:
-        tmp = version.split('-')
-        version = '-'.join(tmp[:-1])
-        release = tmp[-1]
-    return version, release, epoch
+    version_tmpArr = version.split('-')
+    if len(version_tmpArr) == 1:
+       version = version
+       release = 'X'
+       return version, release, epoch
+    else:
+       version = version_tmpArr[0]
+       release = version_tmpArr[1]
+       return version, release, epoch
 
 def installTime(pkg_name, pkg_arch):
     path = '/var/lib/dpkg/info/%s.list' % pkg_name

--- a/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/debUtils.py
+++ b/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/debUtils.py
@@ -1,5 +1,5 @@
 # Client code for Update Agent
-# Copyright (c) 2011--2013 Red Hat, Inc.  Distributed under GPLv2.
+# Copyright (c) 2011--2012 Red Hat, Inc.  Distributed under GPLv2.
 #
 # Author: Simon Lukasik
 #         Lukas Durfina
@@ -23,29 +23,39 @@ def verifyPackages(packages):
 
     return [], missing_packages
 
+# Patch to ignore the epoch so version matches with spacewalk server and ERRATA (pandujar)
 def parseVRE(version):
     epoch = ''
     version_tmpArr = version.split('-')
-    if len(version_tmpArr) == 1:
-       version = version
-       release = 'X'
-       return version, release, epoch
-    else:
-       version = version_tmpArr[0]
-       release = version_tmpArr[1]
-       return version, release, epoch
+    if len(version_tmpArr) == 1 :
+        version = version
+	release = 'X'
 
-def installTime(pkg_name, pkg_arch):
-    path = '/var/lib/dpkg/info/%s.list' % pkg_name
-    if os.path.isfile(path):
-       return os.path.getmtime(path)
     else:
-       # multiarch packages may have the architecture in the name of the list file
-       path = '/var/lib/dpkg/info/%s:%s.list' %(pkg_name, pkg_arch)
-       if os.path.isfile(path):
+        version = version_tmpArr[0]
+        release = version_tmpArr[1]
+
+    return version, release, epoch
+
+#def parseVRE(version):
+#    epoch = ''
+#    release = 'X'
+#    if version.find(':') != -1:
+#        epoch, version = version.split(':')
+#    if version.find('-') != -1:
+#        tmp = version.split('-')
+#        version = '-'.join(tmp[:-1])
+#        release = tmp[-1]
+#    return version, release, epoch
+
+def installTime(pkg_name, arch=None):
+    paths = ['/var/lib/dpkg/info/%s.list' % (pkg_name,)]
+    if arch:
+        paths.append('/var/lib/dpkg/info/%s:%s.list' % (pkg_name, arch))
+    for path in paths:
+        if os.path.isfile(path):
            return os.path.getmtime(path)
-       else:
-           return None
+    return None
 
 #FIXME: Using Apt cache might not be an ultimate solution.
 # It could be better to parse /var/lib/dpkg/status manually.


### PR DESCRIPTION
Spacewalk server ignores the epoch and passes it within the version string, therefore:
Spacewalk was reporting Ubuntu servers with extra packages because of version mismatch and few errata reports were not showing up for the same reason

Modified to correspond to spacewalk backend parsing:
https://github.com/spacewalkproject/spacewalk/blob/master/backend/common/rhn_deb.py#L75-L84