### PR TITLE
Cobbler Distro metadata fixing & refactoring, Improving kernel options handling

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.hbm.xml
@@ -18,6 +18,8 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="basePath" type="string" column="base_path"/>
         <property name="label" type="string" column="label"/>
         <property name="lastModified" type="timestamp" column="last_modified"/>
+        <property name="kernelOptions" type="string" column="kernel_options"/>
+        <property name="kernelOptionsPost" type="string" column="kernel_options_post"/>
 
         <property name="created" type="timestamp" column="created"/>
         <property name="modified" type="timestamp" column="modified"/>

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
@@ -48,6 +48,8 @@ public class KickstartableTree extends BaseDomainHelper {
     private Date lastModified;
     private String cobblerId;
     private String cobblerXenId;
+    private String kernelOptions;
+    private String kernelOptionsPost;
 
     private Org org;
     private KickstartTreeType treeType;
@@ -386,6 +388,34 @@ public class KickstartableTree extends BaseDomainHelper {
      */
     public void setCobblerXenId(String cobblerXenIdIn) {
         this.cobblerXenId = cobblerXenIdIn;
+    }
+
+    /**
+     * @return Returns the kernelOptions.
+     */
+    public String getKernelOptions() {
+        return kernelOptions;
+    }
+
+    /**
+     * @param kernelOptionsIn The kernelOptions to set.
+     */
+    public void setKernelOptions(String kernelOptionsIn) {
+        kernelOptions = kernelOptionsIn;
+    }
+
+    /**
+     * @return Returns the kernelOptionsPost.
+     */
+    public String getKernelOptionsPost() {
+        return kernelOptionsPost;
+    }
+
+    /**
+     * @param kernelOptionsPostIn The kernelOptionsPost to set.
+     */
+    public void setKernelOptionsPost(String kernelOptionsPostIn) {
+        kernelOptionsPost = kernelOptionsPostIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/kickstart/test/KickstartableTreeTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/test/KickstartableTreeTest.java
@@ -209,7 +209,7 @@ public class KickstartableTreeTest extends BaseTestCaseWithUser {
         Distro d = builder.setName(k.getLabel())
                 .setKernel(k.getDefaultKernelPath())
                 .setInitrd(k.getDefaultInitrdPath()[0])
-                .setKsmeta(new HashMap<>())
+                .setKsmeta(new HashMap<String, Object>())
                 .setBreed(k.getInstallType().getCobblerBreed())
                 .setOsVersion(k.getInstallType().getCobblerOsVersion())
                 .setArch(k.getChannel().getChannelArch().cobblerArch())
@@ -217,7 +217,7 @@ public class KickstartableTreeTest extends BaseTestCaseWithUser {
                 .setKernelOptionsPost(k.getKernelOptionsPost())
                 .build(CobblerXMLRPCHelper.getConnection("test"));
 
-        Distro xend = builder.setKsmeta(new HashMap<>())
+        Distro xend = builder.setKsmeta(new HashMap<String, Object>())
                 .build(CobblerXMLRPCHelper.getConnection("test"));
 
         k.setCobblerId(d.getUid());

--- a/java/code/src/com/redhat/rhn/domain/kickstart/test/KickstartableTreeTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/test/KickstartableTreeTest.java
@@ -199,19 +199,26 @@ public class KickstartableTreeTest extends BaseTestCaseWithUser {
         k.setInstallType(installtype);
         k.setTreeType(treetype);
         k.setChannel(treeChannel);
+        k.setKernelOptions("");
+        k.setKernelOptionsPost("");
 
         createKickstartTreeItems(k);
 
-        Distro d = Distro.create(CobblerXMLRPCHelper.getConnection("test"), k.getLabel(),
-                k.getDefaultKernelPath(), k.getDefaultInitrdPath()[0], new HashMap(),
-                k.getInstallType().getCobblerBreed(),
-                k.getInstallType().getCobblerOsVersion(),
-                k.getChannel().getChannelArch().cobblerArch());
-        Distro xend = Distro.create(CobblerXMLRPCHelper.getConnection("test"),
-                k.getLabel(), k.getDefaultKernelPath(), k.getDefaultInitrdPath()[0],
-                new HashMap(), k.getInstallType().getCobblerBreed(),
-                k.getInstallType().getCobblerOsVersion(),
-                k.getChannel().getChannelArch().cobblerArch());
+        Distro.Builder builder = new Distro.Builder();
+
+        Distro d = builder.setName(k.getLabel())
+                .setKernel(k.getDefaultKernelPath())
+                .setInitrd(k.getDefaultInitrdPath()[0])
+                .setKsmeta(new HashMap<>())
+                .setBreed(k.getInstallType().getCobblerBreed())
+                .setOsVersion(k.getInstallType().getCobblerOsVersion())
+                .setArch(k.getChannel().getChannelArch().cobblerArch())
+                .setKernelOptions(k.getKernelOptions())
+                .setKernelOptionsPost(k.getKernelOptionsPost())
+                .build(CobblerXMLRPCHelper.getConnection("test"));
+
+        Distro xend = builder.setKsmeta(new HashMap<>())
+                .build(CobblerXMLRPCHelper.getConnection("test"));
 
         k.setCobblerId(d.getUid());
         k.setCobblerXenId(xend.getUid());

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartDetailsEditAction.java
@@ -146,7 +146,7 @@ public class KickstartDetailsEditAction extends BaseKickstartEditAction {
                     ctx.getCurrentUser()), data.getCobblerId());
         if (prof != null) {
             form.set(KERNEL_OPTIONS, prof.getKernelOptionsString());
-            form.set(POST_KERNEL_OPTIONS, prof.getKernelPostOptionsString());
+            form.set(POST_KERNEL_OPTIONS, prof.getKernelOptionsPostString());
         }
         KickstartVirtualizationType type = data.getKickstartDefaults().
                                                     getVirtualizationType();

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
@@ -530,14 +530,14 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
             ctx.getRequest().setAttribute("distro_kernel_params",
                     distro.getKernelOptionsString());
             ctx.getRequest().setAttribute("distro_post_kernel_params",
-                    distro.getKernelPostOptionsString());
+                    distro.getKernelOptionsPostString());
 
             org.cobbler.Profile profile = org.cobbler.Profile.
                     lookupById(con, cmd.getKsdata().getCobblerId());
             ctx.getRequest().setAttribute("profile_kernel_params",
                     profile.getKernelOptionsString());
             ctx.getRequest().setAttribute("profile_post_kernel_params",
-                    profile.getKernelPostOptionsString());
+                    profile.getKernelOptionsPostString());
             if (cmd.getServer().getCobblerId() != null) {
                 SystemRecord rec = SystemRecord.
                         lookupById(con, cmd.getServer().getCobblerId());
@@ -549,7 +549,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
                     }
                     if (StringUtils.isBlank(form.getString(POST_KERNEL_PARAMS_TYPE))) {
                         form.set(POST_KERNEL_PARAMS_TYPE, KERNEL_PARAMS_CUSTOM);
-                        form.set(POST_KERNEL_PARAMS, rec.getKernelPostOptionsString());
+                        form.set(POST_KERNEL_PARAMS, rec.getKernelOptionsPostString());
                     }
                 }
             }
@@ -981,7 +981,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
         if (!isPost) {
             return ret.getKernelOptionsString();
         }
-        return ret.getKernelPostOptionsString();
+        return ret.getKernelOptionsPostString();
 
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/BaseTreeAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/BaseTreeAction.java
@@ -118,7 +118,7 @@ public abstract class BaseTreeAction extends BaseEditAction {
         else {
             bte.setKernelOptions(form.getString(KERNEL_OPTS));
         }
-        bte.setPostKernelOptions(form.getString(POST_KERNEL_OPTS));
+        bte.setKernelOptionsPost(form.getString(POST_KERNEL_OPTS));
 
         return null;
 

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/TreeEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/TreeEditAction.java
@@ -16,13 +16,13 @@ package com.redhat.rhn.frontend.action.kickstart.tree;
 
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.common.validator.ValidatorResult;
+import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.manager.PersistOperation;
 import com.redhat.rhn.manager.kickstart.tree.BaseTreeEditOperation;
 import com.redhat.rhn.manager.kickstart.tree.TreeEditOperation;
 
 import org.apache.struts.action.DynaActionForm;
-import org.cobbler.Distro;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -70,15 +70,13 @@ public class TreeEditAction extends BaseTreeAction {
     protected void processFormValues(PersistOperation operation,
             DynaActionForm form) {
         BaseTreeEditOperation bte = (BaseTreeEditOperation) operation;
-        form.set(BASE_PATH, bte.getTree().getBasePath());
-        form.set(CHANNEL_ID, bte.getTree().getChannel().getId());
-        form.set(LABEL, bte.getTree().getLabel());
-        form.set(INSTALL_TYPE, bte.getTree().getInstallType().getLabel());
-        Distro distro = bte.getTree().getCobblerObject(bte.getUser());
-        if (distro != null) {
-            form.set(KERNEL_OPTS, distro.getKernelOptionsString());
-            form.set(POST_KERNEL_OPTS, distro.getKernelPostOptionsString());
-        }
+        KickstartableTree tree = bte.getTree();
+        form.set(BASE_PATH, tree.getBasePath());
+        form.set(CHANNEL_ID, tree.getChannel().getId());
+        form.set(LABEL, tree.getLabel());
+        form.set(INSTALL_TYPE, tree.getInstallType().getLabel());
+        form.set(KERNEL_OPTS, tree.getKernelOptions());
+        form.set(POST_KERNEL_OPTS, tree.getKernelOptionsPost());
     }
 
     private void checkDistroValidity(HttpServletRequest request,

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartCloneCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartCloneCommand.java
@@ -68,7 +68,7 @@ public class KickstartCloneCommand extends BaseKickstartCommand {
         cloned.setVirtBridge(original.getVirtBridge());
         cloned.setVirtPath(original.getVirtBridge());
         cloned.setKernelOptions(original.getKernelOptions());
-        cloned.setKernelPostOptions(original.getKernelPostOptions());
+        cloned.setKernelOptionsPost(original.getKernelOptionsPost());
         cloned.save();
 
         return null;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
@@ -24,14 +24,11 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.integration.IntegrationService;
 import com.redhat.rhn.frontend.xmlrpc.util.XMLRPCInvoker;
 
-import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
 import org.apache.log4j.Logger;
 import org.cobbler.CobblerConnection;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import redstone.xmlrpc.XmlRpcFault;
 
@@ -192,23 +189,5 @@ public abstract class CobblerCommand {
             return CobblerXMLRPCHelper.getAutomatedConnection();
         }
         return CobblerXMLRPCHelper.getConnection(user);
-    }
-
-    protected Map<String, String> createKsMetadataFromTree(KickstartableTree tree) {
-        Map<String, String> ksmeta = new HashMap<>();
-
-        KickstartUrlHelper helper = new KickstartUrlHelper(tree);
-        ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
-                helper.getKickstartMediaPath());
-
-        if (!tree.isRhnTree()) {
-            ksmeta.put("org", tree.getOrgId().toString());
-        }
-
-        if (tree.getInstallType().isSUSE()) {
-            ksmeta.put("autoyast", "true");
-        }
-
-        return ksmeta;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
@@ -24,11 +24,14 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.integration.IntegrationService;
 import com.redhat.rhn.frontend.xmlrpc.util.XMLRPCInvoker;
 
+import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
 import org.apache.log4j.Logger;
 import org.cobbler.CobblerConnection;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import redstone.xmlrpc.XmlRpcFault;
 
@@ -189,5 +192,23 @@ public abstract class CobblerCommand {
             return CobblerXMLRPCHelper.getAutomatedConnection();
         }
         return CobblerXMLRPCHelper.getConnection(user);
+    }
+
+    protected Map<String, String> createKsMetadataFromTree(KickstartableTree tree) {
+        Map<String, String> ksmeta = new HashMap<>();
+
+        KickstartUrlHelper helper = new KickstartUrlHelper(tree);
+        ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
+                helper.getKickstartMediaPath());
+
+        if (!tree.isRhnTree()) {
+            ksmeta.put("org", tree.getOrgId().toString());
+        }
+
+        if (tree.getInstallType().isSUSE()) {
+            ksmeta.put("autoyast", "true");
+        }
+
+        return ksmeta;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
@@ -18,11 +18,6 @@ import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
 
-import org.cobbler.CobblerConnection;
-import org.cobbler.Distro;
-
-import java.util.Map;
-
 
 /**
  * CobblerProfileComand - class to contain logic to communicate with cobbler
@@ -55,58 +50,6 @@ public class CobblerDistroCommand extends CobblerCommand {
         super();
         this.tree = ksTreeIn;
     }
-
-    /**
-     * Copy cobbler fields that shouldn't change in cobbler
-     */
-    protected void updateCobblerFields() {
-        CobblerConnection con = getCobblerConnection();
-        Distro nonXen = Distro.lookupById(con, tree.getCobblerId());
-        Distro xen = Distro.lookupById(con, tree.getCobblerXenId());
-
-        Map<String, String> ksmeta = createKsMetadataFromTree(this.tree);
-
-        //if the newly edited tree does para virt....
-        if (tree.doesParaVirt()) {
-            //IT does paravirt so we need to either update the xen distro or create one
-            if (xen == null) {
-                xen = Distro.create(con, tree.getCobblerXenDistroName(), tree
-                        .getKernelXenPath(), tree.getInitrdXenPath(), ksmeta, tree
-                        .getInstallType().getCobblerBreed(), tree.getInstallType()
-                        .getCobblerOsVersion(), tree.getChannel().getChannelArch()
-                        .cobblerArch());
-                tree.setCobblerXenId(xen.getId());
-            }
-            else {
-                xen.setKernel(tree.getKernelXenPath());
-                xen.setInitrd(tree.getInitrdXenPath());
-                xen.setBreed(tree.getInstallType().getCobblerBreed());
-                xen.setOsVersion(tree.getInstallType().getCobblerOsVersion());
-                xen.setKsMeta(ksmeta);
-                xen.setArch(tree.getChannel().getChannelArch().cobblerArch());
-                xen.save();
-            }
-
-        }
-        else {
-            //it doesn't do paravirt, so we need to delete the xen distro
-            if (xen != null) {
-                xen.remove();
-                tree.setCobblerXenId(null);
-            }
-        }
-
-        if (nonXen != null) {
-            nonXen.setInitrd(tree.getInitrdPath());
-            nonXen.setKernel(tree.getKernelPath());
-            nonXen.setBreed(tree.getInstallType().getCobblerBreed());
-            nonXen.setOsVersion(tree.getInstallType().getCobblerOsVersion());
-            nonXen.setKsMeta(ksmeta);
-            nonXen.setArch(tree.getChannel().getChannelArch().cobblerArch());
-            nonXen.save();
-        }
-    }
-
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
@@ -70,8 +70,12 @@ public class CobblerDistroCommand extends CobblerCommand {
         KickstartUrlHelper helper = new KickstartUrlHelper(this.tree);
         ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
                 helper.getKickstartMediaPath());
-        if (tree.getOrgId() != null) {
-            ksmeta.put("org", tree.getOrg().getId());
+        if (!tree.isRhnTree()) {
+            ksmeta.put("org", tree.getOrgId().toString());
+        }
+
+        if (tree.getInstallType().isSUSE()) {
+            ksmeta.put("autoyast", "true");
         }
 
         //if the newly edited tree does para virt....

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
@@ -75,7 +75,6 @@ public class CobblerDistroCommand extends CobblerCommand {
                         .getInstallType().getCobblerBreed(), tree.getInstallType()
                         .getCobblerOsVersion(), tree.getChannel().getChannelArch()
                         .cobblerArch());
-                xen.save();
                 tree.setCobblerXenId(xen.getId());
             }
             else {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCommand.java
@@ -17,12 +17,10 @@ package com.redhat.rhn.manager.kickstart.cobbler;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
 
 import org.cobbler.CobblerConnection;
 import org.cobbler.Distro;
 
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -66,17 +64,7 @@ public class CobblerDistroCommand extends CobblerCommand {
         Distro nonXen = Distro.lookupById(con, tree.getCobblerId());
         Distro xen = Distro.lookupById(con, tree.getCobblerXenId());
 
-        Map ksmeta = new HashMap();
-        KickstartUrlHelper helper = new KickstartUrlHelper(this.tree);
-        ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
-                helper.getKickstartMediaPath());
-        if (!tree.isRhnTree()) {
-            ksmeta.put("org", tree.getOrgId().toString());
-        }
-
-        if (tree.getInstallType().isSUSE()) {
-            ksmeta.put("autoyast", "true");
-        }
+        Map<String, String> ksmeta = createKsMetadataFromTree(this.tree);
 
         //if the newly edited tree does para virt....
         if (tree.doesParaVirt()) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
@@ -19,12 +19,10 @@ import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
 
 import org.apache.log4j.Logger;
 import org.cobbler.Distro;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,17 +73,7 @@ public class CobblerDistroCreateCommand extends CobblerDistroCommand {
     public ValidatorError store() {
         log.debug("Token : [" + xmlRpcToken + "]");
 
-        Map<String, String> ksmeta = new HashMap<String, String>();
-        KickstartUrlHelper helper = new KickstartUrlHelper(this.tree);
-        ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
-                helper.getKickstartMediaPath());
-        if (!tree.isRhnTree()) {
-            ksmeta.put("org", tree.getOrgId().toString());
-        }
-
-        if (tree.getInstallType().isSUSE()) {
-            ksmeta.put("autoyast", "true");
-        }
+        Map<String, String> ksmeta = createKsMetadataFromTree(this.tree);
 
         Distro distro =
                 Distro.create(CobblerXMLRPCHelper.getConnection(user),

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
@@ -21,10 +21,8 @@ import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
 
 import org.apache.log4j.Logger;
-import org.cobbler.Distro;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * KickstartCobblerCommand - class to contain logic to communicate with cobbler
@@ -73,28 +71,15 @@ public class CobblerDistroCreateCommand extends CobblerDistroCommand {
     public ValidatorError store() {
         log.debug("Token : [" + xmlRpcToken + "]");
 
-        Map<String, String> ksmeta = createKsMetadataFromTree(this.tree);
-
-        Distro distro =
-                Distro.create(CobblerXMLRPCHelper.getConnection(user),
-                        tree.getCobblerDistroName(), tree.getKernelPath(),
-                        tree.getInitrdPath(), ksmeta,
-                        tree.getInstallType().getCobblerBreed(),
-                        tree.getInstallType().getCobblerOsVersion(),
-                        tree.getChannel().getChannelArch().cobblerArch());
-        // Setup the kickstart metadata so the URLs and activation key are setup
-        tree.setCobblerId(distro.getUid());
+        CobblerDistroHelper.getInstance().createDistroFromTree(
+                CobblerXMLRPCHelper.getConnection(user),
+                tree);
         invokeCobblerUpdate();
 
         if (tree.doesParaVirt()) {
-            Distro distroXen =
-                    Distro.create(CobblerXMLRPCHelper.getConnection(user),
-                            tree.getCobblerXenDistroName(),
-                            tree.getKernelXenPath(), tree.getInitrdXenPath(),
-                            ksmeta, tree.getInstallType().getCobblerBreed(),
-                            tree.getInstallType().getCobblerOsVersion(),
-                            tree.getChannel().getChannelArch().cobblerArch());
-            tree.setCobblerXenId(distroXen.getUid());
+            CobblerDistroHelper.getInstance().createXenDistroFromTree(
+                    CobblerXMLRPCHelper.getConnection(user),
+                    tree);
         }
 
         if (syncProfiles) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroEditCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroEditCommand.java
@@ -20,8 +20,6 @@ import com.redhat.rhn.domain.user.User;
 import org.cobbler.CobblerConnection;
 import org.cobbler.Distro;
 
-import java.util.Map;
-
 /**
  * KickstartCobblerCommand - class to contain logic to communicate with cobbler
  * @version $Rev$
@@ -55,27 +53,14 @@ public class CobblerDistroEditCommand extends CobblerDistroCommand {
         Distro nonXen = Distro.lookupById(con, tree.getCobblerId());
         Distro xen = Distro.lookupById(con, tree.getCobblerXenId());
 
-        Map<String, String> ksmeta = createKsMetadataFromTree(this.tree);
-
         //if the newly edited tree does para virt....
         if (tree.doesParaVirt()) {
             //IT does paravirt so we need to either update the xen distro or create one
             if (xen == null) {
-                xen = Distro.create(con, tree.getCobblerXenDistroName(), tree
-                        .getKernelXenPath(), tree.getInitrdXenPath(), ksmeta, tree
-                        .getInstallType().getCobblerBreed(), tree.getInstallType()
-                        .getCobblerOsVersion(), tree.getChannel().getChannelArch()
-                        .cobblerArch());
-                tree.setCobblerXenId(xen.getId());
+                CobblerDistroHelper.getInstance().createXenDistroFromTree(con, tree);
             }
             else {
-                xen.setKernel(tree.getKernelXenPath());
-                xen.setInitrd(tree.getInitrdXenPath());
-                xen.setBreed(tree.getInstallType().getCobblerBreed());
-                xen.setOsVersion(tree.getInstallType().getCobblerOsVersion());
-                xen.setKsMeta(ksmeta);
-                xen.setArch(tree.getChannel().getChannelArch().cobblerArch());
-                xen.save();
+                CobblerDistroHelper.getInstance().updateXenDistroFromTree(xen, tree);
             }
         }
         else {
@@ -87,14 +72,9 @@ public class CobblerDistroEditCommand extends CobblerDistroCommand {
         }
 
         if (nonXen != null) {
-            nonXen.setInitrd(tree.getInitrdPath());
-            nonXen.setKernel(tree.getKernelPath());
-            nonXen.setBreed(tree.getInstallType().getCobblerBreed());
-            nonXen.setOsVersion(tree.getInstallType().getCobblerOsVersion());
-            nonXen.setKsMeta(ksmeta);
-            nonXen.setArch(tree.getChannel().getChannelArch().cobblerArch());
-            nonXen.save();
+            CobblerDistroHelper.getInstance().updateDistroFromTree(nonXen, tree);
         }
+
         return null;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroEditCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroEditCommand.java
@@ -17,6 +17,10 @@ package com.redhat.rhn.manager.kickstart.cobbler;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
 import com.redhat.rhn.domain.user.User;
+import org.cobbler.CobblerConnection;
+import org.cobbler.Distro;
+
+import java.util.Map;
 
 /**
  * KickstartCobblerCommand - class to contain logic to communicate with cobbler
@@ -47,7 +51,50 @@ public class CobblerDistroEditCommand extends CobblerDistroCommand {
      */
     @Override
     public ValidatorError store() {
-        updateCobblerFields();
+        CobblerConnection con = getCobblerConnection();
+        Distro nonXen = Distro.lookupById(con, tree.getCobblerId());
+        Distro xen = Distro.lookupById(con, tree.getCobblerXenId());
+
+        Map<String, String> ksmeta = createKsMetadataFromTree(this.tree);
+
+        //if the newly edited tree does para virt....
+        if (tree.doesParaVirt()) {
+            //IT does paravirt so we need to either update the xen distro or create one
+            if (xen == null) {
+                xen = Distro.create(con, tree.getCobblerXenDistroName(), tree
+                        .getKernelXenPath(), tree.getInitrdXenPath(), ksmeta, tree
+                        .getInstallType().getCobblerBreed(), tree.getInstallType()
+                        .getCobblerOsVersion(), tree.getChannel().getChannelArch()
+                        .cobblerArch());
+                tree.setCobblerXenId(xen.getId());
+            }
+            else {
+                xen.setKernel(tree.getKernelXenPath());
+                xen.setInitrd(tree.getInitrdXenPath());
+                xen.setBreed(tree.getInstallType().getCobblerBreed());
+                xen.setOsVersion(tree.getInstallType().getCobblerOsVersion());
+                xen.setKsMeta(ksmeta);
+                xen.setArch(tree.getChannel().getChannelArch().cobblerArch());
+                xen.save();
+            }
+        }
+        else {
+            //it doesn't do paravirt, so we need to delete the xen distro
+            if (xen != null) {
+                xen.remove();
+                tree.setCobblerXenId(null);
+            }
+        }
+
+        if (nonXen != null) {
+            nonXen.setInitrd(tree.getInitrdPath());
+            nonXen.setKernel(tree.getKernelPath());
+            nonXen.setBreed(tree.getInstallType().getCobblerBreed());
+            nonXen.setOsVersion(tree.getInstallType().getCobblerOsVersion());
+            nonXen.setKsMeta(ksmeta);
+            nonXen.setArch(tree.getChannel().getChannelArch().cobblerArch());
+            nonXen.save();
+        }
         return null;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
@@ -115,7 +115,7 @@ public class CobblerDistroHelper {
         distro.setKsMeta(ksmeta);
         distro.setArch(tree.getChannel().getChannelArch().cobblerArch());
         distro.setKernelOptions(tree.getKernelOptions());
-        distro.setKernelPostOptions(tree.getKernelOptionsPost());
+        distro.setKernelOptionsPost(tree.getKernelOptionsPost());
         distro.save();
     }
 
@@ -135,7 +135,7 @@ public class CobblerDistroHelper {
         distro.setKsMeta(ksmeta);
         distro.setArch(tree.getChannel().getChannelArch().cobblerArch());
         distro.setKernelOptions(tree.getKernelOptions());
-        distro.setKernelPostOptions(tree.getKernelOptionsPost());
+        distro.setKernelOptionsPost(tree.getKernelOptionsPost());
         distro.save();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
@@ -55,12 +55,18 @@ public class CobblerDistroHelper {
                                        KickstartableTree tree) {
         Map<String, String> ksmeta = createKsMetadataFromTree(tree);
 
-        Distro distro = Distro.create(cobblerConnection,
-                tree.getCobblerDistroName(), tree.getKernelPath(),
-                tree.getInitrdPath(), ksmeta,
-                tree.getInstallType().getCobblerBreed(),
-                tree.getInstallType().getCobblerOsVersion(),
-                tree.getChannel().getChannelArch().cobblerArch());
+        Distro distro = new Distro.Builder()
+                .setName(tree.getCobblerDistroName())
+                .setKernel(tree.getKernelPath())
+                .setInitrd(tree.getInitrdPath())
+                .setKsmeta(ksmeta)
+                .setBreed(tree.getInstallType().getCobblerBreed())
+                .setOsVersion(tree.getInstallType().getCobblerOsVersion())
+                .setArch(tree.getChannel().getChannelArch().cobblerArch())
+                .setKernelOptions(tree.getKernelOptions())
+                .setKernelOptionsPost(tree.getKernelOptionsPost())
+                .build(cobblerConnection);
+
         tree.setCobblerId(distro.getUid());
         return distro;
     }
@@ -76,12 +82,19 @@ public class CobblerDistroHelper {
     public Distro createXenDistroFromTree(CobblerConnection cobblerConnection,
                                           KickstartableTree tree) {
         Map<String, String> ksmeta = createKsMetadataFromTree(tree);
-        Distro xen = Distro.create(cobblerConnection, tree.getCobblerXenDistroName(),
-                tree.getKernelXenPath(),
-                tree.getInitrdXenPath(), ksmeta,
-                tree.getInstallType().getCobblerBreed(),
-                tree.getInstallType().getCobblerOsVersion(),
-                tree.getChannel().getChannelArch().cobblerArch());
+
+        Distro xen = new Distro.Builder()
+                .setName(tree.getCobblerXenDistroName())
+                .setKernel(tree.getKernelXenPath())
+                .setInitrd(tree.getInitrdXenPath())
+                .setKsmeta(ksmeta)
+                .setBreed(tree.getInstallType().getCobblerBreed())
+                .setOsVersion(tree.getInstallType().getCobblerOsVersion())
+                .setArch(tree.getChannel().getChannelArch().cobblerArch())
+                .setKernelOptions(tree.getKernelOptions())
+                .setKernelOptionsPost(tree.getKernelOptionsPost())
+                .build(cobblerConnection);
+
         tree.setCobblerXenId(xen.getId());
         return xen;
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2015 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.kickstart.cobbler;
+
+import com.redhat.rhn.domain.kickstart.KickstartableTree;
+import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
+import org.cobbler.CobblerConnection;
+import org.cobbler.Distro;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Singleton helper with methods for creating/updating cobbler
+ * Distro from KickstartableTree.
+ */
+public class CobblerDistroHelper {
+
+    private static CobblerDistroHelper instance;
+
+    private CobblerDistroHelper() { }
+
+    /**
+     * Returns an instance of this this class (singleton).
+     * @return instance of this this class (singleton).
+     */
+    public static synchronized CobblerDistroHelper getInstance() {
+        if (instance == null) {
+            instance = new CobblerDistroHelper();
+        }
+        return instance;
+    }
+
+    /**
+     * Create a new (non-XEN) cobbler Distro from the given tree.
+     * Update this tree with the ID of the new Distro.
+     *
+     * @param cobblerConnection connection to use to communicate with Cobbler
+     * @param tree tree containing information for creating the new Distro
+     * @return newly created Distro instance
+     */
+    public Distro createDistroFromTree(CobblerConnection cobblerConnection,
+                                       KickstartableTree tree) {
+        Map<String, String> ksmeta = createKsMetadataFromTree(tree);
+
+        Distro distro = Distro.create(cobblerConnection,
+                tree.getCobblerDistroName(), tree.getKernelPath(),
+                tree.getInitrdPath(), ksmeta,
+                tree.getInstallType().getCobblerBreed(),
+                tree.getInstallType().getCobblerOsVersion(),
+                tree.getChannel().getChannelArch().cobblerArch());
+        tree.setCobblerId(distro.getUid());
+        return distro;
+    }
+
+    /**
+     * Create a new XEN cobbler Distro from the given tree.
+     * Update this tree with the ID of the new Distro.
+     *
+     * @param cobblerConnection connection to use to communicate with Cobbler
+     * @param tree tree containing information for creating the new Distro
+     * @return newly created Distro instance
+     */
+    public Distro createXenDistroFromTree(CobblerConnection cobblerConnection,
+                                          KickstartableTree tree) {
+        Map<String, String> ksmeta = createKsMetadataFromTree(tree);
+        Distro xen = Distro.create(cobblerConnection, tree.getCobblerXenDistroName(),
+                tree.getKernelXenPath(),
+                tree.getInitrdXenPath(), ksmeta,
+                tree.getInstallType().getCobblerBreed(),
+                tree.getInstallType().getCobblerOsVersion(),
+                tree.getChannel().getChannelArch().cobblerArch());
+        tree.setCobblerXenId(xen.getId());
+        return xen;
+    }
+
+    /**
+     * Update the existing (non-XEN) cobbler Distro using data from the given tree.
+     *
+     * @param distro Distro instance to be updated
+     * @param tree tree containing information for updating the new Distro
+     */
+     public void updateDistroFromTree(Distro distro, KickstartableTree tree) {
+        Map<String, String> ksmeta = createKsMetadataFromTree(tree);
+
+        distro.setInitrd(tree.getInitrdPath());
+        distro.setKernel(tree.getKernelPath());
+        distro.setBreed(tree.getInstallType().getCobblerBreed());
+        distro.setOsVersion(tree.getInstallType().getCobblerOsVersion());
+        distro.setKsMeta(ksmeta);
+        distro.setArch(tree.getChannel().getChannelArch().cobblerArch());
+        distro.save();
+    }
+
+    /**
+     * Update the existing XEN cobbler Distro using data from the given tree.
+     *
+     * @param distro Distro instance to be updated
+     * @param tree tree containing information for updating the new Distro
+     */
+    public void updateXenDistroFromTree(Distro distro, KickstartableTree tree) {
+        Map<String, String> ksmeta = createKsMetadataFromTree(tree);
+
+        distro.setKernel(tree.getKernelXenPath());
+        distro.setInitrd(tree.getInitrdXenPath());
+        distro.setBreed(tree.getInstallType().getCobblerBreed());
+        distro.setOsVersion(tree.getInstallType().getCobblerOsVersion());
+        distro.setKsMeta(ksmeta);
+        distro.setArch(tree.getChannel().getChannelArch().cobblerArch());
+        distro.save();
+    }
+
+    private Map<String, String> createKsMetadataFromTree(KickstartableTree tree) {
+        Map<String, String> ksmeta = new HashMap<String, String>();
+
+        KickstartUrlHelper helper = new KickstartUrlHelper(tree);
+        ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
+                helper.getKickstartMediaPath());
+
+        if (!tree.isRhnTree()) {
+            ksmeta.put("org", tree.getOrgId().toString());
+        }
+
+        if (tree.getInstallType().isSUSE()) {
+            ksmeta.put("autoyast", "true");
+        }
+
+        return ksmeta;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
@@ -101,6 +101,8 @@ public class CobblerDistroHelper {
         distro.setOsVersion(tree.getInstallType().getCobblerOsVersion());
         distro.setKsMeta(ksmeta);
         distro.setArch(tree.getChannel().getChannelArch().cobblerArch());
+        distro.setKernelOptions(tree.getKernelOptions());
+        distro.setKernelPostOptions(tree.getKernelOptionsPost());
         distro.save();
     }
 
@@ -119,6 +121,8 @@ public class CobblerDistroHelper {
         distro.setOsVersion(tree.getInstallType().getCobblerOsVersion());
         distro.setKsMeta(ksmeta);
         distro.setArch(tree.getChannel().getChannelArch().cobblerArch());
+        distro.setKernelOptions(tree.getKernelOptions());
+        distro.setKernelPostOptions(tree.getKernelOptionsPost());
         distro.save();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
@@ -202,7 +202,13 @@ public class CobblerDistroSyncCommand extends CobblerCommand {
         KickstartUrlHelper helper = new KickstartUrlHelper(tree);
         ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
                 helper.getKickstartMediaPath());
+        if (!tree.isRhnTree()) {
+            ksmeta.put("org", tree.getOrgId().toString());
+        }
 
+        if (tree.getInstallType().isSUSE()) {
+            ksmeta.put("autoyast", "true");
+        }
 
 
         if (!xen) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
@@ -20,7 +20,6 @@ import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
-import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
 
 import org.apache.log4j.Logger;
 import org.cobbler.Distro;
@@ -198,18 +197,8 @@ public class CobblerDistroSyncCommand extends CobblerCommand {
     private String createDistro(KickstartableTree tree, boolean xen) {
         String treeLabel = tree.getLabel();
         log.debug("Trying to create: " + treeLabel + " in cobbler over xmlrpc");
-        Map ksmeta = new HashMap();
-        KickstartUrlHelper helper = new KickstartUrlHelper(tree);
-        ksmeta.put(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE,
-                helper.getKickstartMediaPath());
-        if (!tree.isRhnTree()) {
-            ksmeta.put("org", tree.getOrgId().toString());
-        }
 
-        if (tree.getInstallType().isSUSE()) {
-            ksmeta.put("autoyast", "true");
-        }
-
+        Map ksmeta = createKsMetadataFromTree(tree);
 
         if (!xen) {
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
@@ -198,8 +198,6 @@ public class CobblerDistroSyncCommand extends CobblerCommand {
         String treeLabel = tree.getLabel();
         log.debug("Trying to create: " + treeLabel + " in cobbler over xmlrpc");
 
-        Map ksmeta = createKsMetadataFromTree(tree);
-
         if (!xen) {
 
             log.debug("tree missing in cobbler. " +
@@ -227,12 +225,9 @@ public class CobblerDistroSyncCommand extends CobblerCommand {
                         "] unusable.";
             }
 
-            Distro distro = Distro.create(CobblerXMLRPCHelper.getAutomatedConnection(),
-                    tree.getCobblerDistroName(), tree.getKernelPath(),
-                    tree.getInitrdPath(), ksmeta, tree.getInstallType().getCobblerBreed(),
-                    tree.getInstallType().getCobblerOsVersion(),
-                    tree.getChannel().getChannelArch().cobblerArch());
-            tree.setCobblerId(distro.getUid());
+            CobblerDistroHelper.getInstance().createDistroFromTree(
+                    CobblerXMLRPCHelper.getAutomatedConnection(),
+                    tree);
             invokeCobblerUpdate();
         }
         else if (tree.doesParaVirt() && xen) {
@@ -246,13 +241,9 @@ public class CobblerDistroSyncCommand extends CobblerCommand {
                 return error;
             }
 
-            Distro distroXen = Distro.create(CobblerXMLRPCHelper.getAutomatedConnection(),
-                    tree.getCobblerXenDistroName(), tree.getKernelXenPath(),
-                    tree.getInitrdXenPath(), ksmeta,
-                    tree.getInstallType().getCobblerBreed(),
-                    tree.getInstallType().getCobblerOsVersion(),
-                    tree.getChannel().getChannelArch().cobblerArch());
-            tree.setCobblerXenId(distroXen.getUid());
+            CobblerDistroHelper.getInstance().createXenDistroFromTree(
+                    CobblerXMLRPCHelper.getAutomatedConnection(),
+                    tree);
         }
         tree.setModified(new Date());
         return null;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
@@ -76,7 +76,7 @@ public abstract class CobblerProfileCommand extends CobblerCommand {
             profile.setKernelOptions(kernelOptions);
         }
         if (postKernelOptions != null) {
-            profile.setKernelPostOptions(postKernelOptions);
+            profile.setKernelOptionsPost(postKernelOptions);
         }
         // redhat_management_key
         KickstartSession ksession =

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -338,7 +338,7 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
             rec.setHostName(getServer().getName());
         }
         rec.setKernelOptions(kernelOptions);
-        rec.setKernelPostOptions(postKernelOptions);
+        rec.setKernelOptionsPost(postKernelOptions);
         try {
             rec.save();
         }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTest.java
@@ -14,21 +14,15 @@
  */
 package com.redhat.rhn.manager.kickstart.cobbler.test;
 
-import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.KickstartableTree;
-import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
-import com.redhat.rhn.domain.kickstart.test.KickstartableTreeTest;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.NetworkInterface;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.NetworkInterfaceTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
-import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
-import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroCreateCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroDeleteCommand;
-import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroEditCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroSyncCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerLoginCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerProfileCreateCommand;
@@ -36,42 +30,15 @@ import com.redhat.rhn.manager.kickstart.cobbler.CobblerProfileDeleteCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerProfileEditCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemCreateCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
-import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
-import com.redhat.rhn.testing.UserTestUtils;
 import org.cobbler.CobblerConnection;
 import org.cobbler.Distro;
-
-import java.io.File;
 
 /**
  * CobblerCommandTest
  */
-public class CobblerCommandTest extends BaseTestCaseWithUser {
-    protected KickstartData ksdata;
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-
-        user = UserTestUtils.createUserInOrgOne();
-        user.addPermanentRole(RoleFactory.ORG_ADMIN);
-        this.ksdata = KickstartDataTest.createKickstartWithDefaultKey(this.user.getOrg());
-        this.ksdata.getTree().setBasePath("/tmp/opt/repo/f9-x86_64/");
-
-        // Uncomment this if you want the tests to actually talk to cobbler
-        //Config.get().setString(CobblerXMLRPCHelper.class.getName(),
-        //        CobblerXMLRPCHelper.class.getName());
-        //Config.get().setString(CobblerConnection.class.getName(),
-        //        CobblerConnection.class.getName());
-        //commitAndCloseSession();
-
-        KickstartableTreeTest.createKickstartTreeItems(this.ksdata.getTree());
-        CobblerDistroCreateCommand dcreate = new
-            CobblerDistroCreateCommand(ksdata.getTree(), user);
-        dcreate.store();
-    }
+public class CobblerCommandTest extends CobblerCommandTestBase {
 
     /*public void testDupSystems() throws Exception {
         Server s = ServerFactory.lookupById(new Long(1000010339));
@@ -131,51 +98,6 @@ public class CobblerCommandTest extends BaseTestCaseWithUser {
         assertNull(ksdata.getCobblerObject(user));
     }
 
-    public void testDistroCreate() throws Exception {
-        CobblerDistroCreateCommand cmd = new
-            CobblerDistroCreateCommand(ksdata.getTree(), user);
-        assertNull(cmd.store());
-        assertNotNull(ksdata.getTree().getCobblerObject(user));
-        assertNotNull(ksdata.getTree().getCobblerObject(user).
-                getKsMeta().get(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE));
-    }
-
-    /**
-     * Tests whether the xen distro is created for a tree with paravirtualization.
-     */
-    public void testDistroCreateXenCreated() throws Exception {
-        KickstartableTree tree = ksdata.getTree();
-        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-
-        Distro distro = Distro.lookupById(con, tree.getCobblerXenId());
-        distro.remove();
-        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
-
-        CobblerDistroCreateCommand cmd = new
-            CobblerDistroCreateCommand(tree, user);
-        cmd.store();
-        assertNotNull(Distro.lookupById(con, tree.getCobblerXenId()));
-    }
-
-    /**
-     * Tests that the xen distro is NOT created for a tree without paravirtualization.
-     */
-    public void testDistroCreateXenNotCreated() throws Exception {
-        KickstartableTree tree = ksdata.getTree();
-        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-
-        Distro.lookupById(con, tree.getCobblerXenId()).remove();
-        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
-
-        File xenPath = new File(tree.getKernelXenPath());
-        xenPath.delete();
-
-        CobblerDistroCreateCommand cmd = new
-            CobblerDistroCreateCommand(tree, user);
-        cmd.store();
-        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
-    }
-
     /**
      * Tests that CobblerDistroSyncCommand recreates missing cobbler entries.
      */
@@ -188,7 +110,8 @@ public class CobblerCommandTest extends BaseTestCaseWithUser {
         }
 
         // verify the distros corresponding to our tree aren't there
-        for (KickstartableTree kickstartableTree : KickstartFactory.lookupKickstartTrees()) {
+        for (KickstartableTree kickstartableTree :
+                KickstartFactory.lookupKickstartTrees()) {
             assertNull(Distro.lookupById(con, kickstartableTree.getCobblerId()));
             assertNull(Distro.lookupById(con, kickstartableTree.getCobblerXenId()));
         }
@@ -197,7 +120,8 @@ public class CobblerCommandTest extends BaseTestCaseWithUser {
         cmd.store();
 
         // verify they got resynced
-        for (KickstartableTree kickstartableTree : KickstartFactory.lookupKickstartTrees()) {
+        for (KickstartableTree kickstartableTree :
+                KickstartFactory.lookupKickstartTrees()) {
             assertNotNull(Distro.lookupById(con, kickstartableTree.getCobblerId()));
             assertNotNull(Distro.lookupById(con, kickstartableTree.getCobblerXenId()));
         }
@@ -207,78 +131,6 @@ public class CobblerCommandTest extends BaseTestCaseWithUser {
         CobblerDistroDeleteCommand cmd = new
             CobblerDistroDeleteCommand(ksdata.getTree(), user);
         assertNull(cmd.store());
-    }
-
-    public void testDistroEdit() throws Exception {
-        CobblerDistroEditCommand cmd = new
-            CobblerDistroEditCommand(ksdata.getTree(), user);
-        String newName = TestUtils.randomString();
-        ksdata.getKickstartDefaults().getKstree().setLabel(newName);
-        assertNull(cmd.store());
-        assertNotNull(ksdata.getTree().getCobblerObject(user));
-        assertNotNull(ksdata.getTree().getCobblerObject(user).getName());
-    }
-
-    /**
-     * Tests the recreation logic of the CobblerDistroEditCommand.
-     * If the tree does paravirtualization, but the cobbler xen distro is missing,
-     * CobblerDistroEditCommand recreates it.
-     */
-    public void testParaDistroRecreateXenDistroOnEdit() throws Exception {
-        KickstartableTree tree = ksdata.getTree();
-        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-
-        // remove the distro
-        Distro xen = Distro.lookupById(con, tree.getCobblerXenId());
-        xen.remove();
-
-        // verify it's null
-        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
-
-        // verify it's recreated
-        CobblerDistroEditCommand cmd = new
-                CobblerDistroEditCommand(tree, user);
-        assertNull(cmd.store());
-        assertNotNull(Distro.lookupById(con, tree.getCobblerXenId()));
-    }
-
-    /**
-     * Tests the removing logic of the CobblerDistroEditCommand.
-     * If the tree does NOT paravirtualization, but the cobbler distro exists,
-     * CobblerDistroEditCommand removes it.
-     */
-    public void testParaDistroXenDistroRemovedOnEdit() throws Exception {
-        KickstartableTree tree = ksdata.getTree();
-        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-
-        // verify it's there
-        assertNotNull(Distro.lookupById(con, tree.getCobblerXenId()));
-
-        // delete its file
-        File xenPath = new File(tree.getKernelXenPath());
-        xenPath.delete();
-
-        // verify it's removed
-        CobblerDistroEditCommand cmd = new
-                CobblerDistroEditCommand(tree, user);
-        assertNull(cmd.store());
-        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
-    }
-
-    /**
-     * Verify that the cobbler xen id stays same after
-     * CobblerDistroEditCommand.store when xen distro already exists.
-     */
-    public void testParaDistroEditIdStaysSameOnEdit() throws Exception {
-        KickstartableTree tree = ksdata.getTree();
-        String xenIdBefore = tree.getCobblerXenId();
-
-        CobblerDistroEditCommand cmd = new
-                CobblerDistroEditCommand(tree, user);
-        cmd.store();
-
-        String xenIdAfter = tree.getCobblerXenId();
-        assertEquals(xenIdBefore, xenIdAfter);
     }
 
     public void testLogin() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTestBase.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerCommandTestBase.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2009--2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.kickstart.cobbler.test;
+
+import com.redhat.rhn.domain.kickstart.KickstartData;
+import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
+import com.redhat.rhn.domain.kickstart.test.KickstartableTreeTest;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroCreateCommand;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.UserTestUtils;
+
+/**
+ * Base for Cobbler command tests.
+ * Contains pre-filled KickstartData instance to be used by tests.
+ */
+public class CobblerCommandTestBase extends BaseTestCaseWithUser {
+
+    protected KickstartData ksdata;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        user = UserTestUtils.createUserInOrgOne();
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        this.ksdata = KickstartDataTest.createKickstartWithDefaultKey(this.user.getOrg());
+        this.ksdata.getTree().setBasePath("/tmp/opt/repo/f9-x86_64/");
+
+        // Uncomment this if you want the tests to actually talk to cobbler
+        //Config.get().setString(CobblerXMLRPCHelper.class.getName(),
+        //        CobblerXMLRPCHelper.class.getName());
+        //Config.get().setString(CobblerConnection.class.getName(),
+        //        CobblerConnection.class.getName());
+        //commitAndCloseSession();
+
+        KickstartableTreeTest.createKickstartTreeItems(this.ksdata.getTree());
+        CobblerDistroCreateCommand dcreate = new
+            CobblerDistroCreateCommand(ksdata.getTree(), user);
+        dcreate.store();
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerDistroCreateCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerDistroCreateCommandTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2009--2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.kickstart.cobbler.test;
+
+import com.redhat.rhn.domain.kickstart.KickstartableTree;
+import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroCreateCommand;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
+import org.cobbler.CobblerConnection;
+import org.cobbler.Distro;
+
+import java.io.File;
+
+/**
+ * CobblerDistroCreateCommand Test.
+ */
+public class CobblerDistroCreateCommandTest extends CobblerCommandTestBase {
+
+    private KickstartableTree tree;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void setUp() throws Exception {
+        super.setUp();
+        tree = ksdata.getTree();
+    }
+
+    /**
+     * Tests whether cobbler Distro can be successfully created using given
+     * data. After creating the distro, tests whether this distro (and its
+     * metadata) can be retrieved using the tree.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testDistroCreate() throws Exception {
+        CobblerDistroCreateCommand cmd = new
+            CobblerDistroCreateCommand(tree, user);
+        assertNull(cmd.store());
+        assertNotNull(tree.getCobblerObject(user));
+        assertNotNull(tree.getCobblerObject(user).
+                getKsMeta().get(KickstartUrlHelper.COBBLER_MEDIA_VARIABLE));
+    }
+
+    /**
+     * Tests whether the xen distro is created for a tree with paravirtualization.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testDistroCreateXenCreated() throws Exception {
+        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
+
+        Distro distro = Distro.lookupById(con, tree.getCobblerXenId());
+        distro.remove();
+        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
+
+        CobblerDistroCreateCommand cmd = new
+            CobblerDistroCreateCommand(tree, user);
+        cmd.store();
+        assertNotNull(Distro.lookupById(con, tree.getCobblerXenId()));
+    }
+
+    /**
+     * Tests that the xen distro is NOT created for a tree without paravirtualization.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testDistroCreateXenNotCreated() throws Exception {
+        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
+
+        Distro.lookupById(con, tree.getCobblerXenId()).remove();
+        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
+
+        File xenPath = new File(tree.getKernelXenPath());
+        xenPath.delete();
+
+        CobblerDistroCreateCommand cmd = new
+            CobblerDistroCreateCommand(tree, user);
+        cmd.store();
+        assertNull(Distro.lookupById(con, tree.getCobblerXenId()));
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerDistroEditCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerDistroEditCommandTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2009--2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.kickstart.cobbler.test;
+
+import com.redhat.rhn.domain.kickstart.KickstartableTree;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerDistroEditCommand;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
+import com.redhat.rhn.testing.TestUtils;
+import org.cobbler.CobblerConnection;
+import org.cobbler.Distro;
+
+import java.io.File;
+
+/**
+ * CobblerDistroEditCommand Test.
+ */
+public class CobblerDistroEditCommandTest extends CobblerCommandTestBase {
+
+    private CobblerConnection connection;
+    private KickstartableTree sourceTree;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        connection = CobblerXMLRPCHelper.getAutomatedConnection();
+        sourceTree = ksdata.getTree();
+    }
+
+    /**
+     * Tests whether cobbler Distro can be successfully edited.
+     * After editing the distro, tests whether this distro (and its metadata)
+     * can be retrieved using the tree.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testDistroEdit() throws Exception {
+        CobblerDistroEditCommand cmd = new
+            CobblerDistroEditCommand(sourceTree, user);
+        String newName = TestUtils.randomString();
+        ksdata.getKickstartDefaults().getKstree().setLabel(newName);
+        assertNull(cmd.store());
+        assertNotNull(ksdata.getTree().getCobblerObject(user));
+        assertNotNull(ksdata.getTree().getCobblerObject(user).getName());
+    }
+
+    /**
+     * Tests the recreation logic of the CobblerDistroEditCommand.
+     * If the tree does paravirtualization, but the cobbler xen distro is missing,
+     * CobblerDistroEditCommand recreates it.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testParaDistroRecreateXenDistroOnEdit() throws Exception {
+        // remove the distro
+        Distro xen = Distro.lookupById(connection, sourceTree.getCobblerXenId());
+        xen.remove();
+
+        // verify it's null
+        assertNull(Distro.lookupById(connection, sourceTree.getCobblerXenId()));
+
+        // verify it's recreated
+        CobblerDistroEditCommand cmd = new
+                CobblerDistroEditCommand(sourceTree, user);
+        assertNull(cmd.store());
+        assertNotNull(Distro.lookupById(connection, sourceTree.getCobblerXenId()));
+    }
+
+    /**
+     * Tests the removing logic of the CobblerDistroEditCommand.
+     * If the tree does NOT paravirtualization, but the cobbler distro exists,
+     * CobblerDistroEditCommand removes it.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testParaDistroXenDistroRemovedOnEdit() throws Exception {
+        // verify it's there
+        assertNotNull(Distro.lookupById(connection, sourceTree.getCobblerXenId()));
+
+        // delete its file
+        File xenPath = new File(sourceTree.getKernelXenPath());
+        xenPath.delete();
+
+        // verify it's removed
+        CobblerDistroEditCommand cmd = new
+                CobblerDistroEditCommand(sourceTree, user);
+        assertNull(cmd.store());
+        assertNull(Distro.lookupById(connection, sourceTree.getCobblerXenId()));
+    }
+
+    /**
+     * Verify that the cobbler xen id stays same after
+     * CobblerDistroEditCommand.store when xen distro already exists.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testParaDistroEditIdStaysSameOnEdit() throws Exception {
+        String xenIdBefore = sourceTree.getCobblerXenId();
+
+        CobblerDistroEditCommand cmd = new
+                CobblerDistroEditCommand(sourceTree, user);
+        cmd.store();
+
+        String xenIdAfter = sourceTree.getCobblerXenId();
+        assertEquals(xenIdBefore, xenIdAfter);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/BaseTreeEditOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/BaseTreeEditOperation.java
@@ -97,11 +97,11 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
 
             Map kOpts = distro.getKernelOptions();
             distro.setKernelOptions(getKernelOptions());
-            distro.setKernelPostOptions(getPostKernelOptions());
+            distro.setKernelOptionsPost(getKernelOptionsPost());
             distro.save();
             if (xenDistro != null) {
                 xenDistro.setKernelOptions(getKernelOptions());
-                xenDistro.setKernelPostOptions(getPostKernelOptions());
+                xenDistro.setKernelOptionsPost(getKernelOptionsPost());
                 xenDistro.save();
             }
         }
@@ -234,18 +234,18 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
 
 
     /**
-     * @return Returns the postKernelOptions.
+     * @return Returns the kernelOptionsPost.
      */
-    public String getPostKernelOptions() {
+    public String getKernelOptionsPost() {
         return tree.getKernelOptionsPost();
     }
 
 
     /**
-     * @param postKernelOptionsIn The postKernelOptions to set.
+     * @param kernelOptionsPostIn The kernelOptionsPost to set.
      */
-    public void setPostKernelOptions(String postKernelOptionsIn) {
-        tree.setKernelOptionsPost(postKernelOptionsIn);
+    public void setKernelOptionsPost(String kernelOptionsPostIn) {
+        tree.setKernelOptionsPost(kernelOptionsPostIn);
     }
 
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/BaseTreeEditOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/BaseTreeEditOperation.java
@@ -48,8 +48,6 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
     protected KickstartableTree tree;
     private static final String EMPTY_STRING = "";
     public static final String KICKSTART_CAPABILITY = "rhn.kickstart.boot_image";
-    private String postKernelOptions = "";
-    private String kernelOptions = "";
 
     /**
      * Constructor
@@ -239,7 +237,7 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
      * @return Returns the postKernelOptions.
      */
     public String getPostKernelOptions() {
-        return postKernelOptions;
+        return tree.getKernelOptionsPost();
     }
 
 
@@ -247,7 +245,7 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
      * @param postKernelOptionsIn The postKernelOptions to set.
      */
     public void setPostKernelOptions(String postKernelOptionsIn) {
-        postKernelOptions = postKernelOptionsIn;
+        tree.setKernelOptionsPost(postKernelOptionsIn);
     }
 
 
@@ -255,7 +253,7 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
      * @return Returns the kernelOptions.
      */
     public String getKernelOptions() {
-        return kernelOptions;
+        return tree.getKernelOptions();
     }
 
 
@@ -263,6 +261,6 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
      * @param kernelOptionsIn The kernelOptions to set.
      */
     public void setKernelOptions(String kernelOptionsIn) {
-        kernelOptions = kernelOptionsIn;
+        tree.setKernelOptions(kernelOptionsIn);
     }
 }

--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -334,8 +334,8 @@ public abstract class CobblerObject {
      * gets the kernel post options in string form
      * @return the string
      */
-    public String getKernelPostOptionsString() {
-        return convertOptionsMap(getKernelPostOptions());
+    public String getKernelOptionsPostString() {
+        return convertOptionsMap(getKernelOptionsPost());
     }
 
     private String convertOptionsMap(Map<String, Object> map) {
@@ -380,8 +380,8 @@ public abstract class CobblerObject {
     /**
      * @param kernelOptsIn the kernelOptions to set
      */
-    public void setKernelPostOptions(String kernelOptsIn) {
-        setKernelPostOptions(parseKernelOpts(kernelOptsIn));
+    public void setKernelOptionsPost(String kernelOptsIn) {
+        setKernelOptionsPost(parseKernelOpts(kernelOptsIn));
     }
 
     private Map<String, Object> parseKernelOpts(String kernelOpts) {
@@ -447,18 +447,18 @@ public abstract class CobblerObject {
 
 
     /**
-     * @return the kernelPostOptions
+     * @return the kernelOptionsPost
      */
-    public Map<String, Object> getKernelPostOptions() {
+    public Map<String, Object> getKernelOptionsPost() {
         return (Map<String, Object>)dataMap.get(KERNEL_OPTIONS_POST);
     }
 
 
     /**
-     * @param kernelPostOptionsIn the kernelPostOptions to set
+     * @param kernelOptionsPostIn the kernelOptionsPost to set
      */
-    public void setKernelPostOptions(Map<String, Object> kernelPostOptionsIn) {
-        modify(SET_KERNEL_OPTIONS_POST, kernelPostOptionsIn);
+    public void setKernelOptionsPost(Map<String, Object> kernelOptionsPostIn) {
+        modify(SET_KERNEL_OPTIONS_POST, kernelOptionsPostIn);
     }
 
     protected void update() {

--- a/java/code/src/org/cobbler/Distro.java
+++ b/java/code/src/org/cobbler/Distro.java
@@ -37,41 +37,6 @@ public class Distro extends CobblerObject {
     }
 
     /**
-     * Create a new distro in cobbler
-     * @param client the xmlrpc client
-     * @param name the name of the distro
-     * @param kernel the kernel path of the distro
-     * @param initrd the initrd path of the distro
-     * @param ksmeta inital ksmeta to set
-     * @param breed initial breed to set
-     * @param osVersion initial os_version to set
-     * @param arch initial cobbler arch to set
-     * @return a new Distro
-     */
-    public static Distro create(CobblerConnection client, String name, String kernel,
-            String initrd, Map ksmeta, String breed, String osVersion, String arch) {
-        Distro distro = new Distro(client);
-        distro.handle = (String) client.invokeTokenMethod("new_distro");
-        distro.modify(NAME, name);
-        distro.setKernel(kernel);
-        distro.setInitrd(initrd);
-        if (ksmeta.containsKey("autoyast")) {
-            distro.setBreed("suse");
-        }
-        else if (breed != null) {
-            distro.setBreed(breed);
-        }
-        if (osVersion != null) {
-            distro.setOsVersion(osVersion);
-        }
-        distro.setKsMeta(ksmeta);
-        distro.setArch(arch);
-        distro.save();
-        distro = lookupByName(client, name);
-        return distro;
-    }
-
-    /**
      * Returns a distro matching the given name or null
      * @param client the xmlrpc client
      * @param name the distro name
@@ -268,5 +233,142 @@ public class Distro extends CobblerObject {
      */
     public void setBreed(String breedIn) {
         modify(BREED, breedIn);
+    }
+
+    /**
+     * Builder to create a Distro
+     */
+    public static class Builder {
+
+        private String name;
+        private String kernel;
+        private String initrd;
+        private Map<String, ? extends Object> ksmeta;
+        private String breed;
+        private String osVersion;
+        private String arch;
+        private String kernelOptions;
+        private String kernelOptionsPost;
+
+
+        /**
+         * Set architecture
+         * @param archIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setArch(String archIn) {
+            arch = archIn;
+            return this;
+        }
+
+        /**
+         * Set breed
+         * @param breedIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setBreed(String breedIn) {
+            breed = breedIn;
+            return this;
+        }
+
+        /**
+         * Set initrd path
+         * @param initrdIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setInitrd(String initrdIn) {
+            initrd = initrdIn;
+            return this;
+        }
+
+        /**
+         * Set kernel path
+         * @param kernelIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setKernel(String kernelIn) {
+            kernel = kernelIn;
+            return this;
+        }
+
+        /**
+         * Set kernel options
+         * @param kernelOptionsIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setKernelOptions(String kernelOptionsIn) {
+            kernelOptions = kernelOptionsIn;
+            return this;
+        }
+
+        /**
+         * Set kernel options (post install)
+         * @param kernelOptionsPostIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setKernelOptionsPost(String kernelOptionsPostIn) {
+            kernelOptionsPost = kernelOptionsPostIn;
+            return this;
+        }
+
+        /**
+         * Set kickstart metadata
+         * @param ksmetaIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setKsmeta(Map<String, ? extends Object> ksmetaIn) {
+            ksmeta = ksmetaIn;
+            return this;
+        }
+
+        /**
+         * Set distro name
+         * @param nameIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setName(String nameIn) {
+            name = nameIn;
+            return this;
+        }
+
+        /**
+         * Set OS version
+         * @param osVersionIn value to set
+         * @return this builder to chain operations
+         */
+        public Builder setOsVersion(String osVersionIn) {
+            osVersion = osVersionIn;
+            return this;
+        }
+
+        /**
+         * Create the distro with the current builder settings
+         * @param connection Connection to use for Distro creation
+         * @return this builder to chain operations
+         */
+        public Distro build(CobblerConnection connection) {
+            Distro distro = new Distro(connection);
+            distro.handle = (String) connection.invokeTokenMethod("new_distro");
+            distro.modify(NAME, name);
+            distro.setKernel(kernel);
+            distro.setInitrd(initrd);
+            if (ksmeta.containsKey("autoyast")) {
+                distro.setBreed("suse");
+            }
+            else if (breed != null) {
+                distro.setBreed(breed);
+            }
+            if (osVersion != null) {
+                distro.setOsVersion(osVersion);
+            }
+            distro.setKsMeta(ksmeta);
+            distro.setArch(arch);
+            distro.setKernelOptions(kernelOptions);
+            distro.setKernelPostOptions(kernelOptionsPost);
+            distro.save();
+            distro = lookupByName(connection, name);
+            return distro;
+        }
+
     }
 }

--- a/java/code/src/org/cobbler/Distro.java
+++ b/java/code/src/org/cobbler/Distro.java
@@ -364,7 +364,7 @@ public class Distro extends CobblerObject {
             distro.setKsMeta(ksmeta);
             distro.setArch(arch);
             distro.setKernelOptions(kernelOptions);
-            distro.setKernelPostOptions(kernelOptionsPost);
+            distro.setKernelOptionsPost(kernelOptionsPost);
             distro.save();
             distro = lookupByName(connection, name);
             return distro;

--- a/java/code/src/org/cobbler/test/DistroTest.java
+++ b/java/code/src/org/cobbler/test/DistroTest.java
@@ -51,7 +51,7 @@ public class DistroTest extends TestCase {
                 .setName(name)
                 .setKernel(kernel)
                 .setInitrd(initrd)
-                .setKsmeta(new HashMap<>())
+                .setKsmeta(new HashMap<String, Object>())
                 .setBreed(breed)
                 .setOsVersion(osVersion)
                 .setArch(arch)

--- a/java/code/src/org/cobbler/test/DistroTest.java
+++ b/java/code/src/org/cobbler/test/DistroTest.java
@@ -47,8 +47,15 @@ public class DistroTest extends TestCase {
         String breed = "redhat";
         String osVersion = "rhel4";
         String arch = "i386";
-        Distro newDistro = Distro.create(client, name, kernel, initrd, new HashMap(),
-                breed, osVersion, arch);
+        Distro newDistro = new Distro.Builder()
+                .setName(name)
+                .setKernel(kernel)
+                .setInitrd(initrd)
+                .setKsmeta(new HashMap<>())
+                .setBreed(breed)
+                .setOsVersion(osVersion)
+                .setArch(arch)
+                .build(client);
         assertEquals(name, newDistro.getName());
         assertEquals(kernel, newDistro.getKernel());
         assertEquals(initrd, newDistro.getInitrd());

--- a/java/code/src/org/cobbler/test/SystemRecordTest.java
+++ b/java/code/src/org/cobbler/test/SystemRecordTest.java
@@ -48,8 +48,15 @@ public class SystemRecordTest extends BaseTestCaseWithUser {
     public void setUp() throws Exception {
         super.setUp();
         connection = CobblerXMLRPCHelper.getConnection(user.getLogin());
-        Distro distro = Distro.create(connection, "test-distro", "kernel", "initrd",
-                new HashMap(), "redhat", "rhel6", "x86_64");
+        Distro distro = new Distro.Builder()
+                .setName("test-distro")
+                .setKernel("kernel")
+                .setInitrd("initrd")
+                .setKsmeta(new HashMap<>())
+                .setBreed("redhat")
+                .setOsVersion("rhel6")
+                .setArch("x86_64")
+                .build(connection);
         Profile profile = Profile.create(connection, "test-profile", distro);
         system = SystemRecord.create(connection, "test-system", profile);
     }

--- a/java/code/src/org/cobbler/test/SystemRecordTest.java
+++ b/java/code/src/org/cobbler/test/SystemRecordTest.java
@@ -52,7 +52,7 @@ public class SystemRecordTest extends BaseTestCaseWithUser {
                 .setName("test-distro")
                 .setKernel("kernel")
                 .setInitrd("initrd")
-                .setKsmeta(new HashMap<>())
+                .setKsmeta(new HashMap<String, Object>())
                 .setBreed("redhat")
                 .setOsVersion("rhel6")
                 .setArch("x86_64")

--- a/schema/spacewalk/common/tables/rhnKickstartableTree.sql
+++ b/schema/spacewalk/common/tables/rhnKickstartableTree.sql
@@ -37,6 +37,8 @@ CREATE TABLE rhnKickstartableTree
     install_type    NUMBER NOT NULL
                         CONSTRAINT rhn_kstree_it_fk
                             REFERENCES rhnKSInstallType (id),
+    kernel_options       VARCHAR2(256),
+    kernel_options_post  VARCHAR2(256),
     last_modified   timestamp with local time zone
                         DEFAULT (current_timestamp) NOT NULL,
     created         timestamp with local time zone

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.3-to-spacewalk-schema-2.4/012-rhnKickstartableTree-kernelOptions.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.3-to-spacewalk-schema-2.4/012-rhnKickstartableTree-kernelOptions.sql
@@ -1,0 +1,3 @@
+ALTER TABLE rhnKickstartableTree
+    ADD COLUMN kernel_options       VARCHAR2(256),
+    ADD COLUMN kernel_options_post  VARCHAR2(256);


### PR DESCRIPTION
## Overview of the PR:
### 1st part (hustodemon)
- Unification of kickstart metadata handling accross scenarios (previously some parts of metadata were missing in some scenarios)
- Code de-duplication by pulling common code to a helper class
- Refactored tests, added more tests
### 2nd part (lucidd)
- Making Cobbler distro's "kernel options" and "kernel options post" part of the `KickstartableTree` and make this persistent (previously they were only stored in cobbler and couldn't be recreated by spacewalk when the cobbler entry was deleted)
- Refactoring
