### PR TITLE
Bug 1300251 - clientCaps.py : IndexError: string index out of range

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/clientCaps.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/clientCaps.py
@@ -52,7 +52,7 @@ def loadLocalCaps(capsDir = "/etc/sysconfig/rhn/clientCaps.d"):
         fd = open(capsFile, "r")
         for line in fd.readlines():
             line = line.strip()
-            if line[0] == "#":
+            if not line or line[0] == "#":
                 continue
             caplist = parseCap(line)
 


### PR DESCRIPTION
Problem with empty line during parsing file  '/etc/sysconfig/rhn/clientCaps.d/configfiles'

(Pdb) fs = open(capsFile, "r")
(Pdb) fs.readlines()
['configfiles.mtime_upload(1)=1\n', 'configfiles.upload(1)=1\n', 'configfiles.deploy(1)=1\n', 'configfiles.diff(1)=1\n', 'configfiles.base64_enc(1)=1\n', '\n']

>> dnf install rhncfg-* -y
...
  File "/usr/share/rhn/up2date_client/clientCaps.py", line 57, in loadLocalCaps
    if line[0] == "#":
IndexError: string index out of range
