### PR TITLE
BugFix: remove inconsistency action description

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -2251,14 +2251,8 @@ available for this kickstart profile to function properly.
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="Remove Packages">
-        <source>Remove Packages</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">Navigation Menu</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="Update Packages">
-        <source>Update Packages</source>
+      <trans-unit id="Package List">
+        <source>Package List</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1602,7 +1602,7 @@ public class ActionManager extends BaseManager {
             name = "Package Removal";
         }
         else if (type.equals(ActionFactory.TYPE_PACKAGES_UPDATE)) {
-            name = "Package Install";
+            name = "Package Install/Upgrade";
         }
         else if (type.equals(ActionFactory.TYPE_PACKAGES_VERIFY)) {
             name = "Package Verify";

--- a/java/code/webapp/WEB-INF/nav/action_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/action_detail.xml
@@ -13,10 +13,7 @@
   <rhn-tab name="Failed Systems">
     <rhn-tab-url>/rhn/schedule/FailedSystems.do</rhn-tab-url>
   </rhn-tab>
-  <rhn-tab name="Remove Packages" acl="generic_action_type(remove)">
-    <rhn-tab-url>/rhn/schedule/PackageList.do</rhn-tab-url>
-  </rhn-tab>
-  <rhn-tab name="Update Packages" acl="generic_action_type(install)">
+  <rhn-tab name="Package List" acl="generic_action_type(remove) or generic_action_type(install)">
     <rhn-tab-url>/rhn/schedule/PackageList.do</rhn-tab-url>
   </rhn-tab>
 </rhn-navi-tree>


### PR DESCRIPTION
There is an inconsistent action description on `package install` and `package upgrade` since the action at the core of the functionality is the same, but the action description says `install` and the package tab says `update`.
This pull request remove this inconsistency and join the separate tab creation on `package remove` to a unique generic tab because the title already explains the action and the tab contains just a list of packages.

BEFORE:
![screenshot from 2015-06-19 09 45 28](https://cloud.githubusercontent.com/assets/7080830/11147308/4c1c217c-8a15-11e5-99f3-03ce7220000d.png)

AFTER:
![screenshot from 2015-11-13 07 36 10](https://cloud.githubusercontent.com/assets/7080830/11151421/549cd7ca-8a2d-11e5-890f-d5670863baa9.png)
