### PR TITLE
rhbz#1232596: Require just openscap-scanner package everywhere

### DIFF
--- a/client/rhel/spacewalk-oscap/spacewalk-oscap.spec
+++ b/client/rhel/spacewalk-oscap/spacewalk-oscap.spec
@@ -12,11 +12,7 @@ BuildArch:	noarch
 BuildRequires:	python-devel
 BuildRequires:	rhnlib
 BuildRequires:  libxslt
-%if 0%{?rhel} && 0%{?rhel} < 6
-Requires:	openscap-utils >= 0.8.0
-%else
-Requires:	openscap-utils >= 0.9.2
-%endif
+Requires:	openscap-scanner
 Requires:	libxslt
 Requires:       rhnlib
 Requires:       rhn-check


### PR DESCRIPTION
openscap-scanner package has emerged after openscap-utils has started to
include more and more dependencies. openscap-scanner contains just the
oscap binary needed by spacewalk-oscap.