### PR TITLE
python3 input compatibility

### DIFF
--- a/client/rhel/rhn-client-tools/src/bin/spacewalk-channel.py
+++ b/client/rhel/rhn-client-tools/src/bin/spacewalk-channel.py
@@ -27,6 +27,7 @@ try: # python2
 except ImportError: # python3
     import urllib.parse as urlparse
     import xmlrpc.client as xmlrpclib
+    raw_input = input
 
 import gettext
 t = gettext.translation('rhn-client-tools', fallback=True)
@@ -53,10 +54,7 @@ class Credentials(object):
 
     def __getattr__(self, attr):
         if attr == 'user':
-            tty = open("/dev/tty", "r+")
-            tty.write('Username: ')
-            tty.close()
-            setattr(self, 'user', sys.stdin.readline().rstrip('\n'))
+            self.user = raw_input('Username: ')
             return self.user
         elif attr == 'password':
             # force user population


### PR DESCRIPTION
bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1259884 comment 35

> rhn-channel -L

An error has occurred:
<class 'io.UnsupportedOperation'>
See /var/log/up2date for more information
[root@daemon2 lau18]# tail /var/log/up2date
  File "/sbin/rhn-channel", line 242, in <module>
    main()
  File "/sbin/rhn-channel", line 232, in main
    list_available_channels(credentials)
  File "/sbin/rhn-channel", line 209, in list_available_channels
    channels = get_available_channels(credentials.user, credentials.password)
  File "/sbin/rhn-channel", line 56, in __getattr__
    tty = open("/dev/tty", "r+")
<class 'io.UnsupportedOperation'>: File or stream is not seekable.
