### PR TITLE
string - AttributeError: 'module'  object has no attribute 

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/clientCaps.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/clientCaps.py
@@ -52,7 +52,7 @@ def loadLocalCaps(capsDir = "/etc/sysconfig/rhn/clientCaps.d"):
 
         fd = open(capsFile, "r")
         for line in fd.readlines():
-            string.strip(line)
+            line = line.strip()
             if line[0] == "#":
                 continue
             caplist = parseCap(line)

--- a/client/rhel/rhn-client-tools/src/up2date_client/up2dateAuth.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/up2dateAuth.py
@@ -52,7 +52,7 @@ def maybeUpdateVersion():
       newSystemId = s.registration.upgrade_version(getSystemId(), systemVer)
 
       path = cfg["systemIdPath"]
-      dir = path[:string.rfind(path, "/")]
+      dir = path[:path.rfind("/")]
       if not os.access(dir, os.W_OK):
           try:
               os.mkdir(dir)


### PR DESCRIPTION
1)  File "/usr/share/rhn/up2date_client/clientCaps.py", line 55, in loadLocalCaps
    string.strip(line)
AttributeError: 'module' object has no attribute 'strip'

2)   File "/usr/share/rhn/up2date_client/up2dateAuth.py", line 55, in maybeUpdateVersion
    dir = path[:string.rfind(path, "/")]
AttributeError: 'module' object has no attribute 'rfind'