### PR TITLE
Use non-immediate errata cache rebuilding on channel unsubscription

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -738,7 +738,7 @@ ORDER BY UPPER(C.name)
 
 <callable-mode name="unsubscribe_server_from_channel">
   <query params="server_id, channel_id">
-      {call rhn_channel.unsubscribe_server(:server_id, :channel_id)}
+      {call rhn_channel.unsubscribe_server(:server_id, :channel_id, 0)}
   </query>
 </callable-mode>
 


### PR DESCRIPTION
Uniform behavior with channel subscription, helps with performance of the API endpoint.