### PR TITLE
python <2.7 fix 'TypeError: encode() takes no keyword arguments'

### DIFF
--- a/client/rhel/rhnlib/rhn/i18n.py
+++ b/client/rhel/rhnlib/rhn/i18n.py
@@ -29,11 +29,11 @@ def ustr(obj):
         if isinstance(obj, str):
             return obj
         else:
-            return str(obj, 'utf8', errors='ignore')
+            return str(obj, 'utf8', 'ignore')
     else: # python2
         if isinstance(obj, unicode):
             return obj
-        return unicode(obj, 'utf8', errors='ignore')
+        return unicode(obj, 'utf8', 'ignore')
 
 def bstr(obj):
     # converts object to bytes like object
@@ -41,11 +41,11 @@ def bstr(obj):
         if isinstance(obj, bytes):
             return obj
         else:
-            return bytes(obj, 'utf8', errors='ignore')
+            return bytes(obj, 'utf8', 'ignore')
     else: # python2
         if isinstance(obj, str):
             return obj
-        return str(obj.encode('utf8', errors='ignore'))
+        return str(obj.encode('utf8', 'ignore'))
 
 def sstr(obj):
     # converts object to string
@@ -53,8 +53,8 @@ def sstr(obj):
         if isinstance(obj, str):
             return obj
         else:
-            return str(obj, 'utf8', errors='ignore')
+            return str(obj, 'utf8', 'ignore')
     else: # python2
         if isinstance(obj, str):
             return obj
-        return str(obj.encode('utf8', errors='ignore'))
+        return str(obj.encode('utf8', 'ignore'))

--- a/client/rhel/rhnlib/rhn/i18n.py
+++ b/client/rhel/rhnlib/rhn/i18n.py
@@ -29,7 +29,7 @@ def ustr(obj):
         if isinstance(obj, str):
             return obj
         else:
-            return str(obj, 'utf8', 'ignore')
+            return str(obj, 'utf8', errors='ignore')
     else: # python2
         if isinstance(obj, unicode):
             return obj
@@ -41,7 +41,7 @@ def bstr(obj):
         if isinstance(obj, bytes):
             return obj
         else:
-            return bytes(obj, 'utf8', 'ignore')
+            return bytes(obj, 'utf8', errors='ignore')
     else: # python2
         if isinstance(obj, str):
             return obj
@@ -53,7 +53,7 @@ def sstr(obj):
         if isinstance(obj, str):
             return obj
         else:
-            return str(obj, 'utf8', 'ignore')
+            return str(obj, 'utf8', errors='ignore')
     else: # python2
         if isinstance(obj, str):
             return obj


### PR DESCRIPTION
http://docs.python.org/library/stdtypes.html#str.decode

doc: str.encode([encoding[, errors]])
Changed in version 2.7: Support for keyword arguments added, but it isn't used in Python 2.4/2.6

