### PR TITLE
Hibernate java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.hbm.xml
@@ -14,7 +14,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
         <property name="product" column="PRODUCT" not-null="true" type="string" length="256" />
         <property name="version" column="VERSION" not-null="true" type="string" length="64" />
-        <property name="beta" column="BETA" not-null="true" type="string" length="1" />
+        <property name="betaMarker" column="BETA" not-null="true" type="string" length="1" />
         <property name="created" column="CREATED" not-null="true" type="timestamp" insert="false" update="false"/>
         <property name="modified" column="MODIFIED" not-null="true" type="timestamp" insert="false" update="false"/>
     </class>

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.java
@@ -25,7 +25,7 @@ public class ChannelProduct {
     private Long id;
     private String product;
     private String version;
-    private String beta;
+    private String betaMarker;
     private Date created;
     private Date modified;
     /**
@@ -77,40 +77,40 @@ public class ChannelProduct {
     }
 
     /**
-     * Getter for beta
+     * Getter for betaMarker
      * @return String to get
     */
-    public String getBeta() {
-        return this.beta;
+    public String getBetaMarker() {
+        return this.betaMarker;
     }
 
     /**
-     * Setter for beta
+     * Setter for betaMarker
      * @param betaIn to set
     */
-    public void setBeta(String betaIn) {
-        this.beta = betaIn;
+    public void setBetaMarker(String betaIn) {
+        this.betaMarker = betaIn;
     }
 
     /**
-     * Whether the channel product is a beta product
-     * @return true if product is a beta product, false otherwise
+     * Whether the channel product is a betaMarker product
+     * @return true if product is a betaMarker product, false otherwise
      */
     public boolean isBeta() {
-        return this.beta.equals("Y");
+        return this.betaMarker.equals("Y");
     }
 
     /**
-     * Setter for whether the channel product is a beta product or not
-     * Can't be named setBeta or hibernate wigs out
-     * @param isBeta true if the product is a beta product, false otherwise
+     * Setter for whether the channel product is a betaMarker product or not
+     * Can't be named setBetaMarker or hibernate wigs out
+     * @param isBeta true if the product is a betaMarker product, false otherwise
      */
-    public void setMyBeta(boolean isBeta) {
+    public void setBeta(boolean isBeta) {
         if (isBeta) {
-            this.setBeta("Y");
+            this.setBetaMarker("Y");
         }
         else {
-            this.setBeta("N");
+            this.setBetaMarker("N");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelProduct.java
@@ -80,7 +80,7 @@ public class ChannelProduct {
      * Getter for betaMarker
      * @return String to get
     */
-    public String getBetaMarker() {
+    private String getBetaMarker() {
         return this.betaMarker;
     }
 
@@ -88,7 +88,7 @@ public class ChannelProduct {
      * Setter for betaMarker
      * @param betaIn to set
     */
-    public void setBetaMarker(String betaIn) {
+    private void setBetaMarker(String betaIn) {
         this.betaMarker = betaIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -896,7 +896,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         ChannelProduct product = new ChannelProduct();
         product.setProduct("proxy" + TestUtils.randomString());
         product.setVersion("1.1");
-        product.setMyBeta(false);
+        product.setBeta(false);
         proxyChan.setProduct(product);
         proxyChan.setChannelFamilies(chanFamilies);
         proxyChan.setParentChannel(baseChan);

--- a/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
@@ -117,7 +117,7 @@ public class ErrataTestUtils {
         ChannelProduct product = new ChannelProduct();
         product.setProduct("ChannelProduct" + TestUtils.randomString());
         product.setVersion("11.3");
-        product.setBeta("N");
+        product.setBeta(false);
         TestUtils.saveAndFlush(product);
         return product;
     }


### PR DESCRIPTION
rename ChannelProduct#beta to ChannelProduct#betaMarker

Following bean naming conventions or spending too much time choosing the right name may sound "picky", but these things always backfire.

ChannelProduct#beta property makes you think it is "is the product beta?", but it is a string that suggests the beta status (it can be 'Y'/'N' but what if it is 'T'?). That field should have been named betaMarker, betaFlag, whatever.

To make life easier a boolean helper was created isBeta()¹ and a boolean setter, which because of Hibernate complaining was named "setMyBeta()"²

Problem is:

* ¹ isBeta clashes with the other property setBeta/getBeta

In Java 7 Class.getDeclaredMethods() does not guarantee order anymore. (http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7023180)

So running tests with OpenJDK, Hibernate will get wrong method for the property
"beta" and the following error will happen:

    java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String

* Even if the badly named setMyBeta() was added, it was not used!. Right. All code goes over setBeta, passing again the 'Y'/'N' value, which is error prone.

So this PR proposes the following:

* Rename the badly named method setBeta/getBeta to setBetaMarker/getBetaMarker
* Rename isBeta and setMyBeta to isBeta/setBeta(bool) to avoid the clash in ¹ but also add some consistency
* Actually USE setBeta in the boolean form (it was not)
* Make the string versions (betaMarker) private.
