### PR TITLE
Taskomatic queue job improvements (errata-cache especially)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
@@ -100,20 +100,15 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
      * Updates the errata cache for the given server.
      * @param serverId Server id which needs to get updated.
      * @param commit commit the database transaction when complete
-     * @return Map of results formatted like so:
-     * Key: 'errata'   Value: list of erratas added
-     * Key: 'packages' Value: list of packages added
      */
-    public Map updateErrataCacheForServer(Long serverId, boolean commit) {
+    public void updateErrataCacheForServer(Long serverId, boolean commit) {
         log.info("Updating errata cache for server [" + serverId + "]");
-        Map changes = null;
         try {
             processServer(serverId);
         }
         catch (Exception e) {
             log.error("Problem updating cache for server", e);
             HibernateFactory.rollbackTransaction();
-
         }
         finally {
             if (commit) {
@@ -121,7 +116,6 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
             }
         }
         log.info("Finished errata cache for server [" + serverId + "]");
-        return changes;
     }
 
 

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
@@ -120,7 +120,7 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
                 handleTransaction();
             }
         }
-        log.info("Finished with servers in channel [" + serverId + "]");
+        log.info("Finished errata cache for server [" + serverId + "]");
         return changes;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
@@ -118,7 +118,6 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
         log.info("Finished errata cache for server [" + serverId + "]");
     }
 
-
     /**
      * Updates the needed cache for particular packages within a channel
      *  This isn't a full regeneration, only the changes are handled
@@ -153,7 +152,6 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
         log.info("Finished with servers in channel [" + cid + "] " +
                 "and errata [" + eid + "]" + " with pids [" + pids + "]");
     }
-
 
     /**
      * Updates the errata cache for all the servers in the given channel.

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnQueueJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnQueueJob.java
@@ -124,7 +124,9 @@ public abstract class RhnQueueJob implements RhnJob {
         }
         int maxWorkItems = Config.get().getInt("taskomatic." + queueName +
                 "_max_work_items", defaultItems);
-        if (queue.getQueueSize() < maxWorkItems) {
+        int queueSize = queue.getQueueSize();
+        getLogger().debug("Queue size (before run): " + queueSize);
+        if (queueSize < maxWorkItems) {
             queue.run(this);
         }
         else {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnQueueJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnQueueJob.java
@@ -127,7 +127,7 @@ public abstract class RhnQueueJob implements RhnJob {
         int queueSize = queue.getQueueSize();
         getLogger().debug("Queue size (before run): " + queueSize);
         if (queueSize < maxWorkItems) {
-            queue.run(this);
+            queue.run();
         }
         else {
             getLogger().debug("Maximum number of workers already put ... skipping.");

--- a/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/errata/ErrataCacheWorker.java
@@ -64,6 +64,9 @@ public class ErrataCacheWorker implements QueueWorker {
                     logger.debug("Updating errata cache for sid [" + sid + "]");
                 }
                 uecc.updateErrataCacheForServer(sid, false);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Finished errata cache for sid [" + sid + "]");
+                }
             }
             else if (ErrataCacheWorker.BY_CHANNEL.equals(task.getName())) {
                 Long cid = task.getData();
@@ -71,6 +74,9 @@ public class ErrataCacheWorker implements QueueWorker {
                     logger.debug("Updating errata cache for cid [" + cid + "]");
                 }
                 uecc.updateErrataCacheForChannel(cid);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Finished errata cache for cid [" + cid + "]");
+                }
             }
             HibernateFactory.commitTransaction();
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -109,7 +109,7 @@ public class TaskQueue {
     public void run() {
         setupQueue();
         List candidates = queueDriver.getCandidates();
-        queueSize = candidates.size();
+        queueSize += candidates.size();
         if (queueSize > 0) {
             queueDriver.getLogger().info("In the queue: " + queueSize);
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -20,7 +20,6 @@ import EDU.oswego.cs.dl.util.concurrent.PooledExecutor;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.taskomatic.TaskoRun;
-import com.redhat.rhn.taskomatic.task.RhnQueueJob;
 
 import java.util.List;
 
@@ -104,11 +103,10 @@ public class TaskQueue {
     }
 
     /**
-     * {@inheritDoc}
-     * @param runIn
-     * @param jobIn
+     * Create workers for all current candidates or set the current job run to FINISHED in
+     * case there is no new candidates and workers are all done.
      */
-    public void run(RhnQueueJob jobIn) {
+    public void run() {
         setupQueue();
         List candidates = queueDriver.getCandidates();
         queueSize = candidates.size();


### PR DESCRIPTION
The only non-cosmetic change in this patch is 84b6dbe, which could need some extra review. It looks like a bug to me: if there is any remainders from the last queue population (call of `getCandidates()`) they would never be counted in if we don't use `+=` it seems?

Apart from this the patch should improve taskomatic logging, especially to make it easier to debug queue jobs like the `errata-cache` job. For instance adding the following line to `log4j.properties` results in the log output shown below:

    log4j.logger.com.redhat.rhn.taskomatic.task.ErrataCacheTask=DEBUG

Output in the taskomatic logfile:

    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:00,935 [DefaultQuartzScheduler_Worker-5] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Starting run 2728
    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:00,940 [DefaultQuartzScheduler_Worker-5] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Queue size (before run): 0
    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:00,964 [DefaultQuartzScheduler_Worker-5] INFO  com.redhat.rhn.taskomatic.task.ErrataCacheTask - In the queue: 1
    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:00,965 [DefaultQuartzScheduler_Worker-5] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Putting worker
    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:00,965 [DefaultQuartzScheduler_Worker-5] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Put worker
    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:00,975 [Thread-63] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Updating errata cache for sid [1000010000]
    INFO   | jvm 1    | 2015/06/30 15:54:01 | 2015-06-30 15:54:01,003 [Thread-63] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Finished errata cache for sid [1000010000]
    INFO   | jvm 1    | 2015/06/30 15:55:00 | 2015-06-30 15:55:00,320 [DefaultQuartzScheduler_Worker-4] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Queue size (before run): 0
    INFO   | jvm 1    | 2015/06/30 15:55:00 | 2015-06-30 15:55:00,325 [DefaultQuartzScheduler_Worker-4] DEBUG com.redhat.rhn.taskomatic.task.ErrataCacheTask - Finishing run 2728
