### PR TITLE
fix pyGIWarning: GUdev was imported without specifying a version first.

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/hardware_gudev.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/hardware_gudev.py
@@ -13,6 +13,8 @@
 #
 
 try:
+    import gi
+    gi.require_version('GUdev', '1.0')
     from gi.repository import GUdev
     gi_gudev = True
 except ImportError:


### PR DESCRIPTION
/usr/share/rhn/up2date_client/hardware_gudev.py:18: PyGIWarning: GUdev was imported without specifying a version first. Use gi.require_version('GUdev', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import GUdev
