### PR TITLE
Allow using custom SSL certificates/keys in Spacewalk

### DIFF
--- a/proxy/installer/answers.txt
+++ b/proxy/installer/answers.txt
@@ -20,6 +20,13 @@ CA_CHAIN=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
 HTTP_PROXY=
 HTTP_USERNAME=
 HTTP_PASSWORD=
+
+# Use the following variables to import custom SSL keys/certificates
+USE_EXISTING_CERTS=N
+CA_CERT=/root/my_ca.crt
+SERVER_CERT=/root/my_server.key
+SERVER_KEY=/root/my_server.crt
+
 # If you want to populate configuration channel 
 # and want to have realy silent installation, then
 # you must run rhncfg-manager to enter your login 

--- a/proxy/installer/configure-proxy.sh.sgml
+++ b/proxy/installer/configure-proxy.sh.sgml
@@ -186,6 +186,30 @@ provide a required response, default answer is used.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
+        <term>--ssl-use-existing-certs=USE_EXISTING_CERTS</term>
+        <listitem>
+            <para>Use custom SSL certificates instead of generating new ones (use --ssl-ca-cert, --ssl-server-key and --ssl-server-cert parameters or corresponding variables to specify paths).</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>--ssl-ca-cert=CA_CERT</term>
+        <listitem>
+            <para>(If --ssl-use-existing-certs=1) use a custom CA certificate from the given file.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>--ssl-server-key=SERVER_KEY</term>
+        <listitem>
+            <para>(If --ssl-use-existing-certs=1) use a server private SSL key from the given file.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>--ssl-server-cert=SERVER_CERT</term>
+        <listitem>
+            <para>(If --ssl-use-existing-certs=1) use a server public SSL certificate from the given file.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
         <term>--version=VERSION</term>
         <listitem>
             <para>Version of Spacewalk Proxy Server you want to activate.</para>
@@ -225,6 +249,30 @@ provide a required response, default answer is used.</para>
         <term>USE_SSL</term>
         <listitem>
            <para>1 if &RHNPROXY; should communicate with parent over SSL. 0 otherwise. Even if disabled, client can still use SSL to connect to &RHNPROXY;</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>USE_EXISTING_CERTS</term>
+        <listitem>
+           <para>Use custom SSL certificates instead of generating new ones (use CA_CERT, SERVER_KEY and SERVER_CERT variables to specify paths).</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>CA_CERT</term>
+        <listitem>
+            <para>(If USE_EXISTING_CERTS=1) use a custom CA certificate from the given file.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>SERVER_KEY</term>
+        <listitem>
+            <para>(If USE_EXISTING_CERTS=1) use a server private SSL key from the given file.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>SERVER_CERT</term>
+        <listitem>
+            <para>(If USE_EXISTING_CERTS=1) use a server public SSL certificate from the given file.</para>
         </listitem>
     </varlistentry>
     <varlistentry>

--- a/spacewalk/certs-tools/rhn-ssl-tool.sgml
+++ b/spacewalk/certs-tools/rhn-ssl-tool.sgml
@@ -189,11 +189,13 @@ Generate and maintain SSL keys, certificates and deployment RPMs.
             <para>generate a CA SSL private key: <command>--gen-ca --key-only <replaceable>...</replaceable></command></para>
             <para>generate a CA SSL public certificate: <command>--gen-ca --cert-only <replaceable>...</replaceable></command></para>
             <para>generate a CA SSL public RPM: <command>--gen-ca --rpm-only <replaceable>...</replaceable></command></para>
+            <para>generate a CA SSL public RPM using a custom CA certificate from the given file: <command>--gen-ca --rpm-only --from-ca-cert=<replaceable>FILE</replaceable></command></para>
 
             <para>generate a web server's SSL private key: <command>--gen-server --key-only <replaceable>...</replaceable></command></para>
             <para>generate a web server's SSL certificate request: <command>--gen-server --cert-req-only <replaceable>...</replaceable></command></para>
             <para>generate/sign a web server's SSL certificate: <command>--gen-server --cert-only <replaceable>...</replaceable></command></para>
             <para>generate a web server's private RPM (and tar archive used for Red Hat Satellite Proxy installations): <command>--gen-server --rpm-only <replaceable>...</replaceable></command></para>
