### PR TITLE
Improvements to the new Channel form

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -98,6 +98,11 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
     public static final String CHANNEL_ARCH = "channel_arch";
     public static final String CHANNEL_ARCH_LABEL = "channel_arch_label";
 
+    public static final String DEFAULT_ARCH = "channel-x86_64";
+    public static final String DEFAULT_CHECKSUM = "sha1";
+    public static final String DEFAULT_ORG_SHARING = "private";
+    public static final String DEFAULT_SUBSCRIPTIONS = "all";
+
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
                                  ActionForm formIn,
@@ -671,9 +676,10 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
             String channelName = LocalizationService.getInstance()
               .getMessage("frontend.actions.channels.manager.create");
             request.setAttribute(CHANNEL_NAME, channelName);
-            form.set(ORG_SHARING, "private");
-            form.set(SUBSCRIPTIONS, "all");
-            form.set(CHECKSUM, "sha1");
+            form.set(ORG_SHARING, DEFAULT_ORG_SHARING);
+            form.set(SUBSCRIPTIONS, DEFAULT_SUBSCRIPTIONS);
+            form.set(CHECKSUM, DEFAULT_CHECKSUM);
+            form.set(ARCH, DEFAULT_ARCH);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -749,7 +749,6 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
 
         // set the list of yum supported checksums
         List<Map<String, String>> checksums = new ArrayList<Map<String, String>>();
-        addOption(checksums, ls.getMessage("generic.jsp.none"), "");
         for (ChecksumType chType : ChannelFactory.listYumSupportedChecksums()) {
             addOption(checksums, chType.getLabel(), chType.getLabel());
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -679,7 +679,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
             form.set(ORG_SHARING, DEFAULT_ORG_SHARING);
             form.set(SUBSCRIPTIONS, DEFAULT_SUBSCRIPTIONS);
             form.set(CHECKSUM, DEFAULT_CHECKSUM);
-            form.set(ARCH, DEFAULT_ARCH);
+            ctx.getRequest().setAttribute(CHANNEL_ARCH_LABEL, DEFAULT_ARCH);
         }
     }
 
@@ -759,7 +759,6 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
             addOption(checksums, chType.getLabel(), chType.getLabel());
         }
         ctx.getRequest().setAttribute("checksums", checksums);
