### PR TITLE
Use reposync logs to show status of last reposync in WebUI

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.channel.manage;
 
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.common.util.RecurringEventPicker;
 import com.redhat.rhn.domain.channel.Channel;
@@ -28,6 +29,7 @@ import com.redhat.rhn.frontend.taglibs.list.helper.ListHelper;
 import com.redhat.rhn.frontend.taglibs.list.helper.Listable;
 import com.redhat.rhn.manager.satellite.SystemCommandExecutor;
 import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.download.DownloadManager;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
@@ -79,6 +81,21 @@ public class SyncRepositoriesAction extends RhnAction implements Listable {
         }
 
         request.setAttribute("status", parseSyncLog(chan, inProgress));
+
+        if (!chan.getSources().isEmpty()) {
+            String lastSync = LocalizationService.getInstance().getMessage(
+                    "channel.edit.repo.neversynced");
+            if (chan.getLastSynced() != null) {
+                lastSync = LocalizationService.getInstance().formatCustomDate(
+                        chan.getLastSynced());
+            }
+            request.setAttribute("last_sync", lastSync);
+            if (!ChannelManager.getLatestSyncLogFiles(chan).isEmpty()) {
+                request.setAttribute("log_url",
+                        DownloadManager.getChannelSyncLogDownloadPath(chan,
+                                context.getCurrentUser()));
+            }
+        }
 
         Map<String, Object> params = new HashMap<String, Object>();
         params.put(RequestContext.CID, chan.getId().toString());

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7939,6 +7939,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="message.syncscheduled">
         <source>Repository sync scheduled for {0}.</source>
       </trans-unit>
+      <trans-unit id="message.syncinprogress">
+        <source>Repository sync is running.</source>
+      </trans-unit>
       <trans-unit id="message.channelsubscribers">
         <source>Per-User subscription restrictions may be applied in the Subscribers tab</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -8077,6 +8077,9 @@ Please note that some manual configuration of these scripts may still be require
       <trans-unit id="repos.jsp.channel.header">
         <source>Repository</source>
       </trans-unit>
+      <trans-unit id="repos.jsp.channel.status">
+        <source>Sync Status</source>
+      </trans-unit>
       <trans-unit id="repos.jsp.channel.repos">
         <source>Channel Repositories</source>
       </trans-unit>

--- a/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
@@ -35,6 +35,27 @@
                     <a href="/rhn/channels/manage/repos/RepoEdit.do?id=${current.id}">${current.label}</a>
                 </rl:column>
 
+                <rl:column sortable="false"
+                           bound="false"
+                           headerkey="repos.jsp.channel.status"
+                           >
+                    <c:set var="repoKey" value="${current.sourceUrl}"/>
+                    <c:set var="progress" value="${status[repoKey]['progress']}"/>
+                    <c:set var="title" value="${status[repoKey]['title']}"/>
+
+                    <c:if test="${status[repoKey]['finished']}">
+                        <c:set var="barStyle" value="progress-bar-success"/>
+                    </c:if>
+
+                    <c:if test="${status[repoKey]['failed']}">
+                        <c:set var="barStyle" value="progress-bar-danger"/>
+                    </c:if>
+
+                    <div class="progress progress-sm" title="${title}">
+                        <div class="progress-bar ${barStyle}" role="progressbar" aria-valuenow="${progress}" aria-valuemin="0" aria-valuemax="100" style="width: ${progress}%;"></div>
+                    </div>
+                </rl:column>
+
             </rl:list>
 
             <div class="checkbox">

--- a/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
@@ -62,7 +62,7 @@
                 <hr />
                 <button type="submit" name="dispatch" value="<bean:message key='repos.jsp.button-sync'/>"
                         class="btn btn-success"
-                        <c:if test="${inactive}">disabled="disabled"</c:if>>
+                        <c:if test="${in_progress || inactive}">disabled="disabled"</c:if>>
                     <rhn:icon type="repo-sync"/>
                     <bean:message key='repos.jsp.button-sync'/>
                 </button>

--- a/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/syncrepos.jsp
@@ -12,6 +12,22 @@
 
         <h2><rhn:icon type="header-package" /> <bean:message key="repos.jsp.channel.repos"/></h2>
 
+        <c:if test='${not empty last_sync}'>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4><bean:message key="channel.edit.jsp.lastsynced"/></h4>
+                </div>
+                <div class="panel-body">
+                    <c:if test='${not empty log_url}'>
+                        <a class="btn btn-info" href='${log_url}'><c:out value='${last_sync}'/></a>
+                    </c:if>
+                    <c:if test='${empty log_url}'>
+                        <c:out value='${last_sync}'/>
+                    </c:if>
+                </div>
+            </div>
+        </c:if>
+
         <rl:listset name="packageSet">
             <rhn:csrf />
 


### PR DESCRIPTION
## Enhancements:
* Parse last reposync log and write information into progress bar on the page.
* Detect running reposync for given channel and notify user.
* Add link to reposync logs (same as on Channel Details page).

## Before:
![before](https://cloud.githubusercontent.com/assets/6650196/8823590/80369d3a-306e-11e5-80ed-da27ae1e8a72.png)

## After:
![after1](https://cloud.githubusercontent.com/assets/6650196/8823597/87bb80f2-306e-11e5-8b60-431790978ec9.png)
![after2](https://cloud.githubusercontent.com/assets/6650196/8823599/8c05926a-306e-11e5-9d5b-5587ea72c15e.png)
