### PR TITLE
Remove custom latest RPM handling in spacewalk-repo-sync

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -209,7 +209,7 @@ class ContentSource(object):
         return to_return
 
     @staticmethod
-    def _sort_packages(self, pkg1 ,pkg2):
+    def _sort_packages(pkg1 ,pkg2):
         """sorts a list of yum package objects by name"""
         if pkg1.name > pkg2.name:
             return 1

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -175,9 +175,9 @@ class ContentSource(object):
         pkglist = ListPackageSack(self.sack.returnPackages())
         self.num_packages = len(pkglist)
         if latest:
-             pkglist = pkglist.returnNewestByNameArch()
+            pkglist = pkglist.returnNewestByNameArch()
         pkglist = yum.misc.unique(pkglist)
-        pkglist.sort(self.sortPkgObj)
+        pkglist.sort(self._sort_packages)
 
         if not filters:
             # if there's no include/exclude filter on command line or in database
@@ -208,7 +208,8 @@ class ContentSource(object):
             to_return.append(new_pack)
         return to_return
 
-    def sortPkgObj(self, pkg1 ,pkg2):
+    @staticmethod
+    def _sort_packages(self, pkg1 ,pkg2):
         """sorts a list of yum package objects by name"""
         if pkg1.name > pkg2.name:
             return 1

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -113,17 +113,6 @@ def getCustomChannels():
 
     return l_custom_ch
 
-def latest_packages(packages):
-    #allows to download only latest packages
-    packages.sort(reverse=True)
-    seen = set()
-    latest = []
-    for pack in packages:
-        if pack.getNRA() not in seen:
-            latest.append(pack)
-            seen.add(pack.getNRA())
-    return latest
-
 class RepoSync(object):
 
     def __init__(self, channel_label, repo_type, url=None, fail=False,
@@ -473,9 +462,7 @@ class RepoSync(object):
         else:
             filters = self.filters
 
-        packages = plug.list_packages(filters)
-        if self.latest:
-            packages = latest_packages(packages)
+        packages = plug.list_packages(filters, self.latest)
         to_process = []
         num_passed = len(packages)
         self.print_msg("Packages in repo:             %5d" % plug.num_packages)


### PR DESCRIPTION
The custom logic was failing for some RPMs in the Oracle Linux repositories. I refactored `yum_src.py` to use the same yum functions as the `reposync` tool from `yum-utils` does.

I also added in the sort function so that the RPMs are downloaded in alphabetical order, like `reposync` does too.

Signed-off-by: Avi Miller <avi.miller@oracle.com>