+            <para>generate a web server's private RPM using a custom SSL key and certificate: <command>--gen-server --rpm-only --from-server-key=<replaceable>FILE</replaceable> --from-server-cert=<replaceable>FILE</replaceable></command></para>
 
             </listitem>
         </varlistentry></variablelist>
@@ -203,6 +205,13 @@ Generate and maintain SSL keys, certificates and deployment RPMs.
         <variablelist><varlistentry>
 
             <term>Using a 3rd party CA (rarely done in the RHN context):</term>
+
+            <para><emphasis>DEPRECATED:</emphasis> Use
+            <command>--from-ca-cert</command>,
+            <command>--from-server-key</command> and
+            <command>--from-server-cert</command> parameters instead as
+            described in Advanced options section.
+            </para>
 
             <listitem>
             <para></para>

--- a/spacewalk/certs-tools/sslToolCli.py
+++ b/spacewalk/certs-tools/sslToolCli.py
@@ -72,6 +72,9 @@ def _getOptionsTree(defs):
 
     _optRpmOnly = make_option('--rpm-only', action='store_true', help='(rarely used) only generate a deployable RPM. (and tar archive if used during the --gen-server step) Review "<baseoption> --rpm-only --help" for more information.')
     _optNoRpm = make_option('--no-rpm',   action='store_true', help='(rarely used) do everything *except* generate an RPM.')
+    _optFromCaCert = make_option('--from-ca-cert', action='store', type="string", help='(for usage with --gen-ca and --rpm-only) Use a custom CA certificate from the given file. Note this doesn\'t affect the output CA certificate filename (for this use --ca-cert option).')
+    _optFromServerKey = make_option('--from-server-key', action='store', type="string", help='(for usage with --gen-server and --rpm-only) Use a server private SSL key from the given file. Note this doesn\'t affect the output server key filename (for this use --server-key option).')
+    _optFromServerCert = make_option('--from-server-cert', action='store', type="string", help='(for usage with --gen-server and --rpm-only) Use server public SSL certificate from the given file. Note this doesn\'t affect the output server certificate filename (for this use --server-cert option).')
 
     _optSetHostname = make_option('--set-hostname', action='store', type="string", help='hostname of the web server you are installing the key set on (default: %s)' % repr(defs['--set-hostname']))
 
@@ -154,7 +157,7 @@ def _getOptionsTree(defs):
     _caCertOnlySet = [_optGenCa] + _caOptions + _caCertOptions \
       + _genOptions + [_optCaCertOnly]
     _caRpmOnlySet = [_optGenCa, _optCaKey, _optCaCert] \
-      + _buildRpmOptions + [_optCaCertRpm] + _genOptions
+      + _buildRpmOptions + [_optFromCaCert] + [_optCaCertRpm] + _genOptions
 
     # server build option tree set possibilities
     _serverSet = [_optGenServer] + _serverKeyOptions + _serverCertReqOptions \
@@ -169,7 +172,8 @@ def _getOptionsTree(defs):
     _serverCertOnlySet = [_optGenServer] + _serverCertOptions \
       + _genOptions + [_optServerCertOnly]
     _serverRpmOnlySet = [_optGenServer, _optServerKey, _optServerCertReq, _optServerCert, _optSetHostname, _optSetCname ] \
