### PR TITLE
Fix removing virtual guests

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -34,7 +34,6 @@ import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.manager.system.SystemManager;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -1481,31 +1480,6 @@ public class Server extends BaseDomainHelper implements Identifiable {
     public void addGuest(VirtualInstance guest) {
         guest.setHostSystem(this);
         guests.add(guest);
-    }
-
-    /**
-     * Removes the virtual instance guest from this server. If the guest is registered,
-     * then the guest server will be deleted from the virtual instance.
-     *
-     * @param guest The virtual instance to delete
-     *
-     * @return <code>true</code> if the guest is deleted, <code>false</code> otherwise.
-     */
-    public boolean deleteGuest(VirtualInstance guest) {
-        if (canDeleteGuest(guest)) {
-            guest.deleteGuestSystem();
-            return removeGuest(guest);
-        }
-        return false;
-    }
-
-    private boolean canDeleteGuest(VirtualInstance guest) {
-        for (VirtualInstance g : getGuests()) {
-            if (g.getId().equals(guest.getId())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -1520,8 +1520,6 @@ public class Server extends BaseDomainHelper implements Identifiable {
         for (Iterator<VirtualInstance> it = guests.iterator(); it.hasNext();) {
             VirtualInstance g = it.next();
             if (g.getId().equals(guest.getId())) {
-                guest.setHostSystem(null);
-
                 it.remove();
                 deleted = true;
                 break;

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.domain.server;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.BaseDomainHelper;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -123,31 +122,6 @@ public class VirtualInstance extends BaseDomainHelper {
 
         if (guest != null) {
             guest.setVirtualInstance(this);
-        }
-    }
-
-    /**
-     * Deletes the guest server when the virtual instance is a registered guest.
-     */
-    public void deleteGuestSystem() {
-        if (isRegisteredGuest()) {
-            guest.setVirtualInstance(null);
-
-            // If outdated, the stored procedure will be deleting *THIS* virtual instance:
-            boolean isOutdated = VirtualInstanceFactory.getInstance().isOutdated(this);
-
-            ServerFactory.delete(guest);
-
-            // Tricky situation here, the stored procedure the above delete call ends up
-            // using will delete from rhnVirtualInstance if it needs to. If that's the
-            // case, we need to make sure to evict ourselves from the session, otherwise
-            // Hibernate gets confused.
-            if (getHostSystem() == null || isOutdated) {
-                HibernateFactory.getSession().evict(this);
-            }
-            else {
-                setGuestSystem(null);
-            }
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.domain.server;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.BaseDomainHelper;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -338,8 +337,10 @@ public class VirtualInstance extends BaseDomainHelper {
 
         VirtualInstance that = (VirtualInstance) object;
 
-        return new EqualsBuilder().append(this.getId(), that.getId()).
-            append(this.getUuid(), that.getUuid()).isEquals();
+        return new EqualsBuilder()
+                .append(this.getUuid(), that.getUuid())
+                .append(this.getHostSystem(), that.getHostSystem())
+                .isEquals();
     }
 
     /**
@@ -347,7 +348,10 @@ public class VirtualInstance extends BaseDomainHelper {
      * {@inheritDoc}
      */
     public int hashCode() {
-        return new HashCodeBuilder().append(getId()).append(getUuid()).toHashCode();
+        return new HashCodeBuilder()
+                .append(getUuid())
+                .append(getHostSystem())
+                .toHashCode();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceFactory.java
@@ -123,25 +123,6 @@ public class VirtualInstanceFactory extends HibernateFactory {
     }
 
     /**
-     * Deletes the virtual instance from the database. If the virtual instance is a
-     * registered guest, then its guest system will be deleted as well.
-     *
-     * @param virtualInstance The virtual instance to delete
-     */
-    public void deleteVirtualInstance(VirtualInstance virtualInstance) {
-       log.debug("deleteVirtualInstance");
-       if (virtualInstance.getHostSystem() != null) {
-           log.debug("deleteVirtualInstance host System");
-           virtualInstance.getHostSystem().deleteGuest(virtualInstance);
-       }
-       else {
-           log.debug("deleteVirtualInstance removing object");
-           removeObject(virtualInstance);
-           virtualInstance.deleteGuestSystem();
-       }
-    }
-
-    /**
      * Deletes the virtual instance from the database.
      * If the virtual instance has an association to a guest system (i.e. it is
      * a registered guest), remove this association.

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceFactory.java
@@ -142,6 +142,29 @@ public class VirtualInstanceFactory extends HibernateFactory {
     }
 
     /**
+     * Deletes the virtual instance from the database.
+     * If the virtual instance has an association to a guest system (i.e. it is
+     * a registered guest), remove this association.
+     * If the virtual instance has an association to a host system, remove this
+     * association.
+     *
+     * @param virtualInstance The virtual instance to delete
+     */
+    public void deleteVirtualInstanceOnly(VirtualInstance virtualInstance) {
+        log.debug("Deleting virtual instance without removing associated objects " +
+                virtualInstance);
+        Server hostSystem = virtualInstance.getHostSystem();
+        if (hostSystem != null) {
+            hostSystem.removeGuest(virtualInstance);
+        }
+        Server guestSystem = virtualInstance.getGuestSystem();
+        if (guestSystem != null) {
+            guestSystem.setVirtualInstance(null);
+        }
+        removeObject(virtualInstance);
+    }
+
+    /**
      * Finds all registered guests, within a particular org, whose hosts do not have any
      * virtualization entitlements.
      *

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryVirtualizationTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryVirtualizationTest.java
@@ -14,14 +14,12 @@
  */
 package com.redhat.rhn.domain.server.test;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
-
 import org.apache.commons.collections.CollectionUtils;
 
 
@@ -63,41 +61,6 @@ public class ServerFactoryVirtualizationTest extends RhnBaseTestCase {
         VirtualInstance retInstance = retrievedHost.getGuests().iterator().next();
 
         assertEquals(retInstance.getHostSystem(), retrievedHost);
-    }
-
-    public void testDeleteGuestFromHostAndSaveHost() throws Exception {
-        VirtualInstance guest =
-                virtualInstanceFactory.newRegisteredGuestWithHost();
-        Long guestId = guest.getGuestSystem().getId();
-        Server host = guest.getHostSystem();
-        ServerFactory.save(host);
-        Long hostId = host.getId();
-
-        HibernateFactory.getSession().save(guest);
-        HibernateFactory.getSession().clear();
-
-        Server retrievedHost = ServerFactory.lookupById(hostId);
-        assertFalse(retrievedHost.getGuests().isEmpty());
-
-        assertTrue(retrievedHost.deleteGuest(guest));
-
-        HibernateFactory.getSession().clear();
-        Server serverWithoutGuest = ServerFactory.lookupById(hostId);
-        Server deletedGuest = ServerFactory.lookupById(guestId);
-
-        assertFalse(serverWithoutGuest.getGuests().contains(deletedGuest));
-        assertNull("guest system was not deleted", deletedGuest);
-    }
-
-    public void testDeleteGuestNotBelongingToHost() throws Exception {
-        VirtualInstance virtualInstance =
-                virtualInstanceFactory.newRegisteredGuestWithHost();
-
-        Server otherHost = ServerFactory.createServer();
-
-        assertFalse(otherHost.deleteGuest(virtualInstance));
-        assertNotNull("guest system should not have been deleted",
-                virtualInstance.getGuestSystem());
     }
 
     public void testUpdateGuestAndSaveHost() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -108,24 +108,6 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         assertEquals(guestSystem, retrievedGuest.getGuestSystem());
     }
 
-    public void testDeleteUnregisteredGuest() throws Exception {
-        // step 1 - create a guest in the database
-        VirtualInstance guest = builder.createUnregisteredGuest()
-                .withVirtHost().build();
-        virtualInstanceDAO.saveVirtualInstance(guest);
-        flushAndEvictGuest(guest);
-
-        // step 2 - fetch the guest from the database so that it is attached to the session
-        VirtualInstance retrievedGuest = virtualInstanceDAO.lookupById(guest
-                .getId());
-
-        // step 3 - delete the guest
-        virtualInstanceDAO.deleteVirtualInstance(retrievedGuest);
-        flushAndEvictGuest(retrievedGuest);
-
-        assertGuestDeleted(guest);
-    }
-
     public void testGetGuestsAndNotHost() throws Exception {
 
         VirtualInstance vi = builder.createUnregisteredGuest()
@@ -143,43 +125,6 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         Server s = ServerFactory.lookupById(sid);
         assertEquals(1, s.getGuests().size());
 
-    }
-
-    public void testDeleteRegisteredGuestWithVirtHost() throws Exception {
-        // step 1 - create a guest in the database
-        VirtualInstance guest = builder.createGuest().withVirtHost().build();
-        //Server guestSystem = guest.getGuestSystem();
-        virtualInstanceDAO.saveVirtualInstance(guest);
-        flushAndEvictGuest(guest);
-        flushAndEvict(guest.getHostSystem());
-
-        // step 2 - fetch the guest so that it is attached to the session
-        VirtualInstance retrievedGuest = virtualInstanceDAO.lookupById(guest
-                .getId());
-        Server guestSystem = retrievedGuest.getGuestSystem();
-
-        // step 3 - delete the guest
-        virtualInstanceDAO.deleteVirtualInstance(retrievedGuest);
-        flushAndEvictGuest(retrievedGuest);
-        flushAndEvict(retrievedGuest.getHostSystem());
-
-        assertGuestDeleted(guest, guestSystem);
-    }
-
-    public void testDeleteGuestWithoutAHost() throws Exception {
-        // step 1 - create a guest in the database
-        VirtualInstance guest = builder.createGuest().withPersistence().build();
-
-        // step 2 - fetch the guest so it is attached to the session
-        VirtualInstance retrievedGuest = virtualInstanceDAO.lookupById(guest
-                .getId());
-        Server guestSystem = retrievedGuest.getGuestSystem();
-
-        // step 3 - delete the guest
-        virtualInstanceDAO.deleteVirtualInstance(retrievedGuest);
-        flushAndEvict(guest);
-
-        assertGuestDeleted(guest, guestSystem);
     }
 
     public void testSaveAndRetrieveInfo() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceTest.java
@@ -14,19 +14,20 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
+import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.Sequence;
+import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
-
-import junit.framework.TestCase;
 
 
 /**
  * VirtualInstanceTest
  * @version $Rev$
  */
-public class VirtualInstanceTest extends TestCase {
+public class VirtualInstanceTest extends RhnBaseTestCase {
 
     private class GuestStub extends VirtualInstance {
         public GuestStub(Long id) {
@@ -37,6 +38,7 @@ public class VirtualInstanceTest extends TestCase {
     private Sequence idSequence;
 
     protected void setUp() throws Exception {
+        super.setUp();
         idSequence = new Sequence();
     }
 
@@ -51,15 +53,24 @@ public class VirtualInstanceTest extends TestCase {
         assertFalse(new VirtualInstance().isRegisteredGuest());
     }
 
+    public void testEqualsAndHashCode() throws Exception {
+        Server host = ServerTestUtils.createTestSystem();
+        Server guest = ServerTestUtils.createTestSystem();
+        String uuid1 = TestUtils.randomString();
+        String uuid2 = TestUtils.randomString();
 
-    public void testEqualsAndHashCode() {
-        VirtualInstance guestA = new GuestStub(idSequence.nextLong());
-        VirtualInstance guestB = new GuestStub(guestA.getId());
-        VirtualInstance guestC = new GuestStub(idSequence.nextLong());
+        VirtualInstance refGuest = createVirtualInstance(host, guest, uuid1);
 
-        assertEquals(true, TestUtils.equalTest(guestA, guestB));
-        assertEquals(false, TestUtils.equalTest(guestA, guestC));
-        assertEquals(false, TestUtils.equalTest(guestA, new Object()));
+        assertEquals(refGuest, createVirtualInstance(host, guest, uuid1));
+        assertFalse(refGuest.equals(createVirtualInstance(host, guest, uuid2)));
+    }
+
+    private VirtualInstance createVirtualInstance(Server host, Server guest, String uuid) {
+        VirtualInstance virtualInstance = new VirtualInstance();
+        virtualInstance.setHostSystem(host);
+        virtualInstance.setGuestSystem(guest);
+        virtualInstance.setUuid(uuid);
+        return virtualInstance;
     }
 
     public void testGetNullInfo() {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/VirtualGuestsConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/VirtualGuestsConfirmAction.java
@@ -30,7 +30,6 @@ import com.redhat.rhn.frontend.struts.StrutsDelegate;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
-
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -42,7 +41,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -110,7 +108,17 @@ public class VirtualGuestsConfirmAction extends BaseSystemListAction {
                 Long vid = new Long(next.getId().longValue());
                 VirtualInstance virtualInstance =
                     VirtualInstanceFactory.getInstance().lookupById(vid);
-                VirtualInstanceFactory.getInstance().deleteVirtualInstance(virtualInstance);
+                Server guestSystem = virtualInstance.getGuestSystem();
+
+                if (guestSystem != null) {
+                    SystemManager.deleteServer(user, guestSystem.getId());
+                }
+                else {
+                    // if a system is not registered, delete at least the VirtualInstance
+                    VirtualInstanceFactory.getInstance()
+                            .deleteVirtualInstanceOnly(virtualInstance);
+                }
+
                 actionCount++;
                 key = "virt.deleted";
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/VirtualGuestsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/VirtualGuestsActionTest.java
@@ -111,22 +111,21 @@ public class VirtualGuestsActionTest extends RhnPostMockStrutsTestCase {
         assertTrue(getActualForward().indexOf("sid=") > 0);
     }
 
+    /**
+     * Verify that invoking the delete action on a guest results in deleting both the guest
+     * system and guest virtual instance.
+     * @throws Exception - if anything goes wrong
+     */
     public void testDeleteGuestConfirm() throws Exception {
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1);
-        Server guest =
-            host.getGuests().iterator().next().getGuestSystem();
-
-        VirtualInstance virtualInstance = new VirtualInstance();
-        virtualInstance.setUuid("1234");
-        virtualInstance.setGuestSystem(guest);
-        virtualInstance.setConfirmed(0L);
-
+        Server guest = host.getGuests().iterator().next().getGuestSystem();
         ServerFactory.save(guest);
-        new VirtualInstanceFactory().saveVirtualInstance(virtualInstance);
 
         addRequestParameter(RequestContext.SID, host.getId().toString());
         addDispatchCall("virtualguests_confirm.jsp.confirm");
         RhnSet set = RhnSetDecl.VIRTUAL_SYSTEMS.get(user);
+        VirtualInstance virtualInstance = guest.getVirtualInstance();
+        new VirtualInstanceFactory().saveVirtualInstance(virtualInstance);
         set.addElement(virtualInstance.getId());
         RhnSetManager.store(set);
         TestUtils.flushAndEvict(virtualInstance);
@@ -143,7 +142,8 @@ public class VirtualGuestsActionTest extends RhnPostMockStrutsTestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("id", virtualInstance.getId());
         DataResult dr = TestUtils.runTestQuery("select_virtual_instance_by_id", params);
-        assertTrue(dr.size() == 0);
+        assertEquals(0, dr.size());
+        assertNull(ServerFactory.lookupById(guest.getId()));
     }
 
     public void testSetGuestMemory() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -79,7 +79,6 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.user.UserManager;
-
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.Session;
@@ -355,9 +354,13 @@ public class SystemManager extends BaseManager {
     }
 
     /**
-     * Deletes a server
+     * Deletes a Server and associated VirtualInstances:
+     *  - If the server was a virtual guest, remove the VirtualInstance that links it to its
+     *  host server.
+     *  - If the server was a virtual host, remove all its entitlements and all
+     *  VirtualInstances that link it to the guest servers.
      * @param user The user doing the deleting.
-     * @param sid The id of the system to be deleted
+     * @param sid The id of the Server to be deleted
      */
     public static void deleteServer(User user, Long sid) {
         /*
@@ -370,22 +373,21 @@ public class SystemManager extends BaseManager {
         CobblerSystemRemoveCommand rc = new CobblerSystemRemoveCommand(user, server);
         rc.store();
 
+        // remove associated VirtualInstances
+        Set<VirtualInstance> toRemove = new HashSet<VirtualInstance>();
         if (server.isVirtualGuest()) {
-            VirtualInstance virtInstance = server.getVirtualInstance();
-            virtInstance.deleteGuestSystem();
+            toRemove.add(server.getVirtualInstance());
         }
         else {
-            if (server.getGuests() != null) {
-                removeAllServerEntitlements(server.getId());
-                // Remove guest associations to the host system we're now deleting:
-                for (Iterator<VirtualInstance> it = server.getGuests().iterator(); it
-                        .hasNext();) {
-                    VirtualInstance vi = it.next();
-                    server.removeGuest(vi);
-                }
-            }
-            ServerFactory.delete(server);
+            removeAllServerEntitlements(server.getId());
+            toRemove.addAll(server.getGuests());
         }
+        for (VirtualInstance virtualInstance : toRemove) {
+            VirtualInstanceFactory.getInstance().deleteVirtualInstanceOnly(virtualInstance);
+        }
+
+        // remove server itself
+        ServerFactory.delete(server);
     }
 
     /**


### PR DESCRIPTION
This aim of this PR is to clean some mess around the `Server <---> VirtualInstance` association:
- cc5c141: `VirtualInstance.hashCode` & `equals` relied on an ID of the entities, which is problematic when the `VirtualInstance` entity also part of some collection (which is true - it has many to one association with the `Server` entity). See [hibernate manual](https://docs.jboss.org/hibernate/stable/core.old/reference/en/html/persistent-classes-equalshashcode.html) for further info.
- 3ed03f5: Fixing removing associations between virtual servers and their guests via the UI
- Rest: Simplifying the deletion of the association between virtual servers and their guests. Previously more methods were used to achieve this, now `VirtualInstanceFactory.deleteVirtualInstanceOnly` is used.
