### PR TITLE
Add option to softwarechannel_setorgaccess for protected sharing of channels

### DIFF
--- a/rel-eng/packages/.readme
+++ b/rel-eng/packages/.readme
@@ -1,3 +1,3 @@
-the rel-eng/packages directory contains metadata files
-named after their packages. Each file has the latest tagged
-version and the project's relative directory.
+Files in this directory are updated using tito tag invoked from
+directories of individual packages.
+Do not modify these files manually without knowing what your've doing.

--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -1593,16 +1593,13 @@ def complete_softwarechannel_setorgaccesstree(self, text, line, beg, end):
     return tab_completer(self.list_base_channels(), text)
 
 def do_softwarechannel_setorgaccesstree(self, args):
-    if not len(args):
-        self.help_softwarechannel_setorgaccesstree()
-        return
     options = [Option('-e', '--enable', action='store_true'),
                Option('-d', '--disable', action='store_true'),
                Option('-p', '--protected', action='append')]
     (args, options) = parse_arguments(args, options)
 
-    if not len(args):
-        self.help_softwarechannel_setorgaccesstree
+    if not len(args) or not (options.enable or options.disable or options.protected):
+        self.help_softwarechannel_setorgaccesstree()
         return
 
     # allow globbing of software channel names

--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -1573,7 +1573,7 @@ def do_softwarechannel_getorgaccesstree(self, args):
         logging.error("Can't call softwarechannel_getorgaccesstree on child channel!")
         self.help_softwarechannel_getorgaccesstree()
         return
-        
+
     for channel in channels:
         do_softwarechannel_getorgaccess(self, channel)
         for child in self.list_child_channels(parent=channel):
@@ -1594,7 +1594,7 @@ def complete_softwarechannel_setorgaccesstree(self, text, line, beg, end):
 
 def do_softwarechannel_setorgaccesstree(self, args):
     if not len(args):
-        self.help_softwarechannel_setorgaccess()
+        self.help_softwarechannel_setorgaccesstree()
         return
     options = [Option('-e', '--enable', action='store_true'),
                Option('-d', '--disable', action='store_true'),


### PR DESCRIPTION
Working with multiple organisations which do not share all channels with each other it is convenient to extend the softwarechannel_[s|g]etorgaccess commands:
I added the option --protected to enable channel sharing only for the given organisations to software_channelsetorgaccess.
software_channelgetorgaccess now reports for protected channels for all trusted organisations if they are enabled or disabled.
And I added software_channel[s|g]etorgaccesstree to work with whole channel trees. Most of the time you want to have the same sharing options on the whole channel tree of a base channel.

I could not figure out why rel-eng/packages/.readme was changed...