### PR TITLE
Fix pwstrength-bootstrap license

### DIFF
--- a/spec-tree/pwstrength/pwstrength-bootstrap.spec
+++ b/spec-tree/pwstrength/pwstrength-bootstrap.spec
@@ -1,7 +1,7 @@
 Name:           pwstrength-bootstrap
 Version:        1.0.2
 Release:        3%{?dist}
-License:        MIT and GPLv3
+License:        MIT or GPLv3
 Summary:        Password quality Twitter Bootstrap Plugin
 Url:            https://github.com/ablanco/jquery.pwstrength.bootstrap
 Group:          Applications/Internet


### PR DESCRIPTION
From https://github.com/ablanco/jquery.pwstrength.bootstrap

"Dual licensed under the MIT and GPL licenses. You can choose the one that suits your purposes better."