### PR TITLE
spacecmd: upload always with base64, but not as binary

### DIFF
--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -34,6 +34,7 @@ BuildRequires: python-json
 Requires:    python-simplejson
 %endif
 Requires:    python
+Requires:    file
 
 %description
 spacecmd is a command-line interface to Spacewalk and Satellite servers

--- a/spacecmd/src/lib/utils.py
+++ b/spacecmd/src/lib/utils.py
@@ -768,7 +768,7 @@ def file_is_binary(self, path):
         if output.startswith("text/"):
             return False
     except OSError:
-        return True
-    return False
+        pass
+    return True
 
 

--- a/spacecmd/src/lib/utils.py
+++ b/spacecmd/src/lib/utils.py
@@ -760,7 +760,7 @@ def file_is_binary(self, path):
        Assumes binary if it can't categorize the file as plaintext"""
     try:
         process = Popen(["file", "-b", "--mime-type", path], stdout=PIPE)
-        (output, err) = process.communicate()
+        output = process.communicate()[0]
         exit_code = process.wait()
         if exit_code != 0:
             return True
@@ -770,5 +770,3 @@ def file_is_binary(self, path):
     except OSError:
         pass
     return True
-
-


### PR DESCRIPTION
In reply to https://github.com/spacewalkproject/spacewalk/pull/247 the issue of trailing newlines with spacecmd was fixed with commit cd86ea1b8671596f025f378c5c06d6918ce6e7fc

While it is true that always base64 encoding workarounds all the problems due to the trim() bug in Redstone XML-RPC, the fix uploads the file as binary, which means scripts can't be edited in the Web user interface anymore.

There is no need to set binary=True when using base64 because the backend handles it as two separate concepts (transport vs storage).

The following patch enables uploading files always as base64, but the binary flag is set according to the file type, which we detect using the "file" command (gives better results than the mimetype module for stuff like /etc/fstab). We set binary false for everything that is text, otherwise, we set binary.

This produces a less surprising experience for the user.

@sdherr may be you are the right one to review it.