### PR TITLE
osad: re-send subscription stanzas after a while

### DIFF
--- a/client/tools/osad/src/osad.py
+++ b/client/tools/osad/src/osad.py
@@ -247,6 +247,11 @@ class Runner(jabber_lib.Runner):
             config = self.read_config()
             raise jabber_lib.NeedRestart
 
+        # make sure that dispatchers are not stuck in state [none + ask] or [from + ask]
+        # for too long. This can happen, for example, if a "subscribe" presence stanza
+        # gets lost - in that case re-send it
+        client.unstick_contacts(self._dispatchers)
+
         # if rhn_check is running or the last one failed, check more often
         if (client._rhn_check_process is None) and (client._rhn_check_fail_count < 1):
             client.process(timeout=180)


### PR DESCRIPTION
The [XMPP protocol](http://xmpp.org/rfcs/rfc3921.html) defines [a state machine for the subscription](http://xmpp.org/rfcs/rfc3921.html#substates) of a client to a contact's state - this is basically a series of intermediate states clients have to go through before getting any notification of another client's availability. We use this to subscribe RHN clients to `osa-dispatcher`'s messages, so clients are expected to go through all states up to `Both` at registration time or soon afterwards.

If for any reason presence stanzas are lost in the process (due to network failures, bugs in osad code, bugs in jabberd etc.) RHN clients might be stuck in one of two limbo states waiting for server to acknowledge a message that it has never received.

The only solution is for clients to retry sending those messages, as `osa-dispatcher` might not even know about client's addresses at this stage - the XMPP standard explicitly states that they should be hidden from its roster:

> 8.2.  User Subscribes to Contact
> [...]
> adding a roster item for the contact to the user's roster, with a state of "None + Pending In" as defined under Subscription StatesSubscription States, however a server SHOULD NOT push or deliver roster items in that state to the contact

Thus this patch adds retrying of subscription in case the state is one of the two limbo states and more than one minute elapsed.