### PR TITLE
auto-healing for duplicate jabber ids

### DIFF
--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -324,6 +324,10 @@ class Runner:
     def _error_callback(self, client, stanza):
         """Logs error stanza messages for diagnostic purposes"""
         log_error("Received an error stanza: ", stanza)
+        for kid in stanza.kids:
+            if kid.getName() == "conflict":
+                log_error("Received an conflict. Restarting with new credentials.")
+                raise NeedRestart
 
 class InvalidCertError(SSL.SSL.Error):
     def __str__(self):


### PR DESCRIPTION
In case 2 systems have the same jabber id, one will get a conflict message and will be dropped from the server. (E.g. cloned image)
Raising NeedRestart force osad to recreate osad-auth.conf with new credentials and authenticate again at the server. 
