### PR TITLE
Add Chile to the list of timezones

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/user/UserFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/user/UserFactory.java
@@ -540,32 +540,26 @@ public  class UserFactory extends HibernateFactory {
                     public int compare(Object o1, Object o2) {
                         RhnTimeZone t1 = (RhnTimeZone) o1;
                         RhnTimeZone t2 = (RhnTimeZone) o2;
-                        int offSet1 = t1.getTimeZone().getRawOffset();
-                        int offSet2 = t2.getTimeZone().getRawOffset();
+                        Integer offSet1 = t1.getTimeZone().getRawOffset();
+                        Integer offSet2 = t2.getTimeZone().getRawOffset();
 
-                        if (offSet2 - offSet1 == 0) {
-                            return t2.getOlsonName().compareTo(t1.getOlsonName());
-                        }
-
-                        if (offSet1 <= -18000000 && offSet1 >= -36000000 &&
-                                offSet2 <= -18000000 && offSet2 >= -36000000) {
-                            //both in America
-                            return offSet2 - offSet1;
-                        }
-
-                        if (offSet1 <= -18000000 && offSet1 >= -36000000) {
-                            //first timezone in America
+                        if (offSet1 == 0 && offSet2 != 0) {
+                            // first one GMT
                             return -1;
                         }
-                        if (offSet2 <= -18000000 && offSet2 >= -36000000) {
-                            //second timezone in America
+
+                        if (offSet1 != 0 && offSet2 == 0) {
+                            // second one GMT
                             return 1;
                         }
 
-                        return offSet1 - offSet2;
+                        if (offSet2.equals(offSet1)) {
+                            return t2.getOlsonName().compareTo(t1.getOlsonName());
+                        }
+
+                        return offSet2.compareTo(offSet1);
                     }
-                }
-                        );
+                });
             }
 
             timeZoneList = timeZones;

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
@@ -178,6 +178,12 @@
           <context context-type="sourcefile">/rhn/account/UserDetails</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="Pacific/Easter">
+        <source>(GMT-0500) Chile (Easter Island)</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/account/UserDetails</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="Pacific/Honolulu">
         <source>(GMT-1000) United States (Hawaii)</source>
         <context-group name="ctx">
@@ -282,6 +288,12 @@
       </trans-unit>
       <trans-unit id="Pacific/Midway">
         <source>(GMT-1100) Midway</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/account/UserDetails</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="America/Santiago">
+        <source>(GMT-0300) Chile (Continental)</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/account/UserDetails</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -393,9 +393,13 @@ public class UserManagerTest extends RhnBaseTestCase {
         assertTrue(lst.get(5) instanceof RhnTimeZone);
         assertTrue(lst.get(34) instanceof RhnTimeZone);
 
+        assertEquals((RhnTimeZone)lst.get(0), UserManager
+                .getTimeZone("GMT"));
+        assertEquals(((RhnTimeZone)lst.get(0)).getOlsonName(), "GMT");
+
+        assertEquals(((RhnTimeZone)lst.get(5)).getOlsonName(), "Pacific/Auckland");
         assertEquals((RhnTimeZone)lst.get(5), UserManager
-                .getTimeZone("America/Denver"));
-        assertEquals(((RhnTimeZone)lst.get(5)).getOlsonName(), "America/Denver");
+                .getTimeZone("Pacific/Auckland"));
     }
 
    public void testUsersInSet() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -93,7 +93,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         regular.removePermanentRole(RoleFactory.ORG_ADMIN);
 
         assertTrue(admin.hasRole(RoleFactory.ORG_ADMIN));
-        assertTrue(!regular.hasRole(RoleFactory.ORG_ADMIN));
+        assertFalse(regular.hasRole(RoleFactory.ORG_ADMIN));
 
         // make sure admin can lookup regular by id and by login
         User test = UserManager.lookupUser(admin, regular.getId());
@@ -258,7 +258,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         UserManager.addRemoveUserRoles(usr, new LinkedList<String>(),
                 removeRoles);
         UserManager.storeUser(usr);
-        assertTrue((numRoles - 1) == usr.getRoles().size());
+        assertEquals(numRoles - 1, usr.getRoles().size());
 
         // Test that taking away org admin properly removes
         // permissions for the user (bz156752). Note that calling
