### PR TITLE
Set HTTP status code for error pages

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
@@ -54,6 +54,7 @@ public class PxtAuthenticationService extends BaseAuthenticationService {
         set.add("/rhn/rpc/api");
         set.add("/rhn/help/");
         set.add("/rhn/apidoc");
+        set.add("/rhn/errors");
         set.add("/rhn/kickstart/DownloadFile");
         set.add("/rhn/ty/TinyUrl");
         set.add("/css");

--- a/java/code/src/com/redhat/rhn/frontend/servlets/EnvironmentFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/EnvironmentFilter.java
@@ -46,6 +46,7 @@ public class EnvironmentFilter implements Filter {
     private static String[] nosslurls = {"/rhn/kickstart/DownloadFile",
                                          "/rhn/common/DownloadFile",
                                          "/rhn/rpc/api",
+                                         "/rhn/errors",
                                          "/rhn/ty/TinyUrl"};
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/servlets/ErrorStatusFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/ErrorStatusFilter.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2015 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Set HTTP status code corresponding to the requested error page.
+ */
+public class ErrorStatusFilter implements Filter {
+
+    /**
+     * {@inheritDoc}
+     */
+    public void doFilter(ServletRequest request, ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        if (httpRequest.getRequestURI().endsWith("/404.jsp")) {
+            httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        }
+        else if (httpRequest.getRequestURI().endsWith("/500.jsp")) {
+            httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see javax.servlet.Filter#destroy()
+     */
+    @Override
+    public void destroy() {
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
+     */
+    @Override
+    public void init(FilterConfig arg0) throws ServletException {
+    }
+}

--- a/java/code/webapp/WEB-INF/web.xml
+++ b/java/code/webapp/WEB-INF/web.xml
@@ -73,6 +73,12 @@
     </init-param>
   </filter>
 
+  <!-- Set the status code for error pages -->
+  <filter>
+    <filter-name>ErrorStatusFilter</filter-name>
+    <filter-class>com.redhat.rhn.frontend.servlets.ErrorStatusFilter</filter-class>
+  </filter>
+
   <!--
    =======================================
               FILTER MAPPINGS
@@ -139,6 +145,11 @@
   <filter-mapping>
     <filter-name>RedirectFilter</filter-name>
     <url-pattern>/Redirect/*</url-pattern>
+  </filter-mapping>
+
+  <filter-mapping>
+    <filter-name>ErrorStatusFilter</filter-name>
+    <url-pattern>/errors/*</url-pattern>
   </filter-mapping>
 
   <!--


### PR DESCRIPTION
This patch solves the following problems around the JSP error pages:

- Do not require the user to be logged in to see error pages
- Allow error pages to be requested unencrypted via HTTP
- Set the HTTP status code correctly for error pages (404, 500)