### PR TITLE
fix delete user by deleting the reference to rhnResetPassword

### DIFF
--- a/schema/spacewalk/common/tables/rhnResetPassword.sql
+++ b/schema/spacewalk/common/tables/rhnResetPassword.sql
@@ -19,7 +19,8 @@ CREATE TABLE rhnResetPassword
     id            NUMBER NOT NULL
                       CONSTRAINT rhn_rstpwd_id_pk primary key,
     user_id       NUMBER NOT NULL
-                      CONSTRAINT rhn_rstpwd_uid_fk REFERENCES web_contact (id),
+                      CONSTRAINT rhn_rstpwd_uid_fk REFERENCES web_contact (id)
+                      ON DELETE CASCADE,
     token         VARCHAR(64) NOT NULL
                       CONSTRAINT rhn_rstpwd_token_uq UNIQUE,
     is_valid      char(1) DEFAULT 'Y' NOT NULL

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.3-to-spacewalk-schema-2.4/013-rhnResetPassword.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.3-to-spacewalk-schema-2.4/013-rhnResetPassword.sql
@@ -19,7 +19,8 @@ CREATE TABLE rhnResetPassword
     id            NUMBER NOT NULL
                       CONSTRAINT rhn_rstpwd_id_pk primary key,
     user_id       NUMBER NOT NULL
-                      CONSTRAINT rhn_rstpwd_uid_fk REFERENCES web_contact (id),
+                      CONSTRAINT rhn_rstpwd_uid_fk REFERENCES web_contact (id)
+                      ON DELETE CASCADE,
     token         VARCHAR(64) NOT NULL
                       CONSTRAINT rhn_rstpwd_token_uq UNIQUE,
     is_valid      char(1) DEFAULT 'Y' NOT NULL


### PR DESCRIPTION
Delete a normal user result in

 ERROR:  -20255 : (cannot_delete_user) - The specified user may not be deleted.

calling "delete from web_contact where id = <NUM>" directly result in:

 ERROR:  update or delete on table "web_contact" violates foreign key constraint "rhn_rstpwd_uid_fk" on table "rhnresetpassword"
 DETAIL:  Key (id)=(3) is still referenced from table "rhnresetpassword".
