### PR TITLE
Log error in AbstractDatabaseAction

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/AbstractDatabaseAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AbstractDatabaseAction.java
@@ -54,7 +54,7 @@ public abstract class AbstractDatabaseAction implements MessageAction {
         }
         catch (Exception e) {
             commit = false;
-            e.printStackTrace();
+            log.error("Error executing action " + getClass().getName() , e);
         }
         finally {
             handleTransactions(commit);


### PR DESCRIPTION
Log the exception instead of doing a `printStackTrace()`. 