### PR TITLE
Fixes orabug 20623622 error: maximum recursion depth exceeded

### DIFF
--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -20,7 +20,7 @@ ULN plugin for spacewalk-repo-sync.
 """
 import sys
 sys.path.append('/usr/share/rhn')
-from up2date_client.rpcServer import RetryServer
+from up2date_client.rpcServer import RetryServer, ServerList
 
 from spacewalk.satellite_tools.repo_plugins.yum_src import ContentSource as yum_ContentSource
 from spacewalk.satellite_tools.syncLib import RhnSyncException
@@ -56,12 +56,14 @@ class ContentSource(yum_ContentSource):
         print "The download URL is: " + self.url
         if self.proxy_addr:
             print "Trying proxy " + self.proxy_addr
-        s = RetryServer(self.uln_url + "/rpc/api",
+        slist = ServerList([self.uln_url+"/rpc/api",])
+        s = RetryServer(slist.server(),
                         refreshCallback=None,
                         proxy=self.proxy_addr,
                         username=self.proxy_user,
                         password=self.proxy_pass,
                         timeout=5)
+        s.addServerList(slist)
         self.key = s.auth.login(self.uln_user, self.uln_pass)
 
     def setup_repo(self, repo):


### PR DESCRIPTION
The recent re-write of the ```uln_src.py``` plugin that allows spacewalk to connect to Unbreakable Linux Network can cause a "max recursion depth exceeded" error.  It could be theorized that other errors could occur from this such as an error response from the server reporting unknown APIs or other seemingly mysterious errors.  Such errors can make it difficult to pinpoint errors in the spacewalk network configuration or prevent troubleshooting other connection issues.

The core issue is that there is no ```serverList``` element defined in the ```RetryServer``` object by default.  This is true even in the case where the ```RetryServer``` object is created according to the class definition and all parameters are supplied properly.  This is because ```serverList``` is not defined in the ```__init__()``` method, but instead *only* defined in the ```addServerList()``` method. Further, the way the ```RetryServer``` object is setup, anything that's not specifically defined as an element of the class, is treated as an RPC.

The ```RetryServer``` object is one of the core connection objects that is used for yum to connect to both RHN & ULN, but in the case of the "normal" use case there is a function defined in the same source file (```/usr/share/rhn/up2date_client/rpcServer.py```) as the ```RetryServer``` class - called ```getServer()``` - which not only initializes the ```RetryServer``` object properly based on the configuration in ```/etc/sysconfig/rhn/up2date```, but it also fills in all bunch of additional data into the ```RetryServer``` object that isn't handled in the ```__init__()``` method.  Among these additional steps is a call to the ```addServerList()``` method, which initializes the ```serverList``` element.

This is all perfectly fine for cases where we're operating within the defined stack of connecting to RHN or ULN for the base purposes of the yum plugin or for registering the server to the respective backends, but in the case of spacewalk, we're not using those configuration files at all.  As such the ```getServer()``` function is inappropriate as it does not allow for overriding of any of the settings that would be found in the up2date sysconfig file.  As such, we minimally need to initialize the crucial ```serverList``` element.  Although this element is not actually a list object, it is treated as an iterable "pseudo-list" for the infinite while loop that makes up the "retry" piece of the ```RetryServer``` class.

In the specific case reported, there was an invalid proxy configuration which made any connections to the eventual backend impossible.  This fact, coupled with the undefined ```serverList```, meant that the ```RetryServer``` was attempting to call ```serverList``` as an RPC to a server that it could never reach - in an infinite loop.  Eventually, it would just death spiral itself into the "max recursion" error and raise an exception, but on it's face the reported exception is not all that revealing about the root cause.

In either case, this should be fixed so that any user that has inadvertently misconfigured their network settings in spacewalk, will be able to properly diagnose these issues and not be mislead by seemingly unrelated exception errors due to ```RetryServer``` not being properly initialized.

A somewhat related piece of information which is not immediately obvious is that, unless specifically defined by the server:port convention in the spacewalk configuration file, the proxy server is assumed to use the same port as the destination server.  This is especially misleading when your proxy server uses the http default port 80 but your destination server uses the https default port of 443.  If the proxy definition doesn’t explicitly define the port as server:80, the ```RetryServer``` connection stack will assume you want to use the same port as the destination for the proxy.