@@ -364,8 +364,8 @@ public class UserManagerTest extends RhnBaseTestCase {
     public void testGetTimeZoneId() {
         RhnTimeZone tz = UserManager.getTimeZone(UserManager
                 .getTimeZone("Indian/Maldives").getTimeZoneId());
-        assertTrue(UserManager.getTimeZone("Indian/Maldives").equals(tz));
-        assertTrue(tz.getOlsonName().equals("Indian/Maldives"));
+        assertEquals(UserManager.getTimeZone("Indian/Maldives"), tz);
+        assertEquals(tz.getOlsonName(), "Indian/Maldives");
 
         RhnTimeZone tz2 = UserManager.getTimeZone(-23);
         assertNull(tz2);
@@ -374,7 +374,7 @@ public class UserManagerTest extends RhnBaseTestCase {
     public void testGetTimeZoneOlson() {
         RhnTimeZone tz = UserManager.getTimeZone("America/New_York");
         assertNotNull(tz);
-        assertTrue(tz.getOlsonName().equals("America/New_York"));
+        assertEquals(tz.getOlsonName(), "America/New_York");
 
         RhnTimeZone tz2 = UserManager.getTimeZone("foo");
         assertNull(tz2);
@@ -383,20 +383,19 @@ public class UserManagerTest extends RhnBaseTestCase {
     public void testGetTimeZoneDefault() {
         RhnTimeZone tz = UserManager.getDefaultTimeZone();
         assertNotNull(tz);
-        assertTrue(tz.getTimeZone().getRawOffset() == UserFactory.getDefaultTimeZone()
+        assertEquals(tz.getTimeZone().getRawOffset(), UserFactory.getDefaultTimeZone()
                 .getTimeZone().getRawOffset());
     }
 
     public void testLookupTimeZoneAll() {
         List lst = UserManager.lookupAllTimeZones();
         assertTrue(lst.size() > 30);
-        assertTrue(lst.get(0) instanceof RhnTimeZone);
         assertTrue(lst.get(5) instanceof RhnTimeZone);
         assertTrue(lst.get(34) instanceof RhnTimeZone);
 
-        assertTrue(((RhnTimeZone)lst.get(5)).equals(UserManager
-                .getTimeZone("America/Denver")));
-        assertTrue(((RhnTimeZone)lst.get(5)).getOlsonName().equals("America/Denver"));
+        assertEquals((RhnTimeZone)lst.get(5), UserManager
+                .getTimeZone("America/Denver"));
+        assertEquals(((RhnTimeZone)lst.get(5)).getOlsonName(), "America/Denver");
     }
 
    public void testUsersInSet() throws Exception {
@@ -482,7 +481,7 @@ public class UserManagerTest extends RhnBaseTestCase {
        SystemSearchResult sr = dr.get(0);
        System.err.println("sr.getDescription() = " + sr.getDescription());
        System.err.println("sr.getHostname() = " + sr.getHostname());
-       assertTrue(sr.getDescription() != null);
+       assertNotNull(sr.getDescription());
        //assertTrue(sr.getHostname() != null);
    }
 }

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -388,17 +388,17 @@ public class UserManagerTest extends RhnBaseTestCase {
     }
 
     public void testLookupTimeZoneAll() {
-        List lst = UserManager.lookupAllTimeZones();
+        List<RhnTimeZone> lst = UserManager.lookupAllTimeZones();
         assertTrue(lst.size() > 30);
         assertTrue(lst.get(5) instanceof RhnTimeZone);
         assertTrue(lst.get(34) instanceof RhnTimeZone);
 
-        assertEquals((RhnTimeZone)lst.get(0), UserManager
+        assertEquals(lst.get(0), UserManager
                 .getTimeZone("GMT"));
-        assertEquals(((RhnTimeZone)lst.get(0)).getOlsonName(), "GMT");
+        assertEquals(lst.get(0).getOlsonName(), "GMT");
 
-        assertEquals(((RhnTimeZone)lst.get(5)).getOlsonName(), "Pacific/Auckland");
-        assertEquals((RhnTimeZone)lst.get(5), UserManager
+        assertEquals(lst.get(5).getOlsonName(), "Pacific/Auckland");
+        assertEquals(lst.get(5), UserManager
                 .getTimeZone("Pacific/Auckland"));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -348,7 +348,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         usr.setEmail("something@changed.redhat.com");
         UserManager.storeUser(usr);
         User u2 = UserFactory.lookupById(id);
-        assertEquals(u2.getEmail(), "something@changed.redhat.com");
+        assertEquals("something@changed.redhat.com", u2.getEmail());
     }
 
     public void testGetSystemGroups() {
@@ -365,7 +365,7 @@ public class UserManagerTest extends RhnBaseTestCase {
         RhnTimeZone tz = UserManager.getTimeZone(UserManager
                 .getTimeZone("Indian/Maldives").getTimeZoneId());
         assertEquals(UserManager.getTimeZone("Indian/Maldives"), tz);
-        assertEquals(tz.getOlsonName(), "Indian/Maldives");
+        assertEquals("Indian/Maldives", tz.getOlsonName());
 
         RhnTimeZone tz2 = UserManager.getTimeZone(-23);
         assertNull(tz2);
@@ -393,13 +393,11 @@ public class UserManagerTest extends RhnBaseTestCase {
         assertTrue(lst.get(5) instanceof RhnTimeZone);
         assertTrue(lst.get(34) instanceof RhnTimeZone);
 
-        assertEquals(lst.get(0), UserManager
-                .getTimeZone("GMT"));
-        assertEquals(lst.get(0).getOlsonName(), "GMT");
+        assertEquals(UserManager.getTimeZone("GMT"), lst.get(0));
+        assertEquals("GMT", lst.get(0).getOlsonName());
 
-        assertEquals(lst.get(5).getOlsonName(), "Pacific/Auckland");
-        assertEquals(lst.get(5), UserManager
-                .getTimeZone("Pacific/Auckland"));
+        assertEquals("Pacific/Auckland", lst.get(5).getOlsonName());
+        assertEquals(UserManager.getTimeZone("Pacific/Auckland"), lst.get(5));
     }
 
    public void testUsersInSet() throws Exception {

--- a/schema/spacewalk/common/data/rhnTimezone.sql
+++ b/schema/spacewalk/common/data/rhnTimezone.sql
@@ -142,6 +142,11 @@ values
   (sequence_nextval('rhn_timezone_id_seq'),
    'America/Anchorage', 'United States (Alaska)');
 
+insert into rhnTimezone
+  (id, olson_name, display_name)
+values
+  (sequence_nextval('rhn_timezone_id_seq'),
+   'America/Santiago', 'Chile (Continental)');
 
 insert into rhnTimezone
   (id, olson_name, display_name)
@@ -256,6 +261,12 @@ insert into rhnTimezone
 values
   (sequence_nextval('rhn_timezone_id_seq'),
    'Atlantic/South_Georgia', 'Sandwich Islands');
+
+insert into rhnTimezone
+  (id, olson_name, display_name)
+values
+  (sequence_nextval('rhn_timezone_id_seq'),
+   'Pacific/Easter', 'Chile (Easter Island)');
 
 insert into rhnTimezone
   (id, olson_name, display_name)

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/202-rhnTimezone-data.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/202-rhnTimezone-data.sql
@@ -1,0 +1,27 @@
+insert into rhnTimezone (id, olson_name, display_name) (
+    select sequence_nextval('rhn_timezone_id_seq'),
+           'America/Santiago',
+           'Chile (Continental)'
+      from dual
+     where not exists (
+           select 1
+             from rhnTimezone
+            where olson_name = 'America/Santiago'
+              and display_name = 'Chile (Continental)'
+     )
+);
+
+insert into rhnTimezone (id, olson_name, display_name) (
+    select sequence_nextval('rhn_timezone_id_seq'),
+           'Pacific/Easter',
+           'Chile (Easter Island)'
+      from dual
+     where not exists (
+           select 1
+             from rhnTimezone
+            where olson_name = 'Pacific/Easter'
+              and display_name = 'Chile (Easter Island)'
+     )
+);
+
+


### PR DESCRIPTION
Chile recently switched to follow UTC-03:00 but without DST so there is no compatible timezone to be selected.

Also, the current timezone sorting algorithm only uses the offset, so tweak it to avoid Chile going to the top.