### PR TITLE
Avoid deadlocks when Taskomatic compares configuration files

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -211,6 +211,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                           inner join sg.groupType.features as f
                           inner join s.capabilities as c
                       where (sg.groupType is not null) and f.label='ftr_config' and c.name = 'configfiles.diff'
+                      order by s.id asc
         ]]>
     </query>
 

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -206,11 +206,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
      <query name="Server.listConfigDiffEnabledSystems">
         <![CDATA[ select s
-                                 from com.redhat.rhn.domain.server.Server as s
-                                         inner join s.groups as sg
-                                         inner join sg.groupType.features as f
-                                         inner join s.capabilities as c
-                                        where (sg.groupType is not null) and f.label='ftr_config' and c.name = 'configfiles.diff']]>
+                      from com.redhat.rhn.domain.server.Server as s
+                          inner join s.groups as sg
+                          inner join sg.groupType.features as f
+                          inner join s.capabilities as c
+                      where (sg.groupType is not null) and f.label='ftr_config' and c.name = 'configfiles.diff'
+        ]]>
     </query>
 
     <sql-query name="Server.findVirtPlatformHostsByOrg">


### PR DESCRIPTION
CompareConfigFilesTask iterates over servers in undefined order, while
rhn_channel.update_needed_cache observes server ID order. Accessing
servers in wrong order could cause deadlocks, Postgres reproducer assuming
two systems (1000010000 and 1000010001) below:

```sql
BEGIN;

INSERT INTO rhnaction (
    id,
    org_id,
    action_type,
    name,
    scheduler,
    earliest_action,
    version,
    archived,
    prerequisite
)
VALUES (
    6666660,
    1,
    18,
    'Diff',
    1,
    now(),
    2,
    0,
    NULL
);

INSERT INTO rhnServerAction (
    result_code,
    result_msg,
    pickup_time,
    completion_time,
    remaining_tries,
    status,
    server_id,
    action_id)
    values (NULL,
    NULL,
    NULL,
    NULL,
    5,
    0,
    1000010000,
    6666660
);

                                    BEGIN;
                                    SELECT rhn_server.update_needed_cache(1000010001);

                                    SELECT rhn_server.update_needed_cache(1000010000);

INSERT INTO rhnaction (
    id,
    org_id,
    action_type,
    name,
    scheduler,
    earliest_action,
    version,
    archived,
    prerequisite
)
VALUES (
    6666661,
    1,
    18,
    'Diff',
    1,
    now(),
    2,
    0,
    NULL
);

INSERT INTO rhnServerAction (
    result_code,
    result_msg,
    pickup_time,
    completion_time,
    remaining_tries,
    status,
    server_id,
    action_id)
    values (NULL,
    NULL,
    NULL,
    NULL,
    5,
    0,
    1000010001,
    6666661
);

 -- ********** Error **********
 --
 -- ERROR: deadlock detected
 -- SQL state: 40P01
 -- Detail: Process XXX waits for ShareLock on transaction AAA; blocked by process YYY.
 -- Process YYY waits for ShareLock on transaction BBB; blocked by process XXX.
 -- Hint: See server log for query details.
 -- Context: SQL statement "SELECT 1 FROM ONLY "public"."rhnserver" x WHERE "id" OPERATOR(pg_catalog.=) $1 FOR  -- SHARE OF x"
```
