### PR TITLE
Unentitled systems fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2197,6 +2197,45 @@ select a.id
   </query>
 </mode>
 
+<mode name="count_systems_in_set_without_entitlement">
+  <query params="user_id, set_label, entitlement_label">
+    SELECT COUNT(*) as count
+      FROM rhnSet
+        LEFT JOIN rhnServerEntitlementView ON rhnSet.element = rhnServerEntitlementView.server_id
+      WHERE rhnSet.user_id = :user_id AND
+        rhnSet.label = :set_label AND
+        (rhnServerEntitlementView.is_base IS NULL OR rhnServerEntitlementView.is_base = 'Y') AND
+        (rhnServerEntitlementView.label IS NULL OR rhnServerEntitlementView.label &lt;&gt; :entitlement_label)
+  </query>
+</mode>
+
+<mode name="count_systems_in_set_without_feature">
+  <query params="user_id, set_label, feature_label">
+    SELECT COUNT(*) as count
+      FROM rhnSet
+      WHERE
+        rhnSet.user_id = :user_id AND
+        rhnSet.label = :set_label AND (
+          SELECT COUNT(*)
+            FROM rhnServerFeaturesView
+            WHERE rhnSet.element = rhnServerFeaturesView.server_id
+              AND rhnServerFeaturesView.label = :feature_label
+        ) = 0;
+  </query>
+</mode>
+
+<mode name="entitled_systems_in_set" class="com.redhat.rhn.frontend.dto.SystemOverview">
+  <query params="user_id, set_label">
+    SELECT rhnServer.id, rhnServer.name
+      FROM rhnServerEntitlementView
+        JOIN rhnSet ON rhnServerEntitlementView.server_id = rhnSet.element
+        JOIN rhnServer ON rhnServerEntitlementView.server_id = rhnServer.id
+      WHERE rhnSet.user_id = :user_id AND
+        rhnSet.label = :set_label AND
+        rhnServerEntitlementView.label IN (%s)
+  </query>
+</mode>
+
 <mode name="systems_in_set_with_tag">
   <query params="user_id, tag_id">
 SELECT * FROM (

--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -178,7 +178,39 @@ public class Access extends BaseHandler {
     }
 
     /**
-     * Check if a system has a management entitlement
+     * Check if all systems in the current system have a certain entitlement.
+     * @param ctx Context map to pass in.
+     * @param params Parameters to use to fetch from context.
+     * @return true if at all systems in the set have the entitlement passed as params[0]
+     */
+    @SuppressWarnings("unchecked")
+    public boolean aclAllSystemsInSetHaveEntitlement(Object ctx,
+            String[] params) {
+        Map<String, Object> map = (Map<String, Object>) ctx;
+        User user = (User) map.get("user");
+
+        return SystemManager.countSystemsInSetWithoutEntitlement(user,
+                RhnSetDecl.SYSTEMS.getLabel(), params[0]) == 0;
+    }
+
+    /**
+     * Check if all systems in the current system have a certain feature.
+     * @param ctx Context map to pass in.
+     * @param params Parameters to use to fetch from context.
+     * @return true if at all systems in the set have the feature passed as params[0]
+     */
+    @SuppressWarnings("unchecked")
+    public boolean aclAllSystemsInSetHaveFeature(Object ctx,
+            String[] params) {
+        Map<String, Object> map = (Map<String, Object>) ctx;
+        User user = (User) map.get("user");
+
+        return SystemManager.countSystemsInSetWithoutFeature(user,
+                RhnSetDecl.SYSTEMS.getLabel(), params[0]) == 0;
+    }
+
+    /**
+     * Check if any system has a management entitlement
      * @param ctx Context map to pass in.
      * @param params Parameters to use to fetch from context.
      * @return True if system has management entitlement, false otherwise.

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -14809,6 +14809,9 @@ any of these revisions.  Are you sure you want to do this?</source>
         <trans-unit id="ssm.provisioning.powermanagement.cobbler_error">
           <source>Unexpected Cobbler error, please check server and Cobbler logs.</source>
         </trans-unit>
+        <trans-unit id="ssm.overview.management.notice">
+          <source>At least one system in the set does not have the management entitlement: some actions will not be available.</source>
+        </trans-unit>
         <!-- SSM Tag Systems -->
         <trans-unit id="ssm.operations.provisioning.tagsystems.header">
           <source>Tag Systems</source>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3337,11 +3337,16 @@ public class SystemHandler extends BaseHandler {
         Server server = SystemManager.lookupByIdAndUser(new Long(sid.longValue()),
                 loggedInUser);
 
-        Action a = ActionManager.scheduleHardwareRefreshAction(loggedInUser, server,
-                earliestOccurrence);
-        Action action = ActionFactory.save(a);
+        try {
+            Action a = ActionManager.scheduleHardwareRefreshAction(loggedInUser, server,
+                    earliestOccurrence);
+            Action action = ActionFactory.save(a);
 
-        return action.getId();
+            return action.getId();
+        }
+        catch (MissingEntitlementException e) {
+            throw new com.redhat.rhn.frontend.xmlrpc.MissingEntitlementException();
+        }
     }
 
     /**
@@ -3364,11 +3369,16 @@ public class SystemHandler extends BaseHandler {
         Server server = SystemManager.lookupByIdAndUser(new Long(sid.longValue()),
                 loggedInUser);
 
-        Action a = ActionManager.schedulePackageRefresh(loggedInUser, server,
-                earliestOccurrence);
-        ActionFactory.save(a);
+        try {
+            Action a = ActionManager.schedulePackageRefresh(loggedInUser, server,
+                    earliestOccurrence);
+            ActionFactory.save(a);
 
-        return a.getId().intValue();
+            return a.getId().intValue();
+        }
+        catch (MissingEntitlementException e) {
+            throw new com.redhat.rhn.frontend.xmlrpc.MissingEntitlementException();
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -1270,6 +1270,50 @@ public class SystemManager extends BaseManager {
     }
 
     /**
+     * Returns a count of systems without a certain entitlement in a set.
+     *
+     * @param user user making the request
+     * @param setLabel label of the set
+     * @param entitlementLabel label of the entitlement
+     * @return number of systems in the set without the entitlement
+     */
+    public static int countSystemsInSetWithoutEntitlement(User user, String setLabel,
+        String entitlementLabel) {
+        SelectMode m = ModeFactory.getMode("System_queries",
+                "count_systems_in_set_without_entitlement");
+
+        Map params = new HashMap();
+        params.put("user_id", user.getId());
+        params.put("set_label", setLabel);
+        params.put("entitlement_label", entitlementLabel);
+
+        DataResult dr = makeDataResult(params, null, null, m);
+        return ((Long)((HashMap)dr.get(0)).get("count")).intValue();
+    }
+
+    /**
+     * Returns a count of systems without a certain feature in a set.
+     *
+     * @param user user making the request
+     * @param setLabel label of the set
+     * @param featureLabel label of the feature
+     * @return number of systems in the set without the feature
+     */
+    public static int countSystemsInSetWithoutFeature(User user, String setLabel,
+        String featureLabel) {
+        SelectMode m = ModeFactory.getMode("System_queries",
+                "count_systems_in_set_without_feature");
+
+        Map params = new HashMap();
+        params.put("user_id", user.getId());
+        params.put("set_label", setLabel);
+        params.put("feature_label", featureLabel);
+
+        DataResult dr = makeDataResult(params, null, null, m);
+        return ((Long)((HashMap)dr.get(0)).get("count")).intValue();
+    }
+
+    /**
      * Returns true if server has capability.
      * @param sid Server id
      * @param capability capability

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -86,6 +86,7 @@ import org.hibernate.Hibernate;
 import org.hibernate.Session;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1096,5 +1097,71 @@ public class SystemManagerTest extends RhnBaseTestCase {
 
     }
 
+    public void testCountSystemsInSetWithoutEntitlement() throws Exception {
+        User user = UserTestUtils.findNewUser("testUser", "testOrg" +
+            this.getClass().getSimpleName());
 
+        String setLabel = TestUtils.randomString();
+        int actual = SystemManager.countSystemsInSetWithoutEntitlement(user, setLabel,
+                        EntitlementManager.ENTERPRISE_ENTITLED);
+        assertEquals(0, actual);
+
+        Server server = ServerFactoryTest.createTestServer(user, true,
+            ServerConstants.getServerGroupTypeEnterpriseEntitled());
+
+        RhnSet set = RhnSetManager.createSet(user.getId(), setLabel, SetCleanup.NOOP);
+        set.addElement(server.getId());
+        RhnSetManager.store(set);
+
+        actual = SystemManager.countSystemsInSetWithoutEntitlement(user, setLabel,
+                        EntitlementManager.ENTERPRISE_ENTITLED);
+        assertEquals(0, actual);
+
+        Server unentitledServer = ServerFactoryTest.createUnentitledTestServer(user, true,
+                        ServerFactoryTest.TYPE_SERVER_NORMAL, new Date());
+        set.addElement(unentitledServer.getId());
+        RhnSetManager.store(set);
+
+        actual = SystemManager.countSystemsInSetWithoutEntitlement(user, setLabel,
+                        EntitlementManager.ENTERPRISE_ENTITLED);
+        assertEquals(1, actual);
+
+        actual = SystemManager.countSystemsInSetWithoutEntitlement(user, "non matching",
+                        EntitlementManager.ENTERPRISE_ENTITLED);
+        assertEquals(0, actual);
+    }
+
+    public void testCountSystemsInSetWithoutFeature() throws Exception {
+        User user = UserTestUtils.findNewUser("testUser", "testOrg" +
+            this.getClass().getSimpleName());
+
+        String setLabel = TestUtils.randomString();
+        int actual = SystemManager.countSystemsInSetWithoutEntitlement(user, setLabel,
+                        EntitlementManager.ENTERPRISE_ENTITLED);
+        assertEquals(0, actual);
+
+        Server server = ServerFactoryTest.createTestServer(user, true,
+            ServerConstants.getServerGroupTypeEnterpriseEntitled());
+
+        RhnSet set = RhnSetManager.createSet(user.getId(), setLabel, SetCleanup.NOOP);
+        set.addElement(server.getId());
+        RhnSetManager.store(set);
+
+        actual = SystemManager.countSystemsInSetWithoutFeature(user, setLabel,
+                        "ftr_kickstart");
+        assertEquals(0, actual);
+
+        Server unentitledServer = ServerFactoryTest.createUnentitledTestServer(user, true,
+                        ServerFactoryTest.TYPE_SERVER_NORMAL, new Date());
+        set.addElement(unentitledServer.getId());
+        RhnSetManager.store(set);
+
+        actual = SystemManager.countSystemsInSetWithoutEntitlement(user, setLabel,
+                        "ftr_kickstart");
+        assertEquals(1, actual);
+
+        actual = SystemManager.countSystemsInSetWithoutEntitlement(user, "non matching",
+                        "ftr_kickstart");
+        assertEquals(0, actual);
+    }
 }

--- a/java/code/webapp/WEB-INF/nav/ssm.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm.xml
@@ -4,11 +4,11 @@
     <rhn-tab name="Systems">
         <rhn-tab-url>/rhn/systems/ssm/ListSystems.do</rhn-tab-url>
     </rhn-tab>
-    <rhn-tab name="Errata">
+    <rhn-tab name="Errata" acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
         <rhn-tab-url>/rhn/systems/ssm/ListErrata.do</rhn-tab-url>
     </rhn-tab>
 
-   <rhn-tab name="Packages">
+   <rhn-tab name="Packages" acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
             <rhn-tab-url>/rhn/ssm/Packages.do</rhn-tab-url>
             <rhn-tab name="Install">
                 <rhn-tab-url>/rhn/ssm/PackageInstall.do</rhn-tab-url>
@@ -24,13 +24,13 @@
             </rhn-tab>
    </rhn-tab>
 
-    <rhn-tab name="Groups" acl="user_role(org_admin)">
+    <rhn-tab name="Groups" acl="user_role(org_admin); all_systems_in_set_have_entitlement(enterprise_entitled)">
         <rhn-tab-url>/rhn/systems/ssm/groups/Manage.do</rhn-tab-url>
         <rhn-tab-url>/rhn/systems/ssm/groups/Confirm.do</rhn-tab-url>
         <rhn-tab-url>/rhn/systems/ssm/groups/Create.do</rhn-tab-url>
     </rhn-tab>
 
-        <rhn-tab name="Channels">
+        <rhn-tab name="Channels" acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
             <rhn-tab-url>/rhn/channel/ssm/ChildSubscriptions.do</rhn-tab-url>
             <rhn-tab name="Base Channels">
                 <rhn-tab-url>/rhn/channel/ssm/BaseChannelSubscribe.do</rhn-tab-url>
@@ -41,7 +41,8 @@
             </rhn-tab>
         </rhn-tab>
 
-        <rhn-tab name="ssm.nav.config" url="/rhn/systems/ssm/config/Deploy.do">
+        <rhn-tab name="ssm.nav.config" url="/rhn/systems/ssm/config/Deploy.do"
+                 acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
           <rhn-tab-directory>/rhn/systems/ssm/config</rhn-tab-directory>
           <rhn-tab name="ssm.nav.config.deploy" url="/rhn/systems/ssm/config/Deploy.do">
             <rhn-tab-url>/rhn/systems/ssm/config/DeploySubmit.do</rhn-tab-url>
@@ -69,16 +70,16 @@
           </rhn-tab>
         </rhn-tab>
 
-        <rhn-tab name="Provisioning" url="/rhn/systems/ssm/kickstart/KickstartableSystems.do">
+        <rhn-tab name="Provisioning" url="/rhn/systems/ssm/kickstart/KickstartableSystems.do" acl="all_systems_in_set_have_feature(ftr_kickstart)">
           <rhn-tab name="Kickstart" url="/rhn/systems/ssm/kickstart/KickstartableSystems.do" >
                 <rhn-tab-url>/rhn/systems/ssm/kickstart/ScheduleByProfile.do</rhn-tab-url>
                 <rhn-tab-url>/rhn/systems/ssm/kickstart/ScheduleByIp.do</rhn-tab-url>
           </rhn-tab>
-          <rhn-tab name="Tag Systems" url="/rhn/systems/ssm/provisioning/TagSystems.do" />
-          <rhn-tab name="Rollback" url="/rhn/systems/ssm/provisioning/Rollback.do">
+          <rhn-tab name="Tag Systems" url="/rhn/systems/ssm/provisioning/TagSystems.do" acl="all_systems_in_set_have_entitlement(enterprise_entitled)"/>
+          <rhn-tab name="Rollback" url="/rhn/systems/ssm/provisioning/Rollback.do"  acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
             <rhn-tab-url>/rhn/systems/ssm/provisioning/RollbackToTag.do</rhn-tab-url>
           </rhn-tab>
-          <rhn-tab name="Remote Command" url="/rhn/systems/ssm/provisioning/RemoteCommand.do">
+          <rhn-tab name="Remote Command" url="/rhn/systems/ssm/provisioning/RemoteCommand.do" acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
               <rhn-tab-url>/rhn/systems/ssm/provisioning/RemoteCommand.do</rhn-tab-url>
           </rhn-tab>
           <rhn-tab name="Power Management Configuration" url="/rhn/systems/ssm/provisioning/PowerManagementConfiguration.do">
@@ -89,12 +90,12 @@
           </rhn-tab>
         </rhn-tab>
 
-        <rhn-tab name="Audit">
+        <rhn-tab name="Audit" acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
                 <rhn-tab-url>/rhn/systems/ssm/audit/ScheduleXccdf.do</rhn-tab-url>
                 <rhn-tab-url>/rhn/systems/ssm/audit/ScheduleXccdfSubmit.do</rhn-tab-url>
         </rhn-tab>
 
-        <rhn-tab name="Misc" url="/rhn/systems/ssm/misc/Index.do">
+        <rhn-tab name="Misc" url="/rhn/systems/ssm/misc/Index.do" acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
             <rhn-tab name="ssm.misc.index.tabs.hardware" url="/rhn/systems/ssm/misc/HardwareRefresh.do"/>
             <rhn-tab name="ssm.misc.index.tabs.software" url="/rhn/systems/ssm/misc/SoftwareRefresh.do"/>
             <rhn-tab name="ssm.misc.index.tabs.migrate" url="/rhn/systems/ssm/MigrateSystems.do"/>
@@ -103,5 +104,10 @@
             <rhn-tab name="ssm.misc.index.tabs.delete" url="/rhn/systems/ssm/DeleteConfirm.do"/>
             <rhn-tab-url>/rhn/systems/ssm/misc/ConfirmSystemPreferences.do</rhn-tab-url>
             <rhn-tab-url>/rhn/systems/ssm/DeleteConfirm.do</rhn-tab-url>
+	</rhn-tab>
+
+        <rhn-tab name="Misc" url="/rhn/systems/ssm/MigrateSystems.do" acl="not all_systems_in_set_have_entitlement(enterprise_entitled)">
+            <rhn-tab name="ssm.misc.index.tabs.migrate" url="/rhn/systems/ssm/MigrateSystems.do"/>
+            <rhn-tab name="ssm.misc.index.tabs.delete" url="/rhn/systems/ssm/DeleteConfirm.do"/>
         </rhn-tab>
 </rhn-navi-tree>

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -29,7 +29,7 @@
     </rhn-tab>
   </rhn-tab>
 
-  <rhn-tab name="Software" url="/rhn/systems/details/packages/Packages.do">
+  <rhn-tab name="Software" acl="system_has_management_entitlement()"  url="/rhn/systems/details/packages/Packages.do">
 
     <rhn-tab name="Errata" acl="system_feature(ftr_errata_updates)">
       <rhn-tab-url>/rhn/systems/details/ErrataList.do</rhn-tab-url>
@@ -72,7 +72,7 @@
       <rhn-tab-url>/rhn/systems/details/SystemChannels.do</rhn-tab-url>
     </rhn-tab>
 
-    <rhn-tab name="Software Crashes">
+    <rhn-tab name="Software Crashes" acl="system_has_management_entitlement()">
       <rhn-tab-url>/rhn/systems/details/SoftwareCrashes.do</rhn-tab-url>
       <rhn-tab-url>/rhn/systems/details/SoftwareCrashDetail.do</rhn-tab-url>
       <rhn-tab-url>/rhn/systems/details/SoftwareCrashDelete.do</rhn-tab-url>
@@ -175,7 +175,7 @@
     <rhn-tab name="Images" url="/rhn/systems/details/virtualization/Images.do"/>
   </rhn-tab>
 
-  <rhn-tab name="Audit">
+  <rhn-tab name="Audit" acl="system_has_management_entitlement()">
     <rhn-tab-url>/rhn/systems/details/audit/ListScap.do</rhn-tab-url>
     <rhn-tab name="nav.system.audit.list_scans">
       <rhn-tab-url>/rhn/systems/details/audit/ListScap.do</rhn-tab-url>

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -162,8 +162,7 @@
     </rhn-tab>
   </rhn-tab>
 
-  <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin)" url="/rhn/systems/details/groups/ListRemove.do">
-
+  <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin);system_has_management_entitlement()" url="/rhn/systems/details/groups/ListRemove.do">
     <rhn-tab name="List / Leave" url="/rhn/systems/details/groups/ListRemove.do"/>
     <rhn-tab name="Join" url="/rhn/systems/details/groups/Add.do"/>
   </rhn-tab>
@@ -188,7 +187,7 @@
     </rhn-tab>
   </rhn-tab>
 
-  <rhn-tab name="Events">
+  <rhn-tab name="Events" acl="system_has_management_entitlement()">
     <rhn-tab-url>/rhn/systems/details/history/Pending.do</rhn-tab-url>
     <rhn-tab-url>/rhn/systems/details/history/Event.do</rhn-tab-url>
     <rhn-tab name="Pending">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/ks-wizard.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/ks-wizard.jspf
@@ -41,7 +41,9 @@
                 <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/proxy-options.jspf" %>
 
         <c:if test="${requestScope.hasProfiles == 'true'}">
+          <rhn:require acl="system_has_management_entitlement()">
                 <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/schedule-options.jspf" %>
+          </rhn:require>
           <table width="100%">
             <tr>
               <td align="right">
@@ -50,8 +52,10 @@
                         value="<bean:message key='kickstart.schedule.button0.jsp'/>"
                         onclick="setStep('fourth');this.form.submit();" />
                           </c:if>
+                <rhn:require acl="system_has_management_entitlement()">
                 <input type="button" class="btn btn-default" value="<bean:message key='kickstart.schedule.button1.jsp'/>" onclick="setStep('second');this.form.submit();" />
                 <input type="button" class="btn btn-default" value="<bean:message key='kickstart.schedule.button2.jsp'/>" onclick="setStep('third');this.form.submit();" />
+                </rhn:require>
               </td>
             </tr>
           </table>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/ssm/header.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/ssm/header.jspf
@@ -2,6 +2,12 @@
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<rhn:require acl="not all_systems_in_set_have_entitlement(enterprise_entitled)">
+  <div class="alert alert-warning">
+    <bean:message key="ssm.overview.management.notice" />
+  </div>
+</rhn:require>
+
 <rhn:toolbar base="h1"
     icon="header-system-groups"
         imgAlt="ssm.jsp.imgAlt"

--- a/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
@@ -29,75 +29,81 @@
                 </div>
             </div>
         </li>
-        <li class="list-group-item">
-            <div class="row">
-                <div class="col-sm-2">
-                    <rhn:icon type="header-errata" title="ssm.overview.errata" />
-                    <bean:message key="ssm.overview.errata"/>
-                </div>
-                <div class="col-sm-10">
-                    <bean:message key="ssm.overview.errata.schedule"/>
-                </div>
-            </div>
-        </li>
-        <li class="list-group-item">
-            <div class="row">
-                <div class="col-sm-2">
-                  <rhn:icon type="header-package" title="ssm.overview.packages" />
-                    <bean:message key="ssm.overview.packages"/>
-                </div>
-                <div class="col-sm-10">
-                    <bean:message key="ssm.overview.packages.upgrade"/>
-                </div>
-            </div>
-        </li>
-        <rhn:require acl="user_role(org_admin)">
+        <rhn:require acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
             <li class="list-group-item">
                 <div class="row">
                     <div class="col-sm-2">
-                      <rhn:icon type="header-system-groups" title="ssm.overview.groups" />
-                        <bean:message key="ssm.overview.groups"/>
+                        <rhn:icon type="header-errata" title="ssm.overview.errata" />
+                        <bean:message key="ssm.overview.errata"/>
                     </div>
                     <div class="col-sm-10">
-                        <bean:message key="ssm.overview.groups.create"/>
+                        <bean:message key="ssm.overview.errata.schedule"/>
+                    </div>
+                </div>
+            </li>
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-sm-2">
+                      <rhn:icon type="header-package" title="ssm.overview.packages" />
+                        <bean:message key="ssm.overview.packages"/>
+                    </div>
+                    <div class="col-sm-10">
+                        <bean:message key="ssm.overview.packages.upgrade"/>
+                    </div>
+                </div>
+            </li>
+            <rhn:require acl="user_role(org_admin)">
+                <li class="list-group-item">
+                    <div class="row">
+                        <div class="col-sm-2">
+                          <rhn:icon type="header-system-groups" title="ssm.overview.groups" />
+                            <bean:message key="ssm.overview.groups"/>
+                        </div>
+                        <div class="col-sm-10">
+                            <bean:message key="ssm.overview.groups.create"/>
+                        </div>
+                    </div>
+                </li>
+            </rhn:require>
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-sm-2">
+                      <rhn:icon type="header-channel" title="ssm.overview.channels" />
+                        <bean:message key="ssm.overview.channels"/>
+                    </div>
+                    <div class="col-sm-10">
+                        <ul>
+                            <li><bean:message key="ssm.overview.channels.memberships"/></li>
+                            <rhn:require acl="user_role(config_admin)">
+                              <li><bean:message key="ssm.overview.channels.subscriptions"/></li>
+                              <li><bean:message key="ssm.overview.channels.deploy"/></li>
+                            </rhn:require>
+                        </ul>
                     </div>
                 </div>
             </li>
         </rhn:require>
-        <li class="list-group-item">
-            <div class="row">
-                <div class="col-sm-2">
-                  <rhn:icon type="header-channel" title="ssm.overview.channels" />
-                    <bean:message key="ssm.overview.channels"/>
+        <rhn:require acl="all_systems_in_set_have_feature(ftr_kickstart)">
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-sm-2">
+                      <rhn:icon type="header-kickstart" title="ssm.overview.provisioning" />
+                        <bean:message key="ssm.overview.provisioning"/>
+                    </div>
+                    <div class="col-sm-10">
+                        <ul>
+                            <li><bean:message key="ssm.overview.provisioning.kickstart"/></li>
+                            <rhn:require acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
+                                <li><bean:message key="ssm.overview.provisioning.rollback"/></li>
+                                <li><bean:message key="ssm.overview.provisioning.remotecommands"/></li>
+                            </rhn:require>
+                            <li><bean:message key="ssm.overview.provisioning.powermanagement.configure"/></li>
+                            <li><bean:message key="ssm.overview.provisioning.powermanagement.operations"/></li>
+                        </ul>
+                    </div>
                 </div>
-                <div class="col-sm-10">
-                    <ul>
-                        <li><bean:message key="ssm.overview.channels.memberships"/></li>
-                        <rhn:require acl="user_role(config_admin)">
-                          <li><bean:message key="ssm.overview.channels.subscriptions"/></li>
-                          <li><bean:message key="ssm.overview.channels.deploy"/></li>
-                        </rhn:require>
-                    </ul>
-                </div>
-            </div>
-        </li>
-        <li class="list-group-item">
-            <div class="row">
-                <div class="col-sm-2">
-                  <rhn:icon type="header-kickstart" title="ssm.overview.provisioning" />
-                    <bean:message key="ssm.overview.provisioning"/>
-                </div>
-                <div class="col-sm-10">
-                    <ul>
-                        <li><bean:message key="ssm.overview.provisioning.kickstart"/></li>
-                        <li><bean:message key="ssm.overview.provisioning.rollback"/></li>
-                        <li><bean:message key="ssm.overview.provisioning.remotecommands"/></li>
-                        <li><bean:message key="ssm.overview.provisioning.powermanagement.configure"/></li>
-                        <li><bean:message key="ssm.overview.provisioning.powermanagement.operations"/></li>
-                    </ul>
-                </div>
-            </div>
-        </li>
+            </li>
+        </rhn:require>
         <li class="list-group-item">
             <div class="row">
                 <div class="col-sm-2">
@@ -106,22 +112,29 @@
                 </div>
                 <div class="col-sm-10">
                     <ul>
-                        <li><bean:message key="ssm.overview.misc.updateprofiles"/></li>
-                        <li><bean:message key="ssm.overview.misc.customvalues"/></li>
-                        <rhn:require acl="user_role(org_admin)">
+                        <rhn:require acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
+                            <li><bean:message key="ssm.overview.misc.updateprofiles"/></li>
+                        </rhn:require>
+                        <rhn:require acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
+                          <li><bean:message key="ssm.overview.misc.customvalues"/></li>
+                        </rhn:require>
+                        <rhn:require acl="user_role(org_admin); all_systems_in_set_have_entitlement(enterprise_entitled)">
                             <li><bean:message key="ssm.overview.misc.entitlements"/></li>
                         </rhn:require>
                         <li><bean:message key="ssm.overview.misc.delete"/></li>
-                        <li><bean:message key="ssm.overview.misc.reboot"/></li>
+                        <rhn:require acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
+                            <li><bean:message key="ssm.overview.misc.reboot"/></li>
+                        </rhn:require>
                         <li><bean:message key="ssm.overview.misc.migrate"/></li>
-                        <li><bean:message key="ssm.overview.misc.lock"/></li>
-                        <li><bean:message key="ssm.overview.misc.scap"/></li>
+                        <rhn:require acl="all_systems_in_set_have_entitlement(enterprise_entitled)">
+                            <li><bean:message key="ssm.overview.misc.lock"/></li>
+                            <li><bean:message key="ssm.overview.misc.scap"/></li>
+                        </rhn:require>
                     </ul>
                 </div>
             </div>
         </li>
     </ul>
- 
 </div>
 
 </body>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/details.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/details.jsp
@@ -74,56 +74,58 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
-                        <label class="col-lg-3 control-label">
-                            <bean:message key="sdc.details.edit.notifications"/>
-                        </label>
-                        <div class="col-lg-6">
-                            <c:choose>
-                                <c:when test="${notifications_disabled}">
-                                    <bean:message key="sdc.details.overview.notifications.disabled"/>
-                                </c:when>
-                                <c:when test="${system.baseEntitlement == null}">
-                                    <bean:message key="sdc.details.edit.notifications.unentitled"/>
-                                </c:when>
-                                <c:otherwise>
-                                    <div class="checkbox">
-                                        <label for="receive_notifications">
-                                            <html:checkbox property="receive_notifications" styleId="receive_notifications"/>
-                                            <strong><bean:message key="sdc.details.edit.updates"/></strong>
-                                        </label>
-                                    </div>
-                                    <div class="checkbox">
-                                        <label for="summary">
-                                            <html:checkbox property="include_in_daily_summary" styleId="summary"/>
-                                            <strong><bean:message key="sdc.details.edit.summary"/></strong>
-                                        </label>
-                                    </div>
-                                </c:otherwise>
-                            </c:choose>
+                    <rhn:require acl="system_has_management_entitlement()">
+                        <div class="form-group">
+                            <label class="col-lg-3 control-label">
+                                <bean:message key="sdc.details.edit.notifications"/>
+                            </label>
+                            <div class="col-lg-6">
+                                <c:choose>
+                                    <c:when test="${notifications_disabled}">
+                                        <bean:message key="sdc.details.overview.notifications.disabled"/>
+                                    </c:when>
+                                    <c:when test="${system.baseEntitlement == null}">
+                                        <bean:message key="sdc.details.edit.notifications.unentitled"/>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <div class="checkbox">
+                                            <label for="receive_notifications">
+                                                <html:checkbox property="receive_notifications" styleId="receive_notifications"/>
+                                                <strong><bean:message key="sdc.details.edit.updates"/></strong>
+                                            </label>
+                                        </div>
+                                        <div class="checkbox">
+                                            <label for="summary">
+                                                <html:checkbox property="include_in_daily_summary" styleId="summary"/>
+                                                <strong><bean:message key="sdc.details.edit.summary"/></strong>
+                                            </label>
+                                        </div>
+                                    </c:otherwise>
+                                </c:choose>
+                            </div>
                         </div>
-                    </div>
 
-                    <div class="form-group">
-                        <label class="col-lg-3 control-label" for="autoerrataupdate">
-                            <bean:message key="sdc.details.edit.autoerrataupdate"/>
-                        </label>
-                        <div class="col-lg-6">
-                            <c:choose>
-                                <c:when test="${system.baseEntitlement == null}">
-                                    <bean:message key="sdc.details.edit.autoupdate.unentitled"/>
-                                </c:when>
-                                <c:otherwise>
-                                    <div class="checkbox">
-                                        <label for="autoerrataupdate">
-                                            <html:checkbox property="auto_update" styleId="autoerrataupdate"/>
-                                            <bean:message key="sdc.details.edit.autoupdate"/>
-                                        </label>
-                                    </div>
-                                </c:otherwise>
-                            </c:choose>
+                        <div class="form-group">
+                            <label class="col-lg-3 control-label" for="autoerrataupdate">
+                                <bean:message key="sdc.details.edit.autoerrataupdate"/>
+                            </label>
+                            <div class="col-lg-6">
+                                <c:choose>
+                                    <c:when test="${system.baseEntitlement == null}">
+                                        <bean:message key="sdc.details.edit.autoupdate.unentitled"/>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <div class="checkbox">
+                                            <label for="autoerrataupdate">
+                                                <html:checkbox property="auto_update" styleId="autoerrataupdate"/>
+                                                <bean:message key="sdc.details.edit.autoupdate"/>
+                                            </label>
+                                        </div>
+                                    </c:otherwise>
+                                </c:choose>
+                            </div>
                         </div>
-                    </div>
+                    </rhn:require>
 
                     <div class="form-group">
                         <label for="description" class="col-lg-3 control-label">

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
@@ -1,622 +1,528 @@
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://rhn.redhat.com/tags/list" prefix="rl" %>
-<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
-<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://rhn.redhat.com/tags/list" prefix="rl"%>
+<%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
+<%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 
 <html:html>
-  <body>
-    <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
-    <html:form method="post"
-    action="/systems/details/SystemHardware.do?sid=${sid}">
-    <rhn:require acl="system_has_management_entitlement()">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h4>
-          <bean:message key="sdc.details.hardware.header" />
-        </h4>
-      </div>
-      <div class="panel-body">
-        <bean:message key="sdc.details.hardware.refresh" />
-          <rhn:csrf />
-          <html:hidden property="submitted" value="true" />
-          <div class="text-right margin-bottom-sm">
-            <html:submit styleClass="btn btn-default">
-              <bean:message key="sdc.details.hardware.schedule" />
-            </html:submit>
-          </div>
-        </div>
-      </div>
-    </rhn:require>
+<body>
+    <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf"%>
+    <html:form method="post" action="/systems/details/SystemHardware.do?sid=${sid}">
+        <rhn:require acl="system_has_management_entitlement()">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.header" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <bean:message key="sdc.details.hardware.refresh" />
+                    <rhn:csrf />
+                    <html:hidden property="submitted" value="true" />
+                    <div class="text-right margin-bottom-sm">
+                        <html:submit styleClass="btn btn-default">
+                            <bean:message key="sdc.details.hardware.schedule" />
+                        </html:submit>
+                    </div>
+                </div>
+            </div>
+        </rhn:require>
 
-          <div class="panel panel-default">
+        <div class="panel panel-default">
             <div class="panel-heading">
-              <h4>
-                <bean:message key="sdc.details.hardware.general" />
-              </h4>
+                <h4>
+                    <bean:message key="sdc.details.hardware.general" />
+                </h4>
             </div>
             <div class="panel-body">
-              <c:if test="${cpu_mhz != null}">(${cpu_count})
+                <c:if test="${cpu_mhz != null}">(${cpu_count})
               ${cpu_model} (${cpu_mhz} MHz)</c:if>
-              <table class="table table-condensed">
-                <tr>
-                  <th>
-                    <bean:message key="sdc.details.hardware.arch" />
-                  </th>
-                  <td>${cpu_arch}</td>
-                  <th>
-                    <bean:message key="sdc.details.hardware.sockets" />
-                  </th>
-                  <td>${cpu_sockets}</td>
-                  <th>
-                    <bean:message key="sdc.details.hardware.cache" />
-                  </th>
-                  <td>${cpu_cache}</td>
-                </tr>
-                <tr>
-                  <th>
-                    <bean:message key="sdc.details.hardware.vendor" />
-                  </th>
-                  <td>${cpu_vendor}</td>
-                  <th>
-                    <bean:message key="sdc.details.hardware.cores" />
-                  </th>
-                  <td>${cpu_cores}</td>
-                  <th>
-                    <bean:message key="sdc.details.hardware.memory" />
-                  </th>
-                  <td>${system_ram} MB</td>
-                </tr>
-                <tr>
-                  <th>
-                    <bean:message key="sdc.details.hardware.family" />
-                  </th>
-                  <td>${cpu_family}</td>
-                  <th>
-                    <bean:message key="sdc.details.hardware.stepping" />
-                  </th>
-                  <td>${cpu_stepping}</td>
-                  <th>
-                    <bean:message key="sdc.details.hardware.swap" />
-                  </th>
-                  <td>${system_swap} MB</td>
-                </tr>
-              </table>
+                <table class="table table-condensed">
+                    <tr>
+                        <th><bean:message key="sdc.details.hardware.arch" /></th>
+                        <td>${cpu_arch}</td>
+                        <th><bean:message key="sdc.details.hardware.sockets" /></th>
+                        <td>${cpu_sockets}</td>
+                        <th><bean:message key="sdc.details.hardware.cache" /></th>
+                        <td>${cpu_cache}</td>
+                    </tr>
+                    <tr>
+                        <th><bean:message key="sdc.details.hardware.vendor" /></th>
+                        <td>${cpu_vendor}</td>
+                        <th><bean:message key="sdc.details.hardware.cores" /></th>
+                        <td>${cpu_cores}</td>
+                        <th><bean:message key="sdc.details.hardware.memory" /></th>
+                        <td>${system_ram}MB</td>
+                    </tr>
+                    <tr>
+                        <th><bean:message key="sdc.details.hardware.family" /></th>
+                        <td>${cpu_family}</td>
+                        <th><bean:message key="sdc.details.hardware.stepping" /></th>
+                        <td>${cpu_stepping}</td>
+                        <th><bean:message key="sdc.details.hardware.swap" /></th>
+                        <td>${system_swap}MB</td>
+                    </tr>
+                </table>
             </div>
-          </div>
-          <c:if test="${empty dmi_vendor}" var="no_vendor" />
-          <c:if test="${empty dmi_bios}" var="no_bios" />
-          <c:if test="${empty dmi_system}" var="no_system" />
-          <c:if test="${empty dmi_product}" var="no_product" />
-          <c:if test="${empty dmi_asset_tag}" var="no_asset_tag" />
-          <c:if test="${empty dmi_board}" var="no_board" />
-          <c:if test="${!(empty dmi_vendor and empty dmi_bios and empty dmi_system and empty dmi_product and empty dmi_asset_tag and empty dmi_board)}">
+        </div>
+        <c:if test="${empty dmi_vendor}" var="no_vendor" />
+        <c:if test="${empty dmi_bios}" var="no_bios" />
+        <c:if test="${empty dmi_system}" var="no_system" />
+        <c:if test="${empty dmi_product}" var="no_product" />
+        <c:if test="${empty dmi_asset_tag}" var="no_asset_tag" />
+        <c:if test="${empty dmi_board}" var="no_board" />
+        <c:if test="${!(empty dmi_vendor and empty dmi_bios and empty dmi_system and empty dmi_product and empty dmi_asset_tag and empty dmi_board)}">
 
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.dmi" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <tr>
-                    <th>
-                      <bean:message key="sdc.details.hardware.dmi_vendor" />
-                    </th>
-                    <td>${dmi_vendor}</td>
-                    <th rowspan="2">
-                      <bean:message key="sdc.details.hardware.dmi_bios" />
-                    </th>
-                    <td rowspan="2">${dmi_bios}</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <bean:message key="sdc.details.hardware.dmi_system" />
-                    </th>
-                    <td>${dmi_system}</td>
-                  </tr>
-                  <tr>
-                    <th rowspan="2">
-                      <bean:message key="sdc.details.hardware.dmi_product" />
-                    </th>
-                    <td rowspan="2">${dmi_product}</td>
-                    <th>
-                      <bean:message key="sdc.details.hardware.dmi_asset_tag" />
-                    </th>
-                    <td>${dmi_asset_tag}</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <bean:message key="sdc.details.hardware.dmi_board" />
-                    </th>
-                    <td>${dmi_board}</td>
-                  </tr>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.dmi" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <tr>
+                            <th><bean:message key="sdc.details.hardware.dmi_vendor" /></th>
+                            <td>${dmi_vendor}</td>
+                            <th rowspan="2"><bean:message key="sdc.details.hardware.dmi_bios" /></th>
+                            <td rowspan="2">${dmi_bios}</td>
+                        </tr>
+                        <tr>
+                            <th><bean:message key="sdc.details.hardware.dmi_system" /></th>
+                            <td>${dmi_system}</td>
+                        </tr>
+                        <tr>
+                            <th rowspan="2"><bean:message key="sdc.details.hardware.dmi_product" /></th>
+                            <td rowspan="2">${dmi_product}</td>
+                            <th><bean:message key="sdc.details.hardware.dmi_asset_tag" /></th>
+                            <td>${dmi_asset_tag}</td>
+                        </tr>
+                        <tr>
+                            <th><bean:message key="sdc.details.hardware.dmi_board" /></th>
+                            <td>${dmi_board}</td>
+                        </tr>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <div class="panel panel-default">
+        </c:if>
+        <div class="panel panel-default">
             <div class="panel-heading">
-              <h4>
-                <bean:message key="sdc.details.hardware.networking" />
-              </h4>
+                <h4>
+                    <bean:message key="sdc.details.hardware.networking" />
+                </h4>
             </div>
             <div class="panel-body">
-              <table class="table table-condensed">
-                <tr>
-                  <th>
-                    <bean:message key="sdc.details.hardware.network_hostname" />
-                  </th>
-                  <td>
-                    <c:choose>
-                      <c:when test="${network_hostname == null}">
-                        <bean:message key="sdc.details.overview.unknown" />
-                      </c:when>
-                      <c:otherwise>
-                        <c:out value="${network_hostname}" />
-                      </c:otherwise>
-                    </c:choose>
-                  </td>
-                </tr>
-                <c:forEach items="${network_cnames}"
-                var="cname_alias" varStatus="loop">
-                  <tr>
-                    <th>
-                      <bean:message key="sdc.details.hardware.network_cname" />
-                    </th>
-                    <td>${cname_alias}</td>
-                  </tr>
-                </c:forEach>
-                <tr>
-                  <th>
-                    <bean:message key="sdc.details.hardware.network_ip_addr" />
-                  </th>
-                  <td>${network_ip_addr}</td>
-                </tr>
-                <tr>
-                  <th>
-                    <bean:message key="sdc.details.hardware.network_ip6_addr" />
-                  </th>
-                  <td>${network_ip6_addr}</td>
-                </tr>
+                <table class="table table-condensed">
+                    <tr>
+                        <th><bean:message key="sdc.details.hardware.network_hostname" /></th>
+                        <td><c:choose>
+                                <c:when test="${network_hostname == null}">
+                                    <bean:message key="sdc.details.overview.unknown" />
+                                </c:when>
+                                <c:otherwise>
+                                    <c:out value="${network_hostname}" />
+                                </c:otherwise>
+                            </c:choose></td>
+                    </tr>
+                    <c:forEach items="${network_cnames}" var="cname_alias" varStatus="loop">
+                        <tr>
+                            <th><bean:message key="sdc.details.hardware.network_cname" /></th>
+                            <td>${cname_alias}</td>
+                        </tr>
+                    </c:forEach>
+                    <tr>
+                        <th><bean:message key="sdc.details.hardware.network_ip_addr" /></th>
+                        <td>${network_ip_addr}</td>
+                    </tr>
+                    <tr>
+                        <th><bean:message key="sdc.details.hardware.network_ip6_addr" /></th>
+                        <td>${network_ip6_addr}</td>
+                    </tr>
 
-                <rhn:require acl="system_has_management_entitlement()">
-                <tr>
-                  <th>
-                    <c:out value="Primary network interface:" />
-                  </th>
-                  <td>
-                    <html:select property="primaryInterface"
-                    styleId="primaryInterface">
-                      <html:options collection="networkInterfaces"
-                      property="value" labelProperty="display" />
-                    </html:select>
-                  </td>
-                </tr>
-                </rhn:require>
+                    <rhn:require acl="system_has_management_entitlement()">
+                        <tr>
+                            <th><c:out value="Primary network interface:" /></th>
+                            <td><html:select property="primaryInterface" styleId="primaryInterface">
+                                    <html:options collection="networkInterfaces" property="value" labelProperty="display" />
+                                </html:select></td>
+                        </tr>
+                    </rhn:require>
 
-              </table>
+                </table>
             </div>
-          </div>
-          <rhn:csrf />
+        </div>
+        <rhn:csrf />
 
-          <rhn:require acl="system_has_management_entitlement()">
-          <div class="text-right margin-bottom-sm">
-            <html:submit property="update_interface"
-            styleClass="btn btn-default">
-              <bean:message key="sdc.details.edit.update" />
-            </html:submit>
-          </div>
-          </rhn:require>
+        <rhn:require acl="system_has_management_entitlement()">
+            <div class="text-right margin-bottom-sm">
+                <html:submit property="update_interface" styleClass="btn btn-default">
+                    <bean:message key="sdc.details.edit.update" />
+                </html:submit>
+            </div>
+        </rhn:require>
 
-          <c:if test="${not empty network_interfaces}">
+        <c:if test="${not empty network_interfaces}">
             <div class="panel panel-default">
-              <div class="panel-body">
-                <table class="table table-condensed" width="90%"
-                cellspacing="0">
-                  <thead>
-                    <tr>
-                      <th>Interface</th>
-                      <th>IP Address</th>
-                      <th>Netmask</th>
-                      <th>Broadcast</th>
-                      <th>Hardware Address</th>
-                      <th>Driver Module</th>
-                    </tr>
-                  </thead>
-                  <c:forEach items="${network_interfaces}"
-                  var="current" varStatus="loop">
-                    <c:choose>
-                      <c:when test="${loop.count % 2 == 0}">
-                        <c:set var="style_class"
-                        value="list-row-even" />
-                      </c:when>
-                      <c:otherwise>
-                        <c:set var="style_class"
-                        value="list-row-odd" />
-                      </c:otherwise>
-                    </c:choose>
-                    <tr class="${style_class}">
-                      <td>${current.name}</td>
-                      <c:choose>
-                        <c:when test="${empty current.ip}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.ip}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <c:choose>
-                        <c:when test="${empty current.netmask}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.netmask}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <c:choose>
-                        <c:when test="${empty current.broadcast}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.broadcast}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <c:choose>
-                        <c:when test="${empty current.hwaddr}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.hwaddr}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <td>${current.module}</td>
-                    </tr>
-                  </c:forEach>
-                </table>
-              </div>
+                <div class="panel-body">
+                    <table class="table table-condensed" width="90%" cellspacing="0">
+                        <thead>
+                            <tr>
+                                <th>Interface</th>
+                                <th>IP Address</th>
+                                <th>Netmask</th>
+                                <th>Broadcast</th>
+                                <th>Hardware Address</th>
+                                <th>Driver Module</th>
+                            </tr>
+                        </thead>
+                        <c:forEach items="${network_interfaces}" var="current" varStatus="loop">
+                            <c:choose>
+                                <c:when test="${loop.count % 2 == 0}">
+                                    <c:set var="style_class" value="list-row-even" />
+                                </c:when>
+                                <c:otherwise>
+                                    <c:set var="style_class" value="list-row-odd" />
+                                </c:otherwise>
+                            </c:choose>
+                            <tr class="${style_class}">
+                                <td>${current.name}</td>
+                                <c:choose>
+                                    <c:when test="${empty current.ip}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.ip}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <c:choose>
+                                    <c:when test="${empty current.netmask}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.netmask}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <c:choose>
+                                    <c:when test="${empty current.broadcast}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.broadcast}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <c:choose>
+                                    <c:when test="${empty current.hwaddr}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.hwaddr}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <td>${current.module}</td>
+                            </tr>
+                        </c:forEach>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty ipv6_network_interfaces}">
+        </c:if>
+        <c:if test="${not empty ipv6_network_interfaces}">
             <div class="panel panel-default">
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th>Interface</th>
-                      <th>IPv6 Address</th>
-                      <th>Netmask</th>
-                      <th>Scope</th>
-                      <th>Hardware Address</th>
-                      <th>Driver Module</th>
-                    </tr>
-                  </thead>
-                  <c:forEach items="${ipv6_network_interfaces}"
-                  var="current" varStatus="loop">
-                    <c:choose>
-                      <c:when test="${loop.count % 2 == 0}">
-                        <c:set var="style_class"
-                        value="list-row-even" />
-                      </c:when>
-                      <c:otherwise>
-                        <c:set var="style_class"
-                        value="list-row-odd" />
-                      </c:otherwise>
-                    </c:choose>
-                    <tr class="${style_class}">
-                      <td>${current.name}</td>
-                      <c:choose>
-                        <c:when test="${empty current.ip6}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.ip6}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <c:choose>
-                        <c:when test="${empty current.netmask}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.netmask}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <c:choose>
-                        <c:when test="${empty current.scope}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.scope}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <c:choose>
-                        <c:when test="${empty current.hwaddr}">
-                          <td>
-                            <span class="no-details">(unknown)</span>
-                          </td>
-                        </c:when>
-                        <c:otherwise>
-                          <td>${current.hwaddr}</td>
-                        </c:otherwise>
-                      </c:choose>
-                      <td>${current.module}</td>
-                    </tr>
-                  </c:forEach>
-                </table>
-              </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Interface</th>
+                                <th>IPv6 Address</th>
+                                <th>Netmask</th>
+                                <th>Scope</th>
+                                <th>Hardware Address</th>
+                                <th>Driver Module</th>
+                            </tr>
+                        </thead>
+                        <c:forEach items="${ipv6_network_interfaces}" var="current" varStatus="loop">
+                            <c:choose>
+                                <c:when test="${loop.count % 2 == 0}">
+                                    <c:set var="style_class" value="list-row-even" />
+                                </c:when>
+                                <c:otherwise>
+                                    <c:set var="style_class" value="list-row-odd" />
+                                </c:otherwise>
+                            </c:choose>
+                            <tr class="${style_class}">
+                                <td>${current.name}</td>
+                                <c:choose>
+                                    <c:when test="${empty current.ip6}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.ip6}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <c:choose>
+                                    <c:when test="${empty current.netmask}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.netmask}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <c:choose>
+                                    <c:when test="${empty current.scope}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.scope}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <c:choose>
+                                    <c:when test="${empty current.hwaddr}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.hwaddr}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <td>${current.module}</td>
+                            </tr>
+                        </c:forEach>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty storageDevices}">
+        </c:if>
+        <c:if test="${not empty storageDevices}">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.storage" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th width="40%">Description</th>
-                      <th width="10%">Bus</th>
-                      <th width="25%">Device</th>
-                      <th width="25%">Physical</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach items="${storageDevices}"
-                    var="current" varStatus="loop">
-                      <c:choose>
-                        <c:when test="${loop.count % 2 == 0}">
-                          <c:set var="style_class"
-                          value="list-row-even" />
-                        </c:when>
-                        <c:otherwise>
-                          <c:set var="style_class"
-                          value="list-row-odd" />
-                        </c:otherwise>
-                      </c:choose>
-                      <tr class="${style_class}">
-                        <td>${current.description}</td>
-                        <td>${current.bus}</td>
-                        <td>${current.device}</td>
-                        <td>${loop.count - 1}</td>
-                      </tr>
-                    </c:forEach>
-                  </tbody>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.storage" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th width="40%">Description</th>
+                                <th width="10%">Bus</th>
+                                <th width="25%">Device</th>
+                                <th width="25%">Physical</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach items="${storageDevices}" var="current" varStatus="loop">
+                                <c:choose>
+                                    <c:when test="${loop.count % 2 == 0}">
+                                        <c:set var="style_class" value="list-row-even" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:set var="style_class" value="list-row-odd" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <tr class="${style_class}">
+                                    <td>${current.description}</td>
+                                    <td>${current.bus}</td>
+                                    <td>${current.device}</td>
+                                    <td>${loop.count - 1}</td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty videoDevices}">
+        </c:if>
+        <c:if test="${not empty videoDevices}">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.video" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th width="40%">Description</th>
-                      <th width="10%">Bus</th>
-                      <th width="10%">Vendor</th>
-                      <th width="40%">Driver</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach items="${videoDevices}"
-                    var="current" varStatus="loop">
-                      <c:choose>
-                        <c:when test="${loop.count % 2 == 0}">
-                          <c:set var="style_class"
-                          value="list-row-even" />
-                        </c:when>
-                        <c:otherwise>
-                          <c:set var="style_class"
-                          value="list-row-odd" />
-                        </c:otherwise>
-                      </c:choose>
-                      <tr class="${style_class}">
-                        <td>${current.description}</td>
-                        <td>${current.bus}</td>
-                        <td>${current.vendor}</td>
-                        <td>${current.driver}</td>
-                      </tr>
-                    </c:forEach>
-                  </tbody>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.video" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th width="40%">Description</th>
+                                <th width="10%">Bus</th>
+                                <th width="10%">Vendor</th>
+                                <th width="40%">Driver</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach items="${videoDevices}" var="current" varStatus="loop">
+                                <c:choose>
+                                    <c:when test="${loop.count % 2 == 0}">
+                                        <c:set var="style_class" value="list-row-even" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:set var="style_class" value="list-row-odd" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <tr class="${style_class}">
+                                    <td>${current.description}</td>
+                                    <td>${current.bus}</td>
+                                    <td>${current.vendor}</td>
+                                    <td>${current.driver}</td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty audioDevices}">
+        </c:if>
+        <c:if test="${not empty audioDevices}">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.audio" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th width="40%">Description</th>
-                      <th width="10%">Bus</th>
-                      <th width="10%">Vendor</th>
-                      <th width="40%">Driver</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach items="${audioDevices}"
-                    var="current" varStatus="loop">
-                      <c:choose>
-                        <c:when test="${loop.count % 2 == 0}">
-                          <c:set var="style_class"
-                          value="list-row-even" />
-                        </c:when>
-                        <c:otherwise>
-                          <c:set var="style_class"
-                          value="list-row-odd" />
-                        </c:otherwise>
-                      </c:choose>
-                      <tr class="${style_class}">
-                        <td>${current.description}</td>
-                        <td>${current.bus}</td>
-                        <td>${current.vendor}</td>
-                        <td>${current.driver}</td>
-                      </tr>
-                    </c:forEach>
-                  </tbody>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.audio" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th width="40%">Description</th>
+                                <th width="10%">Bus</th>
+                                <th width="10%">Vendor</th>
+                                <th width="40%">Driver</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach items="${audioDevices}" var="current" varStatus="loop">
+                                <c:choose>
+                                    <c:when test="${loop.count % 2 == 0}">
+                                        <c:set var="style_class" value="list-row-even" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:set var="style_class" value="list-row-odd" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <tr class="${style_class}">
+                                    <td>${current.description}</td>
+                                    <td>${current.bus}</td>
+                                    <td>${current.vendor}</td>
+                                    <td>${current.driver}</td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty usbDevices}">
+        </c:if>
+        <c:if test="${not empty usbDevices}">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.usb" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th width="40%">Description</th>
-                      <th width="10%">Bus</th>
-                      <th width="25%">Vendor</th>
-                      <th width="25%">Driver</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach items="${usbDevices}" var="current"
-                    varStatus="loop">
-                      <c:choose>
-                        <c:when test="${loop.count % 2 == 0}">
-                          <c:set var="style_class"
-                          value="list-row-even" />
-                        </c:when>
-                        <c:otherwise>
-                          <c:set var="style_class"
-                          value="list-row-odd" />
-                        </c:otherwise>
-                      </c:choose>
-                      <tr class="${style_class}">
-                        <td>${current.description}</td>
-                        <td>${current.bus}</td>
-                        <td>${current.vendor}</td>
-                        <td>${current.driver}</td>
-                      </tr>
-                    </c:forEach>
-                  </tbody>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.usb" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th width="40%">Description</th>
+                                <th width="10%">Bus</th>
+                                <th width="25%">Vendor</th>
+                                <th width="25%">Driver</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach items="${usbDevices}" var="current" varStatus="loop">
+                                <c:choose>
+                                    <c:when test="${loop.count % 2 == 0}">
+                                        <c:set var="style_class" value="list-row-even" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:set var="style_class" value="list-row-odd" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <tr class="${style_class}">
+                                    <td>${current.description}</td>
+                                    <td>${current.bus}</td>
+                                    <td>${current.vendor}</td>
+                                    <td>${current.driver}</td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty captureDevices}">
+        </c:if>
+        <c:if test="${not empty captureDevices}">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.capture" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th width="40%">Description</th>
-                      <th width="10%">Bus</th>
-                      <th width="25%">Vendor</th>
-                      <th width="25%">Driver</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach items="${miscDevices}" var="current"
-                    varStatus="loop">
-                      <c:choose>
-                        <c:when test="${loop.count % 2 == 0}">
-                          <c:set var="style_class"
-                          value="list-row-even" />
-                        </c:when>
-                        <c:otherwise>
-                          <c:set var="style_class"
-                          value="list-row-odd" />
-                        </c:otherwise>
-                      </c:choose>
-                      <tr class="${style_class}">
-                        <td class="${style_class}">Loop: ${loop} :
-                        ${current.description}</td>
-                        <td class="${style_class}">
-                        ${current.bus}</td>
-                        <td class="${style_class}">
-                        ${current.vendor}</td>
-                        <td class="${style_class}">
-                        ${current.driver}</td>
-                      </tr>
-                    </c:forEach>
-                  </tbody>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.capture" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th width="40%">Description</th>
+                                <th width="10%">Bus</th>
+                                <th width="25%">Vendor</th>
+                                <th width="25%">Driver</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach items="${miscDevices}" var="current" varStatus="loop">
+                                <c:choose>
+                                    <c:when test="${loop.count % 2 == 0}">
+                                        <c:set var="style_class" value="list-row-even" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:set var="style_class" value="list-row-odd" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <tr class="${style_class}">
+                                    <td class="${style_class}">Loop: ${loop} : ${current.description}</td>
+                                    <td class="${style_class}">${current.bus}</td>
+                                    <td class="${style_class}">${current.vendor}</td>
+                                    <td class="${style_class}">${current.driver}</td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </div>
             </div>
-          </c:if>
-          <c:if test="${not empty miscDevices}">
+        </c:if>
+        <c:if test="${not empty miscDevices}">
             <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4>
-                  <bean:message key="sdc.details.hardware.misc" />
-                </h4>
-              </div>
-              <div class="panel-body">
-                <table class="table table-condensed">
-                  <thead>
-                    <tr>
-                      <th width="40%">Description</th>
-                      <th width="10%">Bus</th>
-                      <th width="25%">Vendor</th>
-                      <th width="25%">Driver</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach items="${miscDevices}" var="current"
-                    varStatus="loop">
-                      <c:choose>
-                        <c:when test="${loop.count % 2 == 0}">
-                          <c:set var="style_class"
-                          value="list-row-even" />
-                        </c:when>
-                        <c:otherwise>
-                          <c:set var="style_class"
-                          value="list-row-odd" />
-                        </c:otherwise>
-                      </c:choose>
-                      <tr class="${style_class}">
-                        <td>${current.description}</td>
-                        <td>${current.bus}</td>
-                        <td>${current.vendor}</td>
-                        <td>${current.driver}</td>
-                      </tr>
-                    </c:forEach>
-                  </tbody>
-                </table>
-              </div>
+                <div class="panel-heading">
+                    <h4>
+                        <bean:message key="sdc.details.hardware.misc" />
+                    </h4>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th width="40%">Description</th>
+                                <th width="10%">Bus</th>
+                                <th width="25%">Vendor</th>
+                                <th width="25%">Driver</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach items="${miscDevices}" var="current" varStatus="loop">
+                                <c:choose>
+                                    <c:when test="${loop.count % 2 == 0}">
+                                        <c:set var="style_class" value="list-row-even" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:set var="style_class" value="list-row-odd" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <tr class="${style_class}">
+                                    <td>${current.description}</td>
+                                    <td>${current.bus}</td>
+                                    <td>${current.vendor}</td>
+                                    <td>${current.driver}</td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </div>
             </div>
-          </c:if>
-        </html:form>
-  </body>
+        </c:if>
+    </html:form>
+</body>
 </html:html>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
@@ -210,153 +210,157 @@
           </div>
           </rhn:require>
 
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <table class="table table-condensed" width="90%"
-              cellspacing="0">
-                <thead>
-                  <tr>
-                    <th>Interface</th>
-                    <th>IP Address</th>
-                    <th>Netmask</th>
-                    <th>Broadcast</th>
-                    <th>Hardware Address</th>
-                    <th>Driver Module</th>
-                  </tr>
-                </thead>
-                <c:forEach items="${network_interfaces}"
-                var="current" varStatus="loop">
-                  <c:choose>
-                    <c:when test="${loop.count % 2 == 0}">
-                      <c:set var="style_class"
-                      value="list-row-even" />
-                    </c:when>
-                    <c:otherwise>
-                      <c:set var="style_class"
-                      value="list-row-odd" />
-                    </c:otherwise>
-                  </c:choose>
-                  <tr class="${style_class}">
-                    <td>${current.name}</td>
+          <c:if test="${not empty network_interfaces}">
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <table class="table table-condensed" width="90%"
+                cellspacing="0">
+                  <thead>
+                    <tr>
+                      <th>Interface</th>
+                      <th>IP Address</th>
+                      <th>Netmask</th>
+                      <th>Broadcast</th>
+                      <th>Hardware Address</th>
+                      <th>Driver Module</th>
+                    </tr>
+                  </thead>
+                  <c:forEach items="${network_interfaces}"
+                  var="current" varStatus="loop">
                     <c:choose>
-                      <c:when test="${empty current.ip}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
+                      <c:when test="${loop.count % 2 == 0}">
+                        <c:set var="style_class"
+                        value="list-row-even" />
                       </c:when>
                       <c:otherwise>
-                        <td>${current.ip}</td>
+                        <c:set var="style_class"
+                        value="list-row-odd" />
                       </c:otherwise>
                     </c:choose>
-                    <c:choose>
-                      <c:when test="${empty current.netmask}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
-                      </c:when>
-                      <c:otherwise>
-                        <td>${current.netmask}</td>
-                      </c:otherwise>
-                    </c:choose>
-                    <c:choose>
-                      <c:when test="${empty current.broadcast}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
-                      </c:when>
-                      <c:otherwise>
-                        <td>${current.broadcast}</td>
-                      </c:otherwise>
-                    </c:choose>
-                    <c:choose>
-                      <c:when test="${empty current.hwaddr}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
-                      </c:when>
-                      <c:otherwise>
-                        <td>${current.hwaddr}</td>
-                      </c:otherwise>
-                    </c:choose>
-                    <td>${current.module}</td>
-                  </tr>
-                </c:forEach>
-              </table>
+                    <tr class="${style_class}">
+                      <td>${current.name}</td>
+                      <c:choose>
+                        <c:when test="${empty current.ip}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.ip}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <c:choose>
+                        <c:when test="${empty current.netmask}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.netmask}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <c:choose>
+                        <c:when test="${empty current.broadcast}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.broadcast}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <c:choose>
+                        <c:when test="${empty current.hwaddr}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.hwaddr}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <td>${current.module}</td>
+                    </tr>
+                  </c:forEach>
+                </table>
+              </div>
             </div>
-          </div>
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <table class="table table-condensed">
-                <thead>
-                  <tr>
-                    <th>Interface</th>
-                    <th>IPv6 Address</th>
-                    <th>Netmask</th>
-                    <th>Scope</th>
-                    <th>Hardware Address</th>
-                    <th>Driver Module</th>
-                  </tr>
-                </thead>
-                <c:forEach items="${ipv6_network_interfaces}"
-                var="current" varStatus="loop">
-                  <c:choose>
-                    <c:when test="${loop.count % 2 == 0}">
-                      <c:set var="style_class"
-                      value="list-row-even" />
-                    </c:when>
-                    <c:otherwise>
-                      <c:set var="style_class"
-                      value="list-row-odd" />
-                    </c:otherwise>
-                  </c:choose>
-                  <tr class="${style_class}">
-                    <td>${current.name}</td>
+          </c:if>
+          <c:if test="${not empty ipv6_network_interfaces}">
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <table class="table table-condensed">
+                  <thead>
+                    <tr>
+                      <th>Interface</th>
+                      <th>IPv6 Address</th>
+                      <th>Netmask</th>
+                      <th>Scope</th>
+                      <th>Hardware Address</th>
+                      <th>Driver Module</th>
+                    </tr>
+                  </thead>
+                  <c:forEach items="${ipv6_network_interfaces}"
+                  var="current" varStatus="loop">
                     <c:choose>
-                      <c:when test="${empty current.ip6}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
+                      <c:when test="${loop.count % 2 == 0}">
+                        <c:set var="style_class"
+                        value="list-row-even" />
                       </c:when>
                       <c:otherwise>
-                        <td>${current.ip6}</td>
+                        <c:set var="style_class"
+                        value="list-row-odd" />
                       </c:otherwise>
                     </c:choose>
-                    <c:choose>
-                      <c:when test="${empty current.netmask}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
-                      </c:when>
-                      <c:otherwise>
-                        <td>${current.netmask}</td>
-                      </c:otherwise>
-                    </c:choose>
-                    <c:choose>
-                      <c:when test="${empty current.scope}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
-                      </c:when>
-                      <c:otherwise>
-                        <td>${current.scope}</td>
-                      </c:otherwise>
-                    </c:choose>
-                    <c:choose>
-                      <c:when test="${empty current.hwaddr}">
-                        <td>
-                          <span class="no-details">(unknown)</span>
-                        </td>
-                      </c:when>
-                      <c:otherwise>
-                        <td>${current.hwaddr}</td>
-                      </c:otherwise>
-                    </c:choose>
-                    <td>${current.module}</td>
-                  </tr>
-                </c:forEach>
-              </table>
+                    <tr class="${style_class}">
+                      <td>${current.name}</td>
+                      <c:choose>
+                        <c:when test="${empty current.ip6}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.ip6}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <c:choose>
+                        <c:when test="${empty current.netmask}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.netmask}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <c:choose>
+                        <c:when test="${empty current.scope}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.scope}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <c:choose>
+                        <c:when test="${empty current.hwaddr}">
+                          <td>
+                            <span class="no-details">(unknown)</span>
+                          </td>
+                        </c:when>
+                        <c:otherwise>
+                          <td>${current.hwaddr}</td>
+                        </c:otherwise>
+                      </c:choose>
+                      <td>${current.module}</td>
+                    </tr>
+                  </c:forEach>
+                </table>
+              </div>
             </div>
-          </div>
+          </c:if>
           <c:if test="${not empty storageDevices}">
             <div class="panel panel-default">
               <div class="panel-heading">

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
@@ -7,6 +7,9 @@
 <html:html>
   <body>
     <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
+    <html:form method="post"
+    action="/systems/details/SystemHardware.do?sid=${sid}">
+    <rhn:require acl="system_has_management_entitlement()">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4>
@@ -15,8 +18,6 @@
       </div>
       <div class="panel-body">
         <bean:message key="sdc.details.hardware.refresh" />
-        <html:form method="post"
-        action="/systems/details/SystemHardware.do?sid=${sid}">
           <rhn:csrf />
           <html:hidden property="submitted" value="true" />
           <div class="text-right margin-bottom-sm">
@@ -24,6 +25,10 @@
               <bean:message key="sdc.details.hardware.schedule" />
             </html:submit>
           </div>
+        </div>
+      </div>
+    </rhn:require>
+
           <div class="panel panel-default">
             <div class="panel-heading">
               <h4>
@@ -175,6 +180,8 @@
                   </th>
                   <td>${network_ip6_addr}</td>
                 </tr>
+
+                <rhn:require acl="system_has_management_entitlement()">
                 <tr>
                   <th>
                     <c:out value="Primary network interface:" />
@@ -187,16 +194,22 @@
                     </html:select>
                   </td>
                 </tr>
+                </rhn:require>
+
               </table>
             </div>
           </div>
           <rhn:csrf />
+
+          <rhn:require acl="system_has_management_entitlement()">
           <div class="text-right margin-bottom-sm">
             <html:submit property="update_interface"
             styleClass="btn btn-default">
               <bean:message key="sdc.details.edit.update" />
             </html:submit>
           </div>
+          </rhn:require>
+
           <div class="panel panel-default">
             <div class="panel-body">
               <table class="table table-condensed" width="90%"
@@ -601,7 +614,5 @@
             </div>
           </c:if>
         </html:form>
-      </div>
-    </div>
   </body>
 </html:html>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -172,6 +172,7 @@
         </table>
       </div>
 
+      <rhn:require acl="system_has_management_entitlement()">
       <!-- Channel subcriptions -->
       <div class="panel panel-default">
         <div class="panel-heading">
@@ -194,6 +195,7 @@
           </c:if>
         </div>
       </div>
+      </rhn:require>
 
     </div>
 

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -17,44 +17,50 @@
         <c:when test="${unentitled}">
           <rhn:icon type="system-unentitled" /> <bean:message key="sdc.details.overview.unentitled" arg0="/rhn/systems/details/Edit.do?sid=${system.id}"/>
         </c:when>
-        <c:when test="${systemInactive}">
-          <rhn:icon type="system-unknown" /> <bean:message key="sdc.details.overview.inactive1"/>
-        </c:when>
-        <c:when test="${hasUpdates}">
-          <c:choose>
-            <c:when test="${criticalErrataCount > 0}">
-              <rhn:icon type="system-crit" />
-            </c:when>
-            <c:otherwise>
-              <rhn:icon type="system-warn" />
-            </c:otherwise>
-          </c:choose>
-          &nbsp; <bean:message key="sdc.details.overview.updatesavailable" /> &nbsp;&nbsp;
-
-          <c:if test="${criticalErrataCount > 0}">
-            <bean:message key="sdc.details.overview.updates.critical" arg0="/rhn/systems/details/ErrataList.do?sid=${system.id}&type=${rhn:localize('errata.create.securityadvisory')}" arg1="${criticalErrataCount}"/> &nbsp;&nbsp;
-          </c:if>
-          <c:if test="${nonCriticalErrataCount > 0}">
-            <bean:message key="sdc.details.overview.updates.noncritical" arg0="/rhn/systems/details/ErrataList.do?sid=${system.id}&type=${rhn:localize('errata.updates.noncritical')}" arg1="${nonCriticalErrataCount}"/> &nbsp;&nbsp;
-          </c:if>
-          <c:if test="${upgradablePackagesCount > 0}">
-            <bean:message key="sdc.details.overview.updates.packages" arg0="/rhn/systems/details/packages/UpgradableList.do?sid=${system.id}" arg1="${upgradablePackagesCount}"/>
-          </c:if>
-        </c:when>
-
         <c:otherwise>
-          <rhn:icon type="system-ok" /> <bean:message key="sdc.details.overview.updated"/>
-        </c:otherwise>
-      </c:choose>
+          <rhn:require acl="system_has_management_entitlement()">
+              <c:choose>
+                <c:when test="${systemInactive}">
+                  <rhn:icon type="system-unknown" /> <bean:message key="sdc.details.overview.inactive1"/>
+                </c:when>
+                <c:when test="${hasUpdates}">
+                  <c:choose>
+                    <c:when test="${criticalErrataCount > 0}">
+                      <rhn:icon type="system-crit" />
+                    </c:when>
+                    <c:otherwise>
+                      <rhn:icon type="system-warn" />
+                    </c:otherwise>
+                  </c:choose>
+                  &nbsp; <bean:message key="sdc.details.overview.updatesavailable" /> &nbsp;&nbsp;
 
-      <c:if test="${rebootRequired}">
-        <div class="systeminfo">
-          <div class="systeminfo-full">
-            <rhn:icon type="system-reboot" /><bean:message key="sdc.details.overview.requires_reboot"/>
-            <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
-          </div>
-        </div>
-      </c:if>
+                  <c:if test="${criticalErrataCount > 0}">
+                    <bean:message key="sdc.details.overview.updates.critical" arg0="/rhn/systems/details/ErrataList.do?sid=${system.id}&type=${rhn:localize('errata.create.securityadvisory')}" arg1="${criticalErrataCount}"/> &nbsp;&nbsp;
+                  </c:if>
+                  <c:if test="${nonCriticalErrataCount > 0}">
+                    <bean:message key="sdc.details.overview.updates.noncritical" arg0="/rhn/systems/details/ErrataList.do?sid=${system.id}&type=${rhn:localize('errata.updates.noncritical')}" arg1="${nonCriticalErrataCount}"/> &nbsp;&nbsp;
+                  </c:if>
+                  <c:if test="${upgradablePackagesCount > 0}">
+                    <bean:message key="sdc.details.overview.updates.packages" arg0="/rhn/systems/details/packages/UpgradableList.do?sid=${system.id}" arg1="${upgradablePackagesCount}"/>
+                  </c:if>
+                </c:when>
+
+                <c:otherwise>
+                  <rhn:icon type="system-ok" /> <bean:message key="sdc.details.overview.updated"/>
+                </c:otherwise>
+              </c:choose>
+
+              <c:if test="${rebootRequired}">
+                <div class="systeminfo">
+                  <div class="systeminfo-full">
+                    <rhn:icon type="system-reboot" /><bean:message key="sdc.details.overview.requires_reboot"/>
+                    <bean:message key="sdc.details.overview.schedulereboot" arg0="/rhn/systems/details/RebootSystem.do?sid=${system.id}"/>
+                  </div>
+                </div>
+              </c:if>
+          </rhn:require>
+          </c:otherwise>
+      </c:choose>
     </div>
   </div>
 
@@ -142,6 +148,7 @@
             <td><bean:message key="sdc.details.overview.sysid"/></td>
             <td><c:out value="${system.id}" /></td>
           </tr>
+          <rhn:require acl="system_has_management_entitlement()">
           <tr>
             <td><bean:message key="sdc.details.overview.activationkey"/></td>
             <td>
@@ -169,6 +176,7 @@
               </c:choose>
             </td>
           </tr>
+          </rhn:require>
         </table>
       </div>
 
@@ -196,7 +204,6 @@
         </div>
       </div>
       </rhn:require>
-
     </div>
 
     <div class="col-md-6">
@@ -211,10 +218,12 @@
             <td><bean:message key="sdc.details.overview.checkedin"/></td>
             <td><rhn:formatDate humanStyle="calendar" value="${system.lastCheckin}" type="both" dateStyle="short" timeStyle="long"/></td>
           </tr>
+          <rhn:require acl="system_has_management_entitlement()">
           <tr>
             <td><bean:message key="sdc.details.overview.registered"/></td>
             <td><rhn:formatDate humanStyle="calendar" value="${system.created}" type="both" dateStyle="short" timeStyle="long"/></td>
           </tr>
+          </rhn:require>
           <tr>
             <td><bean:message key="sdc.details.overview.lastbooted"/></td>
             <td><rhn:formatDate humanStyle="from" value="${system.lastBootAsDate}" type="both" dateStyle="short" timeStyle="long"/><br/>
@@ -290,13 +299,16 @@
                 <bean:message key="none.message"/>
               </c:when>
               <c:otherwise>
+                <rhn:require acl="system_has_management_entitlement()">
                 <c:forEach items="${system.entitlements}" var="entitlement">
                  [<c:out value="${entitlement.humanReadableLabel}" />]
                 </c:forEach>
+                </rhn:require>
                </c:otherwise>
             </c:choose>
             </td>
           </tr>
+          <rhn:require acl="system_has_management_entitlement()">
           <tr>
             <td><bean:message key="sdc.details.overview.notifications"/></td>
             <td>
@@ -312,6 +324,7 @@
             </c:choose>
             </td>
           </tr>
+          </rhn:require>
           <rhn:require acl="system_feature(ftr_errata_updates)"
                      mixins="com.redhat.rhn.common.security.acl.SystemAclHandler">
           <tr>


### PR DESCRIPTION
In Spacewalk you can remove all entitlements from a system and that leaves it without functionality.

This is a bit pointless in the current implementation but still it is possible, and currently many actions are still possible although they should not be.

In SUSE Manager, we use unentitled systems to represent VMWare hosts and SaltStack minions, among other things, so we figured out those patches should be in Spacewalk as well.