### PR TITLE
Fix typo in spacewalk-common-channels.ini from previous merge

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1053,6 +1053,21 @@ name     = Spacewalk 2.2 Client for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/client/%(arch)s/
 
+[oraclelinux7-spacewalk24-server]
+label    = %(base_channel)s-spacewalk24-server
+archs    = x86_64
+name     = Spacewalk 2.4 Server for Oracle Linux 7 (%(arch)s)
+base_channels = oraclelinux7-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk24/server/%(arch)s/
+
+[oraclelinux7-spacewalk24-client]
+label    = %(base_channel)s-spacewalk24-client
+archs    = %(_x86_archs)s
+name     = Spacewalk 2.4 Client for Oracle Linux 7 (%(arch)s)
+base_channels = oraclelinux7-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk24/client/%(arch)s/
+
+
 [oraclelinux7-openstack20]
 label     = %(base_channel)s-openstack20
 archs     = x86_64
@@ -1141,6 +1156,21 @@ name     = Spacewalk 2.2 Client for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(arch)s/
 
+[oraclelinux6-spacewalk24-server]
+label    = %(base_channel)s-spacewalk24-server
+archs    = x86_64
+name     = Spacewalk 2.4 Server for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux6-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk24/server/%(arch)s/
+
+[oraclelinux6-spacewalk24-client]
+label    = %(base_channel)s-spacewalk24-client
+archs    = %(_x86_archs)s
+name     = Spacewalk 2.4 Client for Oracle Linux 6 (%(arch)s)
+base_channels = oraclelinux6-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk24/client/%(arch)s/
+
+
 [oraclelinux6-scl12]
 label     = %(base_channel)s-scl12
 archs     = x86_64
@@ -1192,4 +1222,11 @@ archs    = %(_x86_archs)s
 name     = Spacewalk 2.2 Client for Oracle Linux 5 (%(arch)s)
 base_channels = oraclelinux5-%(arch)s
 yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL5/spacewalk22/client/%(arch)s/
+
+[oraclelinux5-spacewalk24-client]
+label    = %(base_channel)s-spacewalk24-client
+archs    = %(_x86_archs)s
+name     = Spacewalk 2.4 Client for Oracle Linux 5 (%(arch)s)
+base_channels = oraclelinux5-%(arch)s
+yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL5/spacewalk24/client/%(arch)s/
 

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1062,7 +1062,7 @@ yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack20/%(arch)s/
 
 [oraclelinux7-scl12]
 label     = %(base_channel)s-scl12
-arches    = x86_64
+archs     = x86_64
 name      = Software Collection Library release 1.2 packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections12/%(arch)s/
@@ -1143,7 +1143,7 @@ yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(ar
 
 [oraclelinux6-scl12]
 label     = %(base_channel)s-scl12
-arches    = x86_64
+archs     = x86_64
 name      = Software Collection Library release 1.2 packages for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/SoftwareCollections12/%(arch)s/


### PR DESCRIPTION
This was caught by our internal QA team.

Signed-off-by: Avi Miller <avi.miller@oracle.com>