### PR TITLE
1235955 - fix epoch timestamp calculation

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -837,7 +837,7 @@ SELECT DISTINCT S.id, S.NAME,
    AND P.evr_id = SP.evr_id
    AND P.name_id = SP.name_id
    AND EP.errata_id = E.id AND EP.package_id = P.id
-   AND (to_timestamp('1970-01-01', 'YYYY-MM-DD') + numtodsinterval(S.last_boot, 'second')) &lt; SP.installtime
+   AND (to_timestamp(S.last_boot)) &lt; SP.installtime
    AND E.id IN (SELECT EK.errata_id FROM rhnErrataKeyword EK WHERE EK.keyword = :keyword)
 </query>
 
@@ -867,7 +867,7 @@ SELECT DISTINCT S.id, S.NAME,
           AND P.evr_id = SP.evr_id
           AND P.name_id = SP.name_id
           AND EP.errata_id = E.id AND EP.package_id = P.id
-          AND (to_timestamp('1970-01-01', 'YYYY-MM-DD') + numtodsinterval(S.last_boot, 'second')) &lt; SP.installtime
+          AND (to_timestamp(S.last_boot)) &lt; SP.installtime
           AND E.id IN (SELECT EK.errata_id FROM rhnErrataKeyword EK WHERE EK.keyword = :keyword)
     </query>
 </mode>


### PR DESCRIPTION
Hi,
the epoch to timestamp calculation is incorrect if you're not in GMT with your Spacewalk Server.
Bugzilla Link: https://bugzilla.redhat.com/show_bug.cgi?id=1235955

There is another occurrence of the code in
schema/spacewalk/oracle/procs/epoch_seconds_to_timestamp_tz.sql
But I wasn't sure if its correct on oracle Databases :)