-
     }
 
     /**

--- a/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
@@ -6,35 +6,53 @@
 <html>
     <body>
         <script type="text/javascript">
-            function setChildChannelArchChecksum() {
-                var baseChannelArches = {};
-            <c:forEach items="${parentChannelArches}" var="parentChannel">
+            $(document).ready(function() {
+                var defaultArch = $('#parentarch option:selected').val();
+                var defaultChecksum = $('#checksum option:selected').val();
+
+                function setChildChannelArchChecksum() {
+                    var baseChannelArches = {};
+                    <c:forEach items="${parentChannelArches}" var="parentChannel">
                     baseChannelArches["<c:out value="${parentChannel.key}" />"] = "<c:out value="${parentChannel.value}"/>";
-            </c:forEach>
+                    </c:forEach>
                     var baseChannelChecksums = {};
-            <c:forEach items="${parentChannelChecksums}" var="parentChannel">
+                    <c:forEach items="${parentChannelChecksums}" var="parentChannel">
                     baseChannelChecksums["<c:out value="${parentChannel.key}" />"] = "<c:out value="${parentChannel.value}"/>";
-            </c:forEach>
+                    </c:forEach>
                     var archCompatMap = {};
-            <c:forEach items="${archCompatMap}" var="archCompat">
-                    archCompatMap["<c:out value="${archCompat.key}" />"] = "<c:out value="${archCompat.value}"/>".split(",");
-            </c:forEach>
-            
-                    var parentArchLabel = baseChannelArches[document.getElementById("parent").value]
-                    if (!parentArchLabel) {
-                      parentArchLabel = "";
+                    <c:forEach items="${archCompatMap}" var="archCompat">
+                    archCompatMap["<c:out value="${archCompat.key}" />"] = ${archCompat.value};
+                    </c:forEach>
+
+                    var parentArchLabel = baseChannelArches[$('#parent').val()];
+                    archCompatMapKey = parentArchLabel;
+                    if (typeof parentArchLabel === 'undefined') {
+                        archCompatMapKey = "";
+                        parentArchLabel = defaultArch;
                     }
-                    
-                    var archSelect = document.getElementById("parentarch");
-                    archSelect.options.length=0;
-                    for (i in archCompatMap[parentArchLabel]) {
-                      var arch = archCompatMap[parentArchLabel][i].split(":");
-                      archSelect.options[i]=new Option(arch[1], arch[0], arch[1] == parentArchLabel, arch[1] == parentArchLabel);
+
+                    var archSelect = $('#parentarch');
+                    archSelect.find('option').remove();
+                    $.each(archCompatMap[archCompatMapKey], function(i, compatibleArch) {
+                        archSelect.append($('<option>', {
+                            value: compatibleArch.label,
+                            text: compatibleArch.name,
+                            selected: compatibleArch.label == parentArchLabel
+                        }));
+                    });
+                    archSelect.val(parentArchLabel);
+
+                    var checksum = baseChannelChecksums[$('#parent').val()];
+                    if (typeof checksum === 'undefined') {
+                        checksum = defaultChecksum
                     }
-                    archSelect.value = parentArchLabel;
-                    
-                    document.getElementById("checksum").value = baseChannelChecksums[document.getElementById("parent").value];
+                    $('#checksum').val(checksum);
                 }
+
+                $('#parent').change(function() {
+                    setChildChannelArchChecksum();
+                });
+            });
         </script>
         <rhn:toolbar base="h1" icon="header-channel"
                      deletionUrl="/rhn/channels/manage/Delete.do?cid=${param.cid}"
@@ -125,8 +143,7 @@
                         <c:when test='${empty param.cid}'>
                             <html:select property="parent" styleId="parent"
                                          styleClass="form-control"
-                                         value="${defaultParent}"
-                                         onchange="setChildChannelArchChecksum()">
+                                         value="${defaultParent}">
                                 <html:options collection="parentChannels"
                                               property="value"
                                               labelProperty="label" />

--- a/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
@@ -32,13 +32,9 @@
                     }
 
                     var archSelect = $('#parentarch');
-                    archSelect.find('option').remove();
+                    archSelect.find('option').hide();
                     $.each(archCompatMap[archCompatMapKey], function(i, compatibleArch) {
-                        archSelect.append($('<option>', {
-                            value: compatibleArch.label,
-                            text: compatibleArch.name,
-                            selected: compatibleArch.label == parentArchLabel
-                        }));
+                        archSelect.find('option[value="' + compatibleArch.label + '"]').show();
                     });
                     archSelect.val(parentArchLabel);
 

--- a/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
@@ -162,6 +162,7 @@
                     <c:choose>
                         <c:when test='${empty param.cid}'>
                             <html:select property="arch"
+                                         value="${channel_arch_label}"
                                          styleClass="form-control"
                                          styleId="parentarch">
                                 <html:options collection="channelArches"

--- a/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/edit.jsp
@@ -163,7 +163,6 @@
                         <c:when test='${empty param.cid}'>
                             <html:select property="arch"
                                          styleClass="form-control"
-                                         value="${channel_arch_label}"
                                          styleId="parentarch">
                                 <html:options collection="channelArches"
                                               property="value"


### PR DESCRIPTION
This PR adresses the following things (in separate commits)

* Some refactoring on the Javascript to be unobtrusive
* Removes the checksum type None as discussed in https://www.redhat.com/archives/spacewalk-devel/2015-June/msg00008.html
* When no parent channel is selected, a default architecture is selected (which is defined on the action side, not in the view)
* The default architecture is x86_64
* Supersedes: https://github.com/spacewalkproject/spacewalk/pull/268 and https://github.com/spacewalkproject/spacewalk/pull/271

# Before

![before](https://cloud.githubusercontent.com/assets/15332/8375046/56a7e9f2-1bfa-11e5-98b7-65056aabdfc7.gif)

# After

![after-1](https://cloud.githubusercontent.com/assets/15332/8375055/7008be76-1bfa-11e5-9da9-86b4c6538ed2.gif)

![out](https://cloud.githubusercontent.com/assets/15332/8375137/fd9cc7aa-1bfa-11e5-9df1-9ca91b744086.gif)