### PR TITLE
Modified setup string to make it clearer for Oracle RDBMS

### DIFF
--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -793,7 +793,7 @@ REDO_CONNECT:
 
         ask(
                 -noninteractive => $opts->{"non-interactive"},
-                -question => "Database service name (SID)",
+                -question => "Global Database Name or SID (requires tnsnames.ora)",
                 -test => qr/\S+/,
                 -answer => \$answers->{'db-name'}
         );


### PR DESCRIPTION
Using the Oracle Instant Client implies that most connections will use the ezconnect syntax, i.e. \\host[:port]\database_name. In this syntax, we require the Global Database Name (db_name.db_domain) and not the legacy SID value.

For local XE installs, the global database name and SID are the same value, i.e. "XE", so //localhost/XE works without a tnsnames.ora.

Signed-off-by: Avi Miller <avi.miller@oracle.com>