### PR TITLE
Updated Oracle yum repo URLs and added new repositories for OL6 and OL7.

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -998,10 +998,10 @@ yumrepo_url = http://download.opensuse.org/repositories/systemsmanagement:/space
 archs    = x86_64
 name     = Oracle Linux 7 (%(arch)s)
 checksum = sha256
-gpgkey_url = http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol7
+gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-ol7
 gpgkey_id  = EC551F03
 gpgkey_fingerprint = 4214 4123 FECF C55B 9086  313D 72F9 7B74 EC55 1F03
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/latest/%(arch)s/
 dist_map_release = 7
 
 [oraclelinux7-optional]
@@ -1009,52 +1009,73 @@ label    = %(base_channel)s-optional
 archs    = x86_64
 name     = Optional Packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/optional/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/%(arch)s/
 
 [oraclelinux7-addons]
 label    = %(base_channel)s-addons
 archs    = x86_64
 name     = Addons for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/addons/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/addons/%(arch)s/
 
 [oraclelinux7-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
 name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/UEKR3/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/UEKR3/%(arch)s/
 
 [oraclelinux7-mysql55]
 label    = %(base_channel)s-mysql55
 archs    = x86_64
 name     = MySQL 5.5 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/MySQL55/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL55/%(arch)s/
 
 [oraclelinux7-mysql56]
 label    = %(base_channel)s-mysql56
 archs    = x86_64
 name     = MySQL 5.6 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/MySQL56/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL56/%(arch)s/
+
+[oraclelinux7-mysql57]
+label    = %(base_channel)s-mysql57
+archs    = x86_64
+name     = MySQL 5.7 for Oracle Linux 7 (%(arch)s)
+base_channels = oraclelinux7-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL57_community/%(arch)s/
 
 [oraclelinux7-spacewalk22-client]
 label    = %(base_channel)s-spacewalk22-client
 archs    = x86_64
 name     = Spacewalk 2.2 Client for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/client/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/client/%(arch)s/
+
+[oraclelinux7-openstack20]
+label     = %(base_channel)s-openstack20
+archs     = x86_64
+name      = OpenStack 2.0 packages for Oracle Linux 7 (%(arch)s)
+base_channels = oraclelinux7-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack20/%(arch)s/
+
+[oraclelinux7-scl12]
+label     = %(base_channel)s-scl12
+arches    = x86_64
+name      = Software Collection Library release 1.2 packages for Oracle Linux 7 (%(arch)s)
+base_channels = oraclelinux7-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections12/%(arch)s/
 
 
 [oraclelinux6]
 archs    = %(_x86_archs)s
 name     = Oracle Linux 6 (%(arch)s)
 checksum = sha256
-gpgkey_url = http://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol6
+gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-ol6
 gpgkey_id = EC551F03
 gpgkey_fingerprint = 4214 4123 FECF C55B 9086  313D 72F9 7B74 EC55 1F03
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/latest/%(arch)s/
 dist_map_release = 6
 
 [oraclelinux6-addons]
@@ -1062,65 +1083,79 @@ label    = %(base_channel)s-addons
 archs    = %(_x86_archs)s
 name     = Addons for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/addons/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/addons/%(arch)s/
 
 [oraclelinux6-uek]
 label    = %(base_channel)s-uek
 archs    = %(_x86_archs)s
 name     = Latest Unbreakable Enterprise Kernel Release 2 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/%(arch)s/
 
 [oraclelinux6-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
 name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/%(arch)s/
 
 [oraclelinux6-mysql55]
 label    = %(base_channel)s-mysql
 archs    = %(_x86_archs)s
 name     = MySQL 5.5 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/MySQL/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL/%(arch)s/
 
 [oraclelinux6-mysql56]
 label    = %(base_channel)s-mysql
 archs    = %(_x86_archs)s
 name     = MySQL 5.6 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/MySQL56/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL56/%(arch)s/
+
+[oraclelinux6-mysql57]
+label    = %(base_channel)s-mysql57
+archs    = %(_x86_archs)s
+name     = MySQL 5.7 for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux7-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL57_community/%(arch)s/
 
 [oraclelinux6-playground]
 label    = %(base_channel)s-playground
 archs    = x86_64
 name     = Playground (Mainline) Kernels for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/playground/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/playground/latest/%(arch)s/
 
 [oraclelinux6-spacewalk22-server]
 label    = %(base_channel)s-spacewalk22-server
 archs    = x86_64
 name     = Spacewalk 2.2 Server for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/server/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/server/%(arch)s/
 
 [oraclelinux6-spacewalk22-client]
 label    = %(base_channel)s-spacewalk22-client
 archs    = %(_x86_archs)s
 name     = Spacewalk 2.2 Client for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(arch)s/
+
+[oraclelinux6-scl12]
+label     = %(base_channel)s-scl12
+arches    = x86_64
+name      = Software Collection Library release 1.2 packages for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux6-%(arch)s
+yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/SoftwareCollections12/%(arch)s/
 
 
 [oraclelinux5]
 archs    = %(_x86_archs)s
 name     = Oracle Linux 5 (%(arch)s)
-gpgkey_url = http://public-yum.oracle.com/RPM-GPG-KEY-oracle-el5
+gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-el5
 gpgkey_id = 1E5E0159
 gpgkey_fingerprint = 99FD 2766 28EE DECB 5E5A  F5F8 66CE D3DE 1E5E 0159
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL5/latest/%(arch)s/
 dist_map_release = 5
 
 [oraclelinux5-addons]
@@ -1128,33 +1163,33 @@ label    = %(base_channel)s-addons
 archs    = %(_x86_archs)s
 name     = Addons for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/addons/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/EnterpriseLinux/EL5/addons/%(arch)s/
 
 [oraclelinux5-oracle-addons]
 label    = %(base_channel)s-oracle-addons
 archs    = %(_x86_archs)s
 name     = Oracle software addons for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/oracle_addons/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/EnterpriseLinux/EL5/oracle_addons/%(arch)s/
 
 [oraclelinux5-unsupported]
 label    = %(base_channel)s-unsupported
 archs    = %(_x86_archs)s
 name     = Productivity Applications for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/EnterpriseLinux/EL5/unsupported/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/EnterpriseLinux/EL5/unsupported/%(arch)s/
 
 [oraclelinux5-uek]
 label    = %(base_channel)s-uek
 archs    = %(_x86_archs)s
 name     = Latest Unbreakable Enterprise Kernel for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/UEK/latest/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL5/UEK/latest/%(arch)s/
 
 [oraclelinux5-spacewalk22-client]
 label    = %(base_channel)s-spacewalk22-client
 archs    = %(_x86_archs)s
 name     = Spacewalk 2.2 Client for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL5/spacewalk22/client/%(arch)s/
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL5/spacewalk22/client/%(arch)s/
 


### PR DESCRIPTION
We've simplified the URL for the Oracle Linux Yum Server and added a few extra repositories for MySQL 5.7, Software Collections 1.2 and OpenStack 2.0 for OL7.

Signed-off-by: Avi Miller <avi.miller@oracle.com>