### PR TITLE
Fixed typo in the rhn.conf man page

### DIFF
--- a/spacewalk/config/usr/share/man/man5/rhn.conf.5
+++ b/spacewalk/config/usr/share/man/man5/rhn.conf.5
@@ -220,7 +220,7 @@ then the job will be queued.
 
 .TP
 .B "taskomatic.maxmemory" (integer)
-The maximum abount of memory (MB) that Taskomaic can use. If you find that Taskomatic is running out of memory, consider increasing this.
+The maximum amount of memory (MB) that Taskomatic can use. If you find that Taskomatic is running out of memory, consider increasing this.
 .IP
 .B Default:
 1024


### PR DESCRIPTION
Fixed typo in the rhn.conf man page