### PR TITLE
Fix equals & hashCode in VirtualInstance and consequences

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.domain.server;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.Identifiable;
 import com.redhat.rhn.domain.channel.Channel;
@@ -1520,9 +1521,10 @@ public class Server extends BaseDomainHelper implements Identifiable {
         for (Iterator<VirtualInstance> it = guests.iterator(); it.hasNext();) {
             VirtualInstance g = it.next();
             if (g.getId().equals(guest.getId())) {
-                guest.setHostSystem(null);
-
                 it.remove();
+                if (g.getGuestSystem() == null) {
+                    HibernateFactory.getSession().delete(g);
+                }
                 deleted = true;
                 break;
             }

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -81,7 +81,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         </set>
 
         <set name="virtualGuests" inverse="true" lazy="true" outer-join="true"
-            cascade="all-delete-orphan">
+            cascade="all">
                 <key column="host_system_id"/>
                 <one-to-many class="com.redhat.rhn.domain.server.VirtualInstance"/>
         </set>

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.domain.server;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.BaseDomainHelper;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -338,8 +337,10 @@ public class VirtualInstance extends BaseDomainHelper {
 
         VirtualInstance that = (VirtualInstance) object;
 
-        return new EqualsBuilder().append(this.getId(), that.getId()).
-            append(this.getUuid(), that.getUuid()).isEquals();
+        return new EqualsBuilder()
+                .append(this.getUuid(), that.getUuid())
+                .append(this.getHostSystem(), that.getHostSystem())
+                .isEquals();
     }
 
     /**
@@ -347,7 +348,10 @@ public class VirtualInstance extends BaseDomainHelper {
      * {@inheritDoc}
      */
     public int hashCode() {
-        return new HashCodeBuilder().append(getId()).append(getUuid()).toHashCode();
+        return new HashCodeBuilder()
+                .append(getUuid())
+                .append(getHostSystem())
+                .toHashCode();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
@@ -114,6 +115,7 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
                 .withVirtHost().build();
         virtualInstanceDAO.saveVirtualInstance(guest);
         flushAndEvictGuest(guest);
+        HibernateFactory.getSession().clear();
 
         // step 2 - fetch the guest from the database so that it is attached to the session
         VirtualInstance retrievedGuest = virtualInstanceDAO.lookupById(guest

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceTest.java
@@ -14,19 +14,20 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
+import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.Sequence;
+import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
-
-import junit.framework.TestCase;
 
 
 /**
  * VirtualInstanceTest
  * @version $Rev$
  */
-public class VirtualInstanceTest extends TestCase {
+public class VirtualInstanceTest extends RhnBaseTestCase {
 
     private class GuestStub extends VirtualInstance {
         public GuestStub(Long id) {
@@ -37,6 +38,7 @@ public class VirtualInstanceTest extends TestCase {
     private Sequence idSequence;
 
     protected void setUp() throws Exception {
+        super.setUp();
         idSequence = new Sequence();
     }
 
@@ -51,15 +53,24 @@ public class VirtualInstanceTest extends TestCase {
         assertFalse(new VirtualInstance().isRegisteredGuest());
     }
 
+    public void testEqualsAndHashCode() throws Exception {
+        Server host = ServerTestUtils.createTestSystem();
+        Server guest = ServerTestUtils.createTestSystem();
+        String uuid1 = TestUtils.randomString();
+        String uuid2 = TestUtils.randomString();
 
-    public void testEqualsAndHashCode() {
-        VirtualInstance guestA = new GuestStub(idSequence.nextLong());
-        VirtualInstance guestB = new GuestStub(guestA.getId());
-        VirtualInstance guestC = new GuestStub(idSequence.nextLong());
+        VirtualInstance refGuest = createVirtualInstance(host, guest, uuid1);
 
-        assertEquals(true, TestUtils.equalTest(guestA, guestB));
-        assertEquals(false, TestUtils.equalTest(guestA, guestC));
-        assertEquals(false, TestUtils.equalTest(guestA, new Object()));
+        assertEquals(refGuest, createVirtualInstance(host, guest, uuid1));
+        assertFalse(refGuest.equals(createVirtualInstance(host, guest, uuid2)));
+    }
+
+    private VirtualInstance createVirtualInstance(Server host, Server guest, String uuid) {
+        VirtualInstance virtualInstance = new VirtualInstance();
+        virtualInstance.setHostSystem(host);
+        virtualInstance.setGuestSystem(guest);
+        virtualInstance.setUuid(uuid);
+        return virtualInstance;
     }
 
     public void testGetNullInfo() {

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -203,6 +203,7 @@ public class SystemManagerTest extends RhnBaseTestCase {
 
         // Delete the host first:
         SystemManager.deleteServer(user, host.getId());
+        HibernateFactory.getSession().clear();
         TestUtils.flushAndEvict(host);
 
         SystemManager.deleteServer(user, sid);


### PR DESCRIPTION
- Get rid of using ID in equals & hashCode in VirtualInstance.
- Remove incorrect all-delete-orphans cascade from server->guests
  mapping. In some cases, this cascade can remove VirtualInstances that
  still point to a registered guest system. Programmatic deletion of the
  orphans in appropriate case was implemented instead.
- Adjust tests.