-      + _buildRpmOptions + [_optServerRpm, _optServerTar] + _genOptions
+      + _buildRpmOptions + [_optFromServerKey, _optFromServerCert] \
+      + [_optServerRpm, _optServerTar] + _genOptions
 
     optionsTree = {
         '--gen-ca' : _caSet,

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -459,106 +459,140 @@ sub setup_jabberd {
 sub setup_ssl_certs {
   my $opts = shift;
   my $answers = shift;
+  Spacewalk::Setup::ask(
+    -noninteractive => $opts{"non-interactive"},
+    -question => "Do you want to import exising certificates?",
+    -test => sub { my $text = shift; return $text =~ /^[YyNn]/ },
+    -answer => \$answers->{"ssl-use-existing-certs"},
+    -default => 'N',
+  );
+
+  my $use_own_certs = $answers->{'ssl-use-existing-certs'} &&
+                      $answers->{'ssl-use-existing-certs'} =~ /^[Yy]/;
 
   if ($opts{"skip-ssl-cert-generation"} || $opts{"upgrade"}) {
     print Spacewalk::Setup::loc("** Skipping SSL certificate generation.\n");
     return;
   }
 
-  my ($password_1, $password_2);
+  if (!$use_own_certs) {
+      my ($password_1, $password_2);
 
-  unless ($answers->{"ssl-password"}) {
-    do {
-      ($password_1, $password_2) = (undef, undef); # clear previous passwords
+      unless ($answers->{"ssl-password"}) {
+        do {
+          ($password_1, $password_2) = (undef, undef); # clear previous passwords
+          Spacewalk::Setup::ask(
+            -noninteractive => $opts{"non-interactive"},
+            -question => "CA certificate password",
+              -test => \&valid_ssl_cert_password,
+              -answer => \$password_1,
+              -password => 1,
+             );
+
+          Spacewalk::Setup::ask(
+            -noninteractive => $opts{"non-interactive"},
+              -question => "Re-enter CA certificate password",
+              -test => \&valid_ssl_cert_password,
+              -answer => \$password_2,
+              -password => 1,
+             );
+        } until (passwords_match($password_1, $password_2));
+
+        $answers->{"ssl-password"} ||= $password_1;
+      };
+
       Spacewalk::Setup::ask(
-        -noninteractive => $opts{"non-interactive"},
-        -question => "CA certificate password",
-          -test => \&valid_ssl_cert_password,
-          -answer => \$password_1,
-          -password => 1,
+          -noninteractive => $opts{"non-interactive"},
+          -question => "Organization",
+          -test => sub { my $text = shift;
+                         return $text =~ /\S/ && length($text) <= 128 },
+          -answer => \$answers->{"ssl-set-org"},
          );
 
       Spacewalk::Setup::ask(
-        -noninteractive => $opts{"non-interactive"},
-          -question => "Re-enter CA certificate password",
-          -test => \&valid_ssl_cert_password,
-          -answer => \$password_2,
-          -password => 1,
+          -noninteractive => $opts{"non-interactive"},
+          -question => "Organization Unit",
+          -test => sub { my $text = shift;
+                         return $text =~ /\S/ && length($text) <= 128 },
+          -default => $answers->{'hostname'},
+          -answer => \$answers->{"ssl-set-org-unit"},
          );
-    } until (passwords_match($password_1, $password_2));
 
-    $answers->{"ssl-password"} ||= $password_1;
-  };
+      $answers->{"ssl-set-common-name"} ||= $answers->{hostname};
 
-  Spacewalk::Setup::ask(
-      -noninteractive => $opts{"non-interactive"},
-      -question => "Organization",
-      -test => sub { my $text = shift;
-                     return $text =~ /\S/ && length($text) <= 128 },
-      -answer => \$answers->{"ssl-set-org"},
-     );
+      Spacewalk::Setup::ask(
+          -noninteractive => $opts{"non-interactive"},
+          -question => 'Email Address',
+          -test => sub { my $text = shift;
+                         valid_multiple_email($text) && length($text) <= 128 },
+          -default => $answers->{'admin-email'},
+          -answer => \$answers->{'ssl-set-email'},
+         );
 
-  Spacewalk::Setup::ask(
-      -noninteractive => $opts{"non-interactive"},
-      -question => "Organization Unit",
-      -test => sub { my $text = shift;
-                     return $text =~ /\S/ && length($text) <= 128 },
-      -default => $answers->{'hostname'},
-      -answer => \$answers->{"ssl-set-org-unit"},
-     );
+      Spacewalk::Setup::ask(
+          -noninteractive => $opts{"non-interactive"},
+          -question => 'City',
+          -test => sub { my $text = shift;
+                         $text =~ /\S+/ && length($text) < 128 },
+          -answer => \$answers->{'ssl-set-city'},
+         );
 
-  $answers->{"ssl-set-common-name"} ||= $answers->{hostname};
+      Spacewalk::Setup::ask(
+          -noninteractive => $opts{"non-interactive"},
+          -question => 'State',
+          -test => sub { my $text = shift;
+                         length($text) > 0 && length($text) < 128 },
+          -answer => \$answers->{'ssl-set-state'},
+         );
 
-  Spacewalk::Setup::ask(
-      -noninteractive => $opts{"non-interactive"},
-      -question => 'Email Address',
-      -test => sub { my $text = shift;
-                     valid_multiple_email($text) && length($text) <= 128 },
-      -default => $answers->{'admin-email'},
-      -answer => \$answers->{'ssl-set-email'},
-     );
+      my ($by_code, $by_name) = valid_cert_countries($answers);
 
-  Spacewalk::Setup::ask(
-      -noninteractive => $opts{"non-interactive"},
-      -question => 'City',
-      -test => sub { my $text = shift;
-                     $text =~ /\S+/ && length($text) < 128 },
-      -answer => \$answers->{'ssl-set-city'},
-     );
+      while (not $answers->{'ssl-set-country'}
+             or not (exists $by_code->{$answers->{'ssl-set-country'}}
+                     or exists $by_name->{$answers->{'ssl-set-country'}})) {
+        Spacewalk::Setup::ask(
+            -noninteractive => $opts{"non-interactive"},
+            -question => 'Country code (Examples: "US", "JP", "IN", or type "?" to see a list)',
+            -test => sub { my $text = shift;
+                           exists $by_code->{$text} or exists $by_name->{$text} or $text eq '?' },
+            -answer => \$answers->{'ssl-set-country'},
+           );
 
-  Spacewalk::Setup::ask(
-      -noninteractive => $opts{"non-interactive"},
-      -question => 'State',
-      -test => sub { my $text = shift;
-                     length($text) > 0 && length($text) < 128 },
-      -answer => \$answers->{'ssl-set-state'},
-     );
+        if ($answers->{'ssl-set-country'} eq '?') {
+          print_country_list($by_name);
+          $answers->{'ssl-set-country'} = "";
+        }
+      }
 
-  my ($by_code, $by_name) = valid_cert_countries($answers);
+      if (my $code = $by_name->{$answers->{'ssl-set-country'}}) {
+        $answers->{'ssl-set-country'} = $code;
+      }
 
-  while (not $answers->{'ssl-set-country'}
-         or not (exists $by_code->{$answers->{'ssl-set-country'}}
-                 or exists $by_name->{$answers->{'ssl-set-country'}})) {
-    Spacewalk::Setup::ask(
-        -noninteractive => $opts{"non-interactive"},
-        -question => 'Country code (Examples: "US", "JP", "IN", or type "?" to see a list)',
-        -test => sub { my $text = shift;
-                       exists $by_code->{$text} or exists $by_name->{$text} or $text eq '?' },
-        -answer => \$answers->{'ssl-set-country'},
-       );
-
-    if ($answers->{'ssl-set-country'} eq '?') {
-      print_country_list($by_name);
-      $answers->{'ssl-set-country'} = "";
-    }
+      $answers->{'ssl-ca-cert-expiration'} ||= default_cert_expiration();
+      $answers->{'ssl-server-cert-expiration'} ||= default_cert_expiration();
+  } else {
+      Spacewalk::Setup::ask(
+          -noninteractive => $opts{"non-interactive"},
+          -question => "Path to CA Certificate",
+          -test => sub { my $text = shift;
+                         length($text) > 0 && -r $text && -s $text },
+          -answer => \$answers->{"ssl-ca-cert"},
+         );
+      Spacewalk::Setup::ask(
+          -noninteractive => $opts{"non-interactive"},
+          -question => "Path to Server Certificate",
+          -test => sub { my $text = shift;
+                         length($text) > 0 && -r $text && -s $text },
+          -answer => \$answers->{"ssl-server-cert"},
+         );
+      Spacewalk::Setup::ask(
+          -noninteractive => $opts{"non-interactive"},
+          -question => "Path to Server Key",
+          -test => sub { my $text = shift;
+                         length($text) > 0 && -r $text && -s $text },
+          -answer => \$answers->{"ssl-server-key"},
+         );
   }
-
-  if (my $code = $by_name->{$answers->{'ssl-set-country'}}) {
-    $answers->{'ssl-set-country'} = $code;
-  }
-
-  $answers->{'ssl-ca-cert-expiration'} ||= default_cert_expiration();
-  $answers->{'ssl-server-cert-expiration'} ||= default_cert_expiration();
 
   my @hostname_parts = split(/\./, $answers->{hostname});
   my $system_name;
@@ -573,37 +607,50 @@ sub setup_ssl_certs {
   $answers->{'ssl-server-rpm'} ||= 'rhn-org-httpd-ssl-key-pair-' . $system_name;
   $answers->{'ssl-dir'} ||= '/root/ssl-build';
 
-  print Spacewalk::Setup::loc("** SSL: Generating CA certificate.\n");
-
-  generate_ca_cert(-dir => $answers->{'ssl-dir'},
-                   -password => $answers->{'ssl-password'},
-                   '-set-country' => $answers->{'ssl-set-country'},
-                   '-set-state' => $answers->{'ssl-set-state'},
-                   '-set-city' => $answers->{'ssl-set-city'},
-                   '-set-org' => $answers->{'ssl-set-org'},
-                   '-set-org-unit' => $answers->{'ssl-set-org-unit'},
-                   '-set-common-name' => $answers->{'ssl-set-common-name'},
-                   '-cert-expiration' => $answers->{'ssl-ca-cert-expiration'},
-                  );
-
-  print Spacewalk::Setup::loc("** SSL: Deploying CA certificate.\n");
-
-  deploy_ca_cert("-source-dir" => $answers->{'ssl-dir'},
-                 "-target-dir" => '/var/www/html/pub');
-
-  print Spacewalk::Setup::loc("** SSL: Generating server certificate.\n");
-
-  generate_server_cert(-dir => $answers->{'ssl-dir'},
+  if (!$use_own_certs) {
+      print Spacewalk::Setup::loc("** SSL: Generating CA certificate.\n");
+      generate_ca_cert(-dir => $answers->{'ssl-dir'},
                        -password => $answers->{'ssl-password'},
                        '-set-country' => $answers->{'ssl-set-country'},
                        '-set-state' => $answers->{'ssl-set-state'},
                        '-set-city' => $answers->{'ssl-set-city'},
                        '-set-org' => $answers->{'ssl-set-org'},
                        '-set-org-unit' => $answers->{'ssl-set-org-unit'},
-                       '-cert-expiration' => $answers->{'ssl-server-cert-expiration'},
-                       '-set-email' => $answers->{'ssl-set-email'},
-                       '-set-hostname' => $answers->{'hostname'},
+                       '-set-common-name' => $answers->{'ssl-set-common-name'},
+                       '-cert-expiration' => $answers->{'ssl-ca-cert-expiration'},
                       );
+  } else {
+    my @opts = ( "--gen-ca",
+                 "--rpm-only",
+                 "--from-ca-cert=$answers->{'ssl-ca-cert'}" );
+    Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-tool', @opts], 35, 'Could not import CA certificate.');
+  }
+
+  print Spacewalk::Setup::loc("** SSL: Deploying CA certificate.\n");
+
+  deploy_ca_cert("-source-dir" => $answers->{'ssl-dir'},
+                 "-target-dir" => '/var/www/html/pub');
+
+  if (!$use_own_certs) {
+      print Spacewalk::Setup::loc("** SSL: Generating server certificate.\n");
+      generate_server_cert(-dir => $answers->{'ssl-dir'},
+                           -password => $answers->{'ssl-password'},
+                           '-set-country' => $answers->{'ssl-set-country'},
+                           '-set-state' => $answers->{'ssl-set-state'},
+                           '-set-city' => $answers->{'ssl-set-city'},
+                           '-set-org' => $answers->{'ssl-set-org'},
+                           '-set-org-unit' => $answers->{'ssl-set-org-unit'},
+                           '-cert-expiration' => $answers->{'ssl-server-cert-expiration'},
+                           '-set-email' => $answers->{'ssl-set-email'},
+                           '-set-hostname' => $answers->{'hostname'},
+                          );
+  } else {
+    my @opts = ( "--gen-server",
+                 "--rpm-only",
+                 "--from-server-cert=$answers->{'ssl-server-cert'}",
+                 "--from-server-key=$answers->{'ssl-server-key'}" );
+    Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-tool', @opts], 35, 'Could not import Server certificate and key.');
+  }
 
   print Spacewalk::Setup::loc("** SSL: Storing SSL certificates.\n");
 


### PR DESCRIPTION
Enhance `rhn-ssl-tool`, `configure-proxy.sh` and `spacewalk-setup` scripts to be able to import existing certificates instead of generating them (CA certificate and SSL key/certificate pair).
