### PR TITLE
Fix pagination for `<rhn:list .../>`

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
@@ -86,13 +86,13 @@ public class AffectedSystemsActionTest extends MockObjectTestCase {
     }
 
     private void addPagination(RhnMockHttpServletRequest r) {
-        r.setupAddParameter("First", "someValue");
+        r.setupAddParameter("First Page", "someValue");
         r.setupAddParameter("first_lower", "10");
-        r.setupAddParameter("Prev", "0");
+        r.setupAddParameter("Previous page", "0");
         r.setupAddParameter("prev_lower", "");
-        r.setupAddParameter("Next", "20");
+        r.setupAddParameter("Next Page", "20");
         r.setupAddParameter("next_lower", "");
-        r.setupAddParameter("Last", "");
+        r.setupAddParameter("Last Page", "");
         r.setupAddParameter("last_lower", "20");
         r.setupAddParameter("lower", "10");
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.SetLabels;
 import com.redhat.rhn.frontend.action.common.test.RhnSetActionTest;
 import com.redhat.rhn.frontend.action.errata.AffectedSystemsAction;
+import com.redhat.rhn.frontend.struts.RequestContext.Pagination;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.testing.ActionHelper;
 import com.redhat.rhn.testing.RhnMockDynaActionForm;
@@ -86,14 +87,14 @@ public class AffectedSystemsActionTest extends MockObjectTestCase {
     }
 
     private void addPagination(RhnMockHttpServletRequest r) {
-        r.setupAddParameter("First Page", "someValue");
-        r.setupAddParameter("first_lower", "10");
-        r.setupAddParameter("Previous page", "0");
-        r.setupAddParameter("prev_lower", "");
-        r.setupAddParameter("Next Page", "20");
-        r.setupAddParameter("next_lower", "");
-        r.setupAddParameter("Last Page", "");
-        r.setupAddParameter("last_lower", "20");
+        r.setupAddParameter(Pagination.FIRST.getElementName(), "someValue");
+        r.setupAddParameter(Pagination.FIRST.getLowerAttributeName(), "10");
+        r.setupAddParameter(Pagination.PREV.getElementName(), "0");
+        r.setupAddParameter(Pagination.PREV.getLowerAttributeName(), "");
+        r.setupAddParameter(Pagination.NEXT.getElementName(), "20");
+        r.setupAddParameter(Pagination.NEXT.getLowerAttributeName(), "");
+        r.setupAddParameter(Pagination.LAST.getElementName(), "");
+        r.setupAddParameter(Pagination.LAST.getLowerAttributeName(), "20");
         r.setupAddParameter("lower", "10");
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
@@ -499,20 +499,16 @@ public class RequestContext {
      */
     public String processPagination() {
         String lower;
-        if (request.getParameter("First") != null ||
-                request.getParameter("First.x") != null) {
+        if (request.getParameter("First") != null) {
             lower = request.getParameter("first_lower");
         }
-        else if (request.getParameter("Prev") != null ||
-                request.getParameter("Prev.x") != null) {
+        else if (request.getParameter("Prev") != null) {
             lower = request.getParameter("prev_lower");
         }
-        else if (request.getParameter("Next") != null ||
-                request.getParameter("Next.x") != null) {
+        else if (request.getParameter("Next") != null) {
             lower = request.getParameter("next_lower");
         }
-        else if (request.getParameter("Last") != null ||
-                request.getParameter("Last.x") != null) {
+        else if (request.getParameter("Last") != null) {
             lower = request.getParameter("last_lower");
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
@@ -104,6 +104,41 @@ public class RequestContext {
     public static final String MODE = "mode";
     public static final String POST = "POST";
 
+    /**
+     * Names of pagination elements (and their corresponding attributes).
+     *  - elementName - pagination control button element name
+     *  - lowerAttributeName - name of the request attribute containing index of the first
+     *    element in the paginated list
+     */
+    public enum Pagination {
+        FIRST("First Page", "first_lower"),
+        PREV("Previous Page", "prev_lower"),
+        NEXT("Next Page", "next_lower"),
+        LAST("Last Page", "last_lower");
+
+        private String elementName;
+        private String lowerAttributeName;
+
+        Pagination(String elementNameIn, String lowerAttributeNameIn) {
+            this.elementName = elementNameIn;
+            this.lowerAttributeName = lowerAttributeNameIn;
+        }
+
+        /**
+         * @return the pagination control button element name
+         */
+        public String getElementName() {
+            return elementName;
+        }
+
+        /**
+         * @return the name of the request attribute containing index of the first
+         * element in the paginated list
+         */
+        public String getLowerAttributeName() {
+            return lowerAttributeName;
+        }
+    }
 
     private final HttpServletRequest request;
     private User               currentUser;
@@ -498,23 +533,13 @@ public class RequestContext {
      * @return the lowest value to display.
      */
     public String processPagination() {
-        String lower;
-        if (request.getParameter("First") != null) {
-            lower = request.getParameter("first_lower");
+        for (Pagination pagination : Pagination.values()) {
+            if (request.getParameter(pagination.getElementName()) != null) {
+                return request.getParameter(pagination.getLowerAttributeName());
+            }
         }
-        else if (request.getParameter("Prev") != null) {
-            lower = request.getParameter("prev_lower");
-        }
-        else if (request.getParameter("Next") != null) {
-            lower = request.getParameter("next_lower");
-        }
-        else if (request.getParameter("Last") != null) {
-            lower = request.getParameter("last_lower");
-        }
-        else {
-            lower = request.getParameter("lower");
-        }
-        return lower;
+
+        return request.getParameter("lower");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTag.java
@@ -133,14 +133,6 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
  */
 public class ListDisplayTag extends ListDisplayTagBase {
     private static final long serialVersionUID = 8952182346554627507L;
-    private static final String LAST = "Last Page";
-    private static final String NEXT = "Next Page";
-    private static final String PREV = "Previous Page";
-    private static final String FIRST = "First Page";
-    private static final String LAST_LOWER = "last_lower";
-    private static final String NEXT_LOWER = "next_lower";
-    private static final String PREV_LOWER = "prev_lower";
-    private static final String FIRST_LOWER = "first_lower";
     private static final Set<String> PAGINATION_WASH_SET = buildPaginationWashSet();
 
     /** row count determines whether we're an even or odd row */
@@ -478,10 +470,14 @@ public class ListDisplayTag extends ListDisplayTagBase {
                                     getPageList().getEnd() - getPageList().getStart() + 1,
                                     getPageList().getTotalSize());
 
-        renderHidden(target, FIRST_LOWER, putil.getFirstLower());
-        renderHidden(target, PREV_LOWER, putil.getPrevLower());
-        renderHidden(target, NEXT_LOWER, putil.getNextLower());
-        renderHidden(target, LAST_LOWER, putil.getLastLower());
+        renderHidden(target, RequestContext.Pagination.FIRST.getLowerAttributeName(),
+                putil.getFirstLower());
+        renderHidden(target, RequestContext.Pagination.PREV.getLowerAttributeName(),
+                putil.getPrevLower());
+        renderHidden(target, RequestContext.Pagination.NEXT.getLowerAttributeName(),
+                putil.getNextLower());
+        renderHidden(target, RequestContext.Pagination.LAST.getLowerAttributeName(),
+                putil.getLastLower());
         out.append(target.toString());
     }
 
@@ -580,13 +576,19 @@ public class ListDisplayTag extends ListDisplayTagBase {
         boolean canGoBack = getPageList().getStart() > 1;
 
         if (canGoForward || canGoBack) {
-            out.append(renderPaginationButton(FIRST,
+            out.append(renderPaginationButton(
+                    RequestContext.Pagination.FIRST.getElementName(),
                     DataSetManipulator.ICON_FIRST, canGoBack));
-            out.append(renderPaginationButton(PREV, DataSetManipulator.ICON_PREV,
+            out.append(renderPaginationButton(
+                    RequestContext.Pagination.PREV.getElementName(),
+                    DataSetManipulator.ICON_PREV,
                     canGoBack));
-            out.append(renderPaginationButton(NEXT, DataSetManipulator.ICON_NEXT,
+            out.append(renderPaginationButton(
+                    RequestContext.Pagination.NEXT.getElementName(),
+                    DataSetManipulator.ICON_NEXT,
                     canGoForward));
-            out.append(renderPaginationButton(LAST,
+            out.append(renderPaginationButton(
+                    RequestContext.Pagination.LAST.getElementName(),
                     DataSetManipulator.ICON_LAST, canGoForward));
         }
         out.append("</div>\n");
@@ -777,12 +779,10 @@ public class ListDisplayTag extends ListDisplayTagBase {
      * @return a set of all URL variables that are pagination-specific
      */
     private static Set<String> buildPaginationWashSet() {
-        String [] keys = new String[] {FIRST, PREV, NEXT, LAST,
-                                        FIRST_LOWER, PREV_LOWER,
-                                            NEXT_LOWER, LAST_LOWER };
         Set<String> result = new HashSet<String>();
-        for (int i = 0; i < keys.length; i++) {
-            result.add(keys[i]);
+        for (RequestContext.Pagination pagination : RequestContext.Pagination.values()) {
+            result.add(pagination.getElementName());
+            result.add(pagination.getLowerAttributeName());
         }
         return Collections.unmodifiableSet(result);
     }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
@@ -108,10 +108,10 @@ public class ListDisplayTagTest extends MockObjectTestCase {
      * @param htmlOut the html output
      */
     private void assertPaginationControls(String htmlOut) {
-        assertTrue(htmlOut.indexOf("name=\"first_lower") > -1);
-        assertTrue(htmlOut.indexOf("name=\"prev_lower") > -1);
-        assertTrue(htmlOut.indexOf("name=\"next_lower") > -1);
-        assertTrue(htmlOut.indexOf("name=\"last_lower") > -1);
+        for (RequestContext.Pagination pagination : RequestContext.Pagination.values()) {
+            String att = pagination.getLowerAttributeName();
+            assertTrue(htmlOut.indexOf("name=\"" + att) > -1);
+        }
         assertTrue(htmlOut.indexOf("name=\"lower") > -1);
     }
 

--- a/java/code/src/com/redhat/rhn/testing/ActionHelper.java
+++ b/java/code/src/com/redhat/rhn/testing/ActionHelper.java
@@ -215,13 +215,13 @@ public class ActionHelper extends Assert {
      * listview Actions.
      */
     public void setupProcessPagination() {
-        getRequest().setupAddParameter("First", "someValue");
+        getRequest().setupAddParameter("First Page", "someValue");
         getRequest().setupAddParameter("first_lower", "10");
-        getRequest().setupAddParameter("Prev", "0");
+        getRequest().setupAddParameter("Previous Page", "0");
         getRequest().setupAddParameter("prev_lower", "");
-        getRequest().setupAddParameter("Next", "20");
+        getRequest().setupAddParameter("Next Page", "20");
         getRequest().setupAddParameter("next_lower", "");
-        getRequest().setupAddParameter("Last", "");
+        getRequest().setupAddParameter("Last Page", "");
         getRequest().setupAddParameter("last_lower", "20");
         getRequest().setupAddParameter("lower", "10");
     }

--- a/java/code/src/com/redhat/rhn/testing/ActionHelper.java
+++ b/java/code/src/com/redhat/rhn/testing/ActionHelper.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.testing;
 import com.redhat.rhn.common.util.MethodUtil;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.frontend.struts.RequestContext.Pagination;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.taglibs.list.ListTagUtil;
 import com.redhat.rhn.frontend.taglibs.list.TagHelper;
@@ -215,14 +216,14 @@ public class ActionHelper extends Assert {
      * listview Actions.
      */
     public void setupProcessPagination() {
-        getRequest().setupAddParameter("First Page", "someValue");
-        getRequest().setupAddParameter("first_lower", "10");
-        getRequest().setupAddParameter("Previous Page", "0");
-        getRequest().setupAddParameter("prev_lower", "");
-        getRequest().setupAddParameter("Next Page", "20");
-        getRequest().setupAddParameter("next_lower", "");
-        getRequest().setupAddParameter("Last Page", "");
-        getRequest().setupAddParameter("last_lower", "20");
+        getRequest().setupAddParameter(Pagination.FIRST.getElementName(), "someValue");
+        getRequest().setupAddParameter(Pagination.FIRST.getLowerAttributeName(), "10");
+        getRequest().setupAddParameter(Pagination.PREV.getElementName(), "0");
+        getRequest().setupAddParameter(Pagination.PREV.getLowerAttributeName(), "");
+        getRequest().setupAddParameter(Pagination.NEXT.getElementName(), "20");
+        getRequest().setupAddParameter(Pagination.NEXT.getLowerAttributeName(), "");
+        getRequest().setupAddParameter(Pagination.LAST.getElementName(), "");
+        getRequest().setupAddParameter(Pagination.LAST.getLowerAttributeName(), "20");
         getRequest().setupAddParameter("lower", "10");
     }
 


### PR DESCRIPTION
Change https://github.com/spacewalkproject/spacewalk/commit/65ed77d32f438c516e8779d5fdb6611756a2d333#diff-a53224fadf9a06ea207bc7d70fa8b117R136 disabled pagination for lists created using `<rhn:list .../>` tag.

The bug was caused by changing the string `"First"` to `"First Page"` in `ListDisplayTag`. This string served as a pagination-controlling parameter in the request. However, the request handling logic (in `RequestContext`) still relied on the string value `"First"`.

Fixed by unifying the strings and putting them into a single enum.
