### PR TITLE
Clean up base classes for tests

### DIFF
--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -67,13 +67,7 @@ public abstract class RhnBaseTestCase extends TestCase {
      */
     protected void setUp() throws Exception {
         super.setUp();
-        try {
-            LoggingFactory.clearLogId();
-        }
-        catch (Exception se) {
-            TestCaseHelper.tearDownHelper();
-            LoggingFactory.clearLogId();
-        }
+        TestCaseHelper.setUpHelper();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -34,7 +34,6 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.util.Asserts;
-import com.redhat.rhn.domain.common.LoggingFactory;
 
 /**
  * RhnBaseTestCase is the base class for all RHN TestCases.

--- a/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
@@ -14,8 +14,6 @@
  */
 package com.redhat.rhn.testing;
 
-import com.redhat.rhn.domain.common.LoggingFactory;
-
 import org.jmock.cglib.MockObjectTestCase;
 
 /**
@@ -31,13 +29,7 @@ public abstract class RhnJmockBaseTestCase extends MockObjectTestCase {
      */
     protected void setUp() throws Exception {
         super.setUp();
-        try {
-            LoggingFactory.clearLogId();
-        }
-        catch (Exception se) {
-            TestCaseHelper.tearDownHelper();
-            LoggingFactory.clearLogId();
-        }
+        TestCaseHelper.setUpHelper();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009--2012 Red Hat, Inc.
+ * Copyright (c) 2015 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,55 +14,39 @@
  */
 package com.redhat.rhn.testing;
 
-import org.jmock.Mock;
+import com.redhat.rhn.domain.common.LoggingFactory;
+
 import org.jmock.cglib.MockObjectTestCase;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
- *
- * RhnJmockBaseTestCase - Add a bit of cleanup logic to the MockObjectTestCase
- * @version $Rev$
+ * RhnJmockBaseTestCase - This is the same thing as {@link RhnBaseTestCase}
+ * but it extends from {@link MockObjectTestCase}.
  */
 public abstract class RhnJmockBaseTestCase extends MockObjectTestCase {
 
     /**
-     * {@inheritDoc}
+     * Called once per test method.
+     *
+     * @throws Exception if an error occurs during test setup
+     */
+    protected void setUp() throws Exception {
+        super.setUp();
+        try {
+            LoggingFactory.clearLogId();
+        }
+        catch (Exception se) {
+            TestCaseHelper.tearDownHelper();
+            LoggingFactory.clearLogId();
+        }
+    }
+
+    /**
+     * Called once per test method to clean up.
+     *
+     * @throws Exception if an error occurs during tear down
      */
     protected void tearDown() throws Exception {
-        // TODO Auto-generated method stub
         super.tearDown();
         TestCaseHelper.tearDownHelper();
     }
-
-    /**
-     * Add a variable to the Mocked request object
-     * @param mreq Mock of the HttpServletRequest object
-     * @param name of the parameter
-     * @param value value of the param
-     */
-    public void addRequestParam(Mock mreq, String name, String value) {
-        if (!(mreq.proxy() instanceof HttpServletRequest)) {
-            throw new IllegalArgumentException(
-                    "mreq must be a proxy/mock of a HttpServletRequest");
-        }
-        mreq.expects(atLeastOnce()).method("getParameter").
-            with(eq(name)).will(returnValue(value));
-    }
-    /**
-     * Util for turning of the spew from the l10n service for
-     * test cases that make calls with dummy string IDs.
-     */
-    public static void disableLocalizationServiceLogging() {
-        RhnBaseTestCase.disableLocalizationServiceLogging();
-    }
-
-    /**
-     * Util for turning on the spew from the l10n service for
-     * test cases that make calls with dummy string IDs.
-     */
-    public static void enableLocalizationServiceLogging() {
-        RhnBaseTestCase.enableLocalizationServiceLogging();
-    }
-
 }

--- a/java/code/src/com/redhat/rhn/testing/TestCaseHelper.java
+++ b/java/code/src/com/redhat/rhn/testing/TestCaseHelper.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.testing;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.common.LoggingFactory;
 
 import org.hibernate.TransactionException;
 
@@ -27,6 +28,19 @@ import org.hibernate.TransactionException;
 public class TestCaseHelper {
 
     private TestCaseHelper() {
+    }
+
+    /**
+     * Shared logic for setting up unit tests.
+     */
+    public static void setUpHelper() {
+        try {
+            LoggingFactory.clearLogId();
+        }
+        catch (Exception se) {
+            TestCaseHelper.tearDownHelper();
+            LoggingFactory.clearLogId();
+        }
     }
 
     /**


### PR DESCRIPTION
This patch cleans up `RhnJmockBaseTestCase` so that the `setUp()` method would actually do the same thing as the `setUp()` in `RhnBaseTestCase`. Unreferenced methods are further removed and the contents of `setUp()` is moved into `TestCaseHelper` for de-duplication.