### PR TITLE
Pwayper close unused check connection statement

### DIFF
--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -210,6 +210,9 @@ class Database(sql_base.Database):
         try:
             c = self.prepare("select 1")
             c.execute()
+            # Paul Wayper - 2015-10-01 - this normally leaves a statement
+			# open, so fetch all its results so it can be closed.
+            junk = c.fetchall_hash()
         except:  # try to reconnect, that one MUST WORK always
             log_error("DATABASE CONNECTION TO '%s' LOST" % self.database,
                       "Exception information: %s" % sys.exc_info()[1])

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -211,7 +211,7 @@ class Database(sql_base.Database):
             c = self.prepare("select 1")
             c.execute()
             # Paul Wayper - 2015-10-01 - this normally leaves a statement
-			# open, so fetch all its results so it can be closed.
+            # open, so fetch all its results so it can be closed.
             junk = c.fetchall_hash()
         except:  # try to reconnect, that one MUST WORK always
             log_error("DATABASE CONNECTION TO '%s' LOST" % self.database,


### PR DESCRIPTION
This is a slightly more verbose patch for the problem described in Red Hat bug 1266216:

https://bugzilla.redhat.com/show_bug.cgi?id=1266216

Basically, the problem seems to be that in some circumstances, the "select 1" statement can cause the Postgres server to keep a statement cursor open.  This ties up extra resources in the database, which can lead to connection problems, memory problems and more.