### PR TITLE
Fix typo and remove from whitelist

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -22581,7 +22581,7 @@ given channel.</source>
         <target>সংযোজন নিশ্চায়ণ</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>আপনার উল্লিখিত মান অনুযায়ী কোনো প্যাকেজ পাওয়া যায়নি।</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -23778,7 +23778,7 @@ für einen angegebenen Channel aufgelistet wird.</target>
         <target>Hinzufügen bestätigen</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>Keine Pakete für diese Kriterien gefunden.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -19914,7 +19914,7 @@ given channel.</source>
         <source>Confirm Addition</source>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">
         <source>Below is the list of packages you can add to this channel. The "Channel" select box allows you to restrict the set of available packages. To add a package to this channel, select it here, and click 'Add Packages' below.

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -23780,7 +23780,7 @@ given channel.</source>
         <target>Confirmar adición</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>No se encontró ningún paquete para este criterio.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -23776,7 +23776,7 @@ fois pour un canal donné.</target>
         <target>Confirmer l'ajout</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>Aucun paquetage correspondant à votre critère n'a été trouvé.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -22584,7 +22584,7 @@ given channel.</source>
         <target>ઉમેરવાની ખાતરી કરો</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>આ વિચારધારા માટે પેકેજો મળ્યા નહિં.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -22584,7 +22584,7 @@ given channel.</source>
         <target>जोड़ने की पुष्टि करें</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>इस इरेटा के लिए कोई संकुल नहीं मिला.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -23737,7 +23737,7 @@ stesso pacchetto in un singolo canale, ciò potrebbe causare però il
         <target>Conferma aggiunta</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>Nessun pacchetto trovato per questo criterio.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -23779,7 +23779,7 @@ given channel.</source>
         <target>追加の確認</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>この条件に一致するパッケージは見つかりませんでした。</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -23311,7 +23311,7 @@ given channel.</source>
         <target>추가 확인 </target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>기준과 일치하는 패키지를 찾을 수 없음.  </target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -22583,7 +22583,7 @@ given channel.</source>
         <target>ਜੋੜਨ ਪੁਸ਼ਟੀ</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>ਇਸ ਸ਼ਰਤ ਲਈ ਕੋਈ ਪੈਕੇਜ ਨਹੀਂ ਲੱਭਿਆ।</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -23772,7 +23772,7 @@ of @@PRODUCT_NAME@@.</target>
         <target>Confirmar Adição</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>Não foi encontrado nenhum pacote para este critério.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -23751,7 +23751,7 @@ given channel.</source>
         <target>Подтвердить добавление</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>Нет пакетов, удовлетворяющих заданным критериям.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -22582,7 +22582,7 @@ given channel.</source>
         <target>சேர்த்தலை உறுதிப்படுத்தவும்</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>இந்த தகவல்க்கு தொகுப்புகள் எதுவும் காணப்படவில்லை.</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -23767,7 +23767,7 @@ given channel.</source>
         <target>确认添加</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>没有找到符合这个标准的软件包。</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -23771,7 +23771,7 @@ given channel.</source>
         <target>確認新增</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addemptylist">
-        <source>No packages found for this critera.</source>
+        <source>No packages found for this criteria.</source>
         <target>沒發現與您的搜尋準則相符的套件。</target>
       </trans-unit>
       <trans-unit id="channel.jsp.package.addmessage">

--- a/java/scripts/spelling/ignored_en.txt
+++ b/java/scripts/spelling/ignored_en.txt
@@ -145,7 +145,6 @@ Configs
 Cpus
 CreateCorporate
 CreateProfileWizard
-critera
 Cron
 crypto
 cryptokey


### PR DESCRIPTION
I'm not sure about that removal from ignored_en.txt, but that looks like
some spell-check whitelist and have last commit in 2011, so it doesn't
seem to be maintained anyways.