### PR TITLE
BugFix: skip similar tasks only if task is 'single threaded'

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.taskomatic;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.taskomatic.task.RhnJob;
+import com.redhat.rhn.taskomatic.task.RhnQueueJob;
 import com.redhat.rhn.taskomatic.task.TaskHelper;
 
 import org.apache.log4j.Logger;
@@ -62,12 +63,26 @@ public class TaskoJob implements Job {
 
     private boolean isTaskSingleThreaded(TaskoTask task) {
         try {
-            Class.forName(task.getTaskClass()).newInstance();
+            return Class.forName(task.getTaskClass()).newInstance() instanceof RhnQueueJob;
         }
-        catch (Exception e) {
+        catch (InstantiationException e) {
+            // will be caught later
+            log.error("Error trying to instance a new class of " +
+                    task.getTaskClass() + ": " + e.getMessage());
             return false;
         }
-        return true;
+        catch (IllegalAccessException e) {
+            // will be caught later
+            log.error("Error trying to instance a new class of " +
+                    task.getTaskClass() + ": " + e.getMessage());
+            return false;
+        }
+        catch (ClassNotFoundException e) {
+            // will be caught later
+            log.error("Error trying to instance a new class of " +
+                    task.getTaskClass() + ": " + e.getMessage());
+            return false;
+        }
     }
 
     private boolean isTaskRunning(TaskoTask task) {


### PR DESCRIPTION
If a task is defined as `single threaded`, any other calls of this task are skipped if one of that type is already running. While checking if a task is single threaded, `TaskoJob.java` does an incorrect check returning always true and skipping all task but one for each type of task. This should not happen for `reposync` task, because it is not a single threaded task, and all `reposync` tasks should be run even if any other is running.

The solution: revert the behaviour of `TaskoJob.java` to the original one and refactor it.

The bug was introduced by removing the casting in the commit https://github.com/spacewalkproject/spacewalk/commit/f3d9e83a1d28b917c20aa6fcd6d92d55ee8d91cc