### PR TITLE
Refactor rendering of the navigation menu markup

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.frontend.nav.NavTreeIndex;
 import com.redhat.rhn.frontend.nav.RenderGuard;
 import com.redhat.rhn.frontend.nav.Renderable;
 import com.redhat.rhn.frontend.nav.TitleRenderer;
+import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 
 import java.util.Map;
 
@@ -43,12 +44,13 @@ public class NavDialogMenuTag extends NavMenuTag {
     }
 
     /** {@inheritDoc} */
-    protected String renderNav(NavTreeIndex nti, Renderable r,
-                               RenderGuard guard, Map params) {
-        String body = super.renderNav(nti, r, guard, params);
-        String title = super.renderNav(nti, new TitleRenderer(), guard, params);
-        HttpServletRequest req =
-            (HttpServletRequest) pageContext.getRequest();
+    protected String renderNav(NavTreeIndex navTreeIndex, Renderable renderable,
+            RenderGuard guard, Map<String, String[]> params) {
+        String body = RenderUtils.getInstance().render(
+                navTreeIndex, renderable, guard, params);
+        String title = RenderUtils.getInstance().render(
+                navTreeIndex, new TitleRenderer(), guard, params);
+        HttpServletRequest req = (HttpServletRequest) pageContext.getRequest();
         req.setAttribute("innernavtitle", title);
         return body;
     }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/NavMenuTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/NavMenuTag.java
@@ -14,28 +14,9 @@
  */
 package com.redhat.rhn.frontend.taglibs;
 
-import com.redhat.rhn.common.util.ServletUtils;
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.nav.AclGuard;
-import com.redhat.rhn.frontend.nav.DepthGuard;
-import com.redhat.rhn.frontend.nav.NavCache;
-import com.redhat.rhn.frontend.nav.NavTree;
-import com.redhat.rhn.frontend.nav.NavTreeIndex;
-import com.redhat.rhn.frontend.nav.RenderEngine;
-import com.redhat.rhn.frontend.nav.RenderGuard;
-import com.redhat.rhn.frontend.nav.RenderGuardComposite;
-import com.redhat.rhn.frontend.nav.Renderable;
-import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.StringTokenizer;
-
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.TagSupport;
 
 /**
@@ -55,7 +36,7 @@ import javax.servlet.jsp.tagext.TagSupport;
  */
 public class NavMenuTag extends TagSupport {
 
-    /** minimum mindepth to display */
+    /** minimum depth to display */
     private int mindepth = 0;
     /** maximum depth to be rendered */
     private int maxdepth = Integer.MAX_VALUE;
@@ -67,87 +48,15 @@ public class NavMenuTag extends TagSupport {
     /** {@inheritDoc}
      * @throws JspException*/
     public int doStartTag() throws JspException {
-
-        JspWriter out = null;
         try {
-            /*
-             * There should probably be a Nav service to inquire to handle the
-             * rendering.
-             *
-             */
-
-            /*
-             * Find the NavTree by looking it up in the smart cache.
-             * Then create a new NavTreeIndex passing in NavTree.
-             */
-
-            out = pageContext.getOut();
-
-            URL url = pageContext.getServletContext().getResource(definition);
-
-            NavTree nt = NavCache.getTree(url);
-            NavTreeIndex nti = new NavTreeIndex(nt);
-
-            HttpServletRequest req =
-                (HttpServletRequest) pageContext.getRequest();
-            String requestPath = ServletUtils.getRequestPath(req);
-
-            RequestContext requestContext = new RequestContext(req);
-
-            Map aclContext = new HashMap();
-            User user = requestContext.getCurrentUser();
-            aclContext.put("user", user);
-            // Add the formvar(s) to the context as well.
-            if (nt.getFormvar() != null) {
-                StringTokenizer st = new StringTokenizer(nt.getFormvar());
-                while (st.hasMoreTokens()) {
-                    String token = st.nextToken();
-                    aclContext.put(token, req.getParameter(token));
-                }
-            }
-            AclGuard guard = new AclGuard(aclContext, nt.getAclMixins());
-            nt.setGuard(guard);
-
-            // Here we try and fetch the previously
-            // successfull navigation match from the Session
-            // This is used as a fallback if the current URL doesnt
-            // have a matching navigation map
-            StringBuilder locationKey = new StringBuilder();
-            locationKey.append(nt.getLabel());
-            locationKey.append("navi_location");
-
-            String naviLocation =
-                (String) req.getSession().getAttribute(locationKey.toString());
-
-            String lastActive = nti.computeActiveNodes(requestPath, naviLocation);
-
-            // Store the computed URL in the Session
-            req.getSession().setAttribute(locationKey.toString(), lastActive);
-
-            Renderable r =
-                (Renderable) Class.forName(getRenderer()).newInstance();
-            //r.setRenderGuard(new DepthGuard(getMindepth(), getMaxdepth()));
-            RenderGuardComposite comp = new RenderGuardComposite();
-            comp.addRenderGuard(new DepthGuard(getMindepth(), getMaxdepth()));
-            comp.addRenderGuard(guard);
-
-            out.print(renderNav(nti, r, comp, req.getParameterMap()));
-        }
-        catch (IOException ioe) {
-            throw new JspException("Error writing to JSP file:", ioe);
+            pageContext.getOut().print(RenderUtils.getInstance().renderNavigationMenu(
+                    pageContext.getRequest(), definition, renderer, mindepth, maxdepth));
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);
         }
 
         return (SKIP_BODY);
-    }
-
-    protected String renderNav(NavTreeIndex nti, Renderable r,
-                               RenderGuard guard, Map params) {
-        r.setRenderGuard(guard);
-        RenderEngine re = new RenderEngine(nti);
-        return re.render(r, params);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/NavMenuTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/NavMenuTag.java
@@ -50,7 +50,7 @@ public class NavMenuTag extends TagSupport {
     public int doStartTag() throws JspException {
         try {
             pageContext.getOut().print(RenderUtils.getInstance().renderNavigationMenu(
-                    pageContext.getRequest(), definition, renderer, mindepth, maxdepth));
+                    pageContext, definition, renderer, mindepth, maxdepth));
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
@@ -98,7 +98,7 @@ public enum RenderUtils {
         NavTreeIndex navTreeIndex = new NavTreeIndex(navTree);
 
         User user = new RequestContext(req).getCurrentUser();
-        Map<String, Object> aclContext = new HashMap<>();
+        Map<String, Object> aclContext = new HashMap<String, Object>();
         aclContext.put("user", user);
         // Add the formvar(s) to the context as well
         if (navTree.getFormvar() != null) {

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2015 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.taglibs.helpers;
+
+import com.redhat.rhn.common.util.ServletUtils;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.nav.AclGuard;
+import com.redhat.rhn.frontend.nav.DepthGuard;
+import com.redhat.rhn.frontend.nav.NavCache;
+import com.redhat.rhn.frontend.nav.NavTree;
+import com.redhat.rhn.frontend.nav.NavTreeIndex;
+import com.redhat.rhn.frontend.nav.RenderEngine;
+import com.redhat.rhn.frontend.nav.RenderGuard;
+import com.redhat.rhn.frontend.nav.RenderGuardComposite;
+import com.redhat.rhn.frontend.nav.Renderable;
+import com.redhat.rhn.frontend.struts.RequestContext;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utility methods for rendering navigation menus that are defined in XML files.
+ */
+public enum RenderUtils {
+    /**
+     * Singleton instance
+     */
+    INSTANCE;
+
+    RenderUtils() { }
+
+    /**
+     * Singleton implementation
+     * @return an instance of this class
+     */
+    public static RenderUtils getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Render the navigation menu given by the menu definition using the given renderer
+     * class. Therefore find the NavTree by looking it up in the smart cache first, then
+     * create a new NavTreeIndex passing in NavTree.
+     *
+     * @param request the request object
+     * @param menuDefinition the menu definition XML file
+     * @param rendererClass the renderer class to use
+     * @param minDepth minimal depth
+     * @param maxDepth maximal depth
+     * @return the rendered navigation menu as string
+     * @throws Exception in case of an error
+     */
+    public String renderNavigationMenu(ServletRequest request, String menuDefinition,
+            String rendererClass, int minDepth, int maxDepth) throws Exception {
+        URL url = request.getServletContext().getResource(menuDefinition);
+        NavTree navTree = NavCache.getTree(url);
+        NavTreeIndex navTreeIndex = new NavTreeIndex(navTree);
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        User user = new RequestContext(req).getCurrentUser();
+        Map<String, Object> aclContext = new HashMap<>();
+        aclContext.put("user", user);
+        // Add the formvar(s) to the context as well
+        if (navTree.getFormvar() != null) {
+            StringTokenizer st = new StringTokenizer(navTree.getFormvar());
+            while (st.hasMoreTokens()) {
+                String token = st.nextToken();
+                aclContext.put(token, req.getParameter(token));
+            }
+        }
+        AclGuard guard = new AclGuard(aclContext, navTree.getAclMixins());
+        navTree.setGuard(guard);
+
+        // We try to fetch the previously successful navigation match from the Session.
+        // Used as fallback if the current URL doesn't have a matching navigation map.
+        StringBuilder locationKey = new StringBuilder();
+        locationKey.append(navTree.getLabel());
+        locationKey.append("navi_location");
+
+        String location = (String) req.getSession().getAttribute(locationKey.toString());
+        String lastActive = navTreeIndex.computeActiveNodes(
+                ServletUtils.getRequestPath(req), location);
+
+        // Store the computed URL in the Session
+        req.getSession().setAttribute(locationKey.toString(), lastActive);
+
+        Renderable renderable = (Renderable) Class.forName(rendererClass).newInstance();
+        RenderGuardComposite comp = new RenderGuardComposite();
+        comp.addRenderGuard(new DepthGuard(minDepth, maxDepth));
+        comp.addRenderGuard(guard);
+
+        return render(navTreeIndex, renderable, comp, req.getParameterMap());
+    }
+
+    /**
+     * Call the {@link RenderEngine} to render a given {@link Renderable}.
+     *
+     * @param navTreeIndex the navigation tree index
+     * @param renderable the renderable
+     * @param guard the guard
+     * @param params parameters
+     * @return the rendered string
+     */
+    public String render(NavTreeIndex navTreeIndex, Renderable renderable,
+            RenderGuard guard, Map<String, String[]> params) {
+        renderable.setRenderGuard(guard);
+        RenderEngine engine = new RenderEngine(navTreeIndex);
+        return engine.render(renderable, params);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
@@ -87,7 +87,7 @@ public enum RenderUtils {
      */
     public String renderNavigationMenu(HttpServletRequest request, String menuDefinition,
             String rendererClass, int minDepth, int maxDepth) throws Exception {
-        URL url = request.getServletContext().getResource(menuDefinition);
+        URL url = request.getSession().getServletContext().getResource(menuDefinition);
         return renderNavigationMenu(url, request, rendererClass, minDepth, maxDepth);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
@@ -32,8 +32,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
 
 /**
  * Utility methods for rendering navigation menus that are defined in XML files.
@@ -55,9 +55,27 @@ public enum RenderUtils {
     }
 
     /**
-     * Render the navigation menu given by the menu definition using the given renderer
-     * class. Therefore find the NavTree by looking it up in the smart cache first, then
-     * create a new NavTreeIndex passing in NavTree.
+     * Render the navigation menu for a given page context and menu definition using the
+     * given renderer class.
+     *
+     * @param pageContext the JSP page context
+     * @param menuDefinition the menu definition XML file
+     * @param rendererClass the renderer class to use
+     * @param minDepth minimal depth
+     * @param maxDepth maximal depth
+     * @return the rendered navigation menu as string
+     * @throws Exception in case of an error
+     */
+    public String renderNavigationMenu(PageContext pageContext, String menuDefinition,
+            String rendererClass, int minDepth, int maxDepth) throws Exception {
+        URL url = pageContext.getServletContext().getResource(menuDefinition);
+        HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
+        return renderNavigationMenu(url, request, rendererClass, minDepth, maxDepth);
+    }
+
+    /**
+     * Render the navigation menu for a given request and menu definition using the given
+     * renderer class.
      *
      * @param request the request object
      * @param menuDefinition the menu definition XML file
@@ -67,13 +85,18 @@ public enum RenderUtils {
      * @return the rendered navigation menu as string
      * @throws Exception in case of an error
      */
-    public String renderNavigationMenu(ServletRequest request, String menuDefinition,
+    public String renderNavigationMenu(HttpServletRequest request, String menuDefinition,
             String rendererClass, int minDepth, int maxDepth) throws Exception {
         URL url = request.getServletContext().getResource(menuDefinition);
+        return renderNavigationMenu(url, request, rendererClass, minDepth, maxDepth);
+    }
+
+    private String renderNavigationMenu(URL url, HttpServletRequest req,
+            String rendererClass, int minDepth, int maxDepth) throws Exception {
+        // Try to find the NavTree in the cache and index it
         NavTree navTree = NavCache.getTree(url);
         NavTreeIndex navTreeIndex = new NavTreeIndex(navTree);
 
-        HttpServletRequest req = (HttpServletRequest) request;
         User user = new RequestContext(req).getCurrentUser();
         Map<String, Object> aclContext = new HashMap<>();
         aclContext.put("user", user);


### PR DESCRIPTION
This patch is a refactoring of the `NavMenuTag` custom JSP tag that also affects the `NavDialogMenuTag`. The code that actually renders the markup is extracted into a helper class which simplifies a lot the tag implementation itself (`NavMenuTag.java`). This makes it also possible to render those menus from within other classes allowing us to even include the generated markup in pages that are served by a different web framework.

Unit tests apparently rely on the `pageContext` object though, so it was necessary to add a second entry point to `renderNavigationMenu()`, see 561e085.