### PR TITLE
Fixed missing method for sorting of rhnChannels

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/rhnChannel.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/rhnChannel.py
@@ -29,6 +29,12 @@ class rhnChannel:
     def __setitem__(self, item, value):
         self.dict[item] = value
 
+    def __lt__(self, other):
+        if self.dict["name"] < other.dict["name"]:
+            return True
+        else:
+            return False
+
     def keys(self):
         return self.dict.keys()
 


### PR DESCRIPTION
bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1259884 comment 24

Traceback (most recent call last):
  File "/usr/sbin/rhn-channel", line 242, in <module>
    main()
  File "/usr/sbin/rhn-channel", line 226, in main
    list_channels()
  File "/usr/sbin/rhn-channel", line 203, in list_channels
    for channel in sorted(channels):
<class 'TypeError'>: unorderable types: rhnChannel() < rhnChannel()