### PR TITLE
New Channel: Fix setting the default arch/checksum when selecting back Parent: None

### DIFF
--- a/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
@@ -6,35 +6,53 @@
 <html>
     <body>
         <script type="text/javascript">
-            function setChildChannelArchChecksum() {
-                var baseChannelArches = {};
-            <c:forEach items="${parentChannelArches}" var="parentChannel">
+            $(document).ready(function() {
+                var defaultArch = $('#parentarch option:selected').val();
+                var defaultChecksum = $('#checksum option:selected').val();
+
+                function setChildChannelArchChecksum() {
+                    var baseChannelArches = {};
+                    <c:forEach items="${parentChannelArches}" var="parentChannel">
                     baseChannelArches["<c:out value="${parentChannel.key}" />"] = "<c:out value="${parentChannel.value}"/>";
-            </c:forEach>
+                    </c:forEach>
                     var baseChannelChecksums = {};
-            <c:forEach items="${parentChannelChecksums}" var="parentChannel">
+                    <c:forEach items="${parentChannelChecksums}" var="parentChannel">
                     baseChannelChecksums["<c:out value="${parentChannel.key}" />"] = "<c:out value="${parentChannel.value}"/>";
-            </c:forEach>
+                    </c:forEach>
                     var archCompatMap = {};
-            <c:forEach items="${archCompatMap}" var="archCompat">
-                    archCompatMap["<c:out value="${archCompat.key}" />"] = "<c:out value="${archCompat.value}"/>".split(",");
-            </c:forEach>
-            
-                    var parentArchLabel = baseChannelArches[document.getElementById("parent").value]
-                    if (!parentArchLabel) {
-                      parentArchLabel = "";
+                    <c:forEach items="${archCompatMap}" var="archCompat">
+                    archCompatMap["<c:out value="${archCompat.key}" />"] = ${archCompat.value};
+                    </c:forEach>
+
+                    var parentArchLabel = baseChannelArches[$('#parent').val()];
+                    archCompatMapKey = parentArchLabel;
+                    if (typeof parentArchLabel === 'undefined') {
+                        archCompatMapKey = "";
+                        parentArchLabel = defaultArch;
                     }
-                    
-                    var archSelect = document.getElementById("parentarch");
-                    archSelect.options.length=0;
-                    for (i in archCompatMap[parentArchLabel]) {
-                      var arch = archCompatMap[parentArchLabel][i].split(":");
-                      archSelect.options[i]=new Option(arch[1], arch[0], arch[1] == parentArchLabel, arch[1] == parentArchLabel);
+
+                    var archSelect = $('#parentarch');
+                    archSelect.find('option').remove();
+                    $.each(archCompatMap[archCompatMapKey], function(i, compatibleArch) {
+                        archSelect.append($('<option>', {
+                            value: compatibleArch.label,
+                            text: compatibleArch.name,
+                            selected: compatibleArch.label == parentArchLabel
+                        }));
+                    });
+                    archSelect.val(parentArchLabel);
+
+                    var checksum = baseChannelChecksums[$('#parent').val()];
+                    if (typeof checksum === 'undefined') {
+                        checksum = defaultChecksum
                     }
-                    archSelect.value = parentArchLabel;
-                    
-                    document.getElementById("checksum").value = baseChannelChecksums[document.getElementById("parent").value];
+                    $('#checksum').val(checksum);
                 }
+
+                $('#parent').change(function() {
+                    setChildChannelArchChecksum();
+                });
+            });
         </script>
         <rhn:toolbar base="h1" icon="header-channel"
                      deletionUrl="/rhn/channels/manage/Delete.do?cid=${param.cid}"
@@ -125,8 +143,7 @@
                         <c:when test='${empty param.cid}'>
                             <html:select property="parent" styleId="parent"
                                          styleClass="form-control"
-                                         value="${defaultParent}"
-                                         onchange="setChildChannelArchChecksum()">
+                                         value="${defaultParent}">
                                 <html:options collection="parentChannels"
                                               property="value"
                                               labelProperty="label" />

--- a/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
@@ -32,13 +32,9 @@
                     }
 
                     var archSelect = $('#parentarch');
-                    archSelect.find('option').remove();
+                    archSelect.find('option').hide();
                     $.each(archCompatMap[archCompatMapKey], function(i, compatibleArch) {
-                        archSelect.append($('<option>', {
-                            value: compatibleArch.label,
-                            text: compatibleArch.name,
-                            selected: compatibleArch.label == parentArchLabel
-                        }));
+                        archSelect.find('option[value="' + compatibleArch.label + '"]').show();
                     });
                     archSelect.val(parentArchLabel);
 


### PR DESCRIPTION
* If the checksum is set to null because of setting back Parent to none, no metadata will generated
  and no feedback is given to the user. This prevents this problem.
* The default still comes from the Action default values, so no duplicates of default values are
  kept in the view.

While at it:

* Refactored the javascript generation to use standard js objects instead of a custom
  encoding using ':' and ',' that required unnecessary joining and splitting.
* Use the jquery functions to remove onChange tag and keep the js unobtrusive. Step
  needed to get rid of all inline Javascript in the future.

Demo of the fix: (demo taken in our maintenance branch, based on 2.1, that has not the architecture compatibility map, and therefore is a simplified version of this patch)

![5685ef3a-1017-11e5-8da9-856587d4483d](https://cloud.githubusercontent.com/assets/15332/8129108/f424c092-1105-11e5-960e-ff1361057a86.gif)
