### PR TITLE
Python24rhel5

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/config.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/config.py
@@ -163,7 +163,7 @@ class ConfigFile:
                 return
 
         f = open(self.fileName+'.new', "w")
-        os.chmod(self.fileName, int('0o600', 8))
+        os.chmod(self.fileName, int('0600', 8))
 
         f.write("# Automatically generated Red Hat Update Agent "\
                 "config file, do not edit.\n")

--- a/client/rhel/rhn-client-tools/src/up2date_client/rhnreg.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/rhnreg.py
@@ -147,7 +147,7 @@ def _write_secure_file(secure_file, file_contents):
         except:
             return False
 
-    fd = os.open(secure_file, os.O_WRONLY | os.O_CREAT, int('0o600', 8))
+    fd = os.open(secure_file, os.O_WRONLY | os.O_CREAT, int('0600', 8))
     fd_file = os.fdopen(fd, 'w')
     try:
         fd_file.write(sstr(file_contents))

--- a/client/rhel/rhn-client-tools/src/up2date_client/up2dateAuth.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/up2dateAuth.py
@@ -72,7 +72,7 @@ def maybeUpdateVersion():
       f.write(newSystemId)
       f.close()
       try:
-          os.chmod(path, int('0o600', 8))
+          os.chmod(path, int('0600', 8))
       except:
           pass
 
@@ -96,12 +96,12 @@ def writeCachedLogin():
     if not os.access(pcklDir, os.W_OK):
         try:
             os.mkdir(pcklDir)
-            os.chmod(pcklDir, int('0o700', 8))
+            os.chmod(pcklDir, int('0700', 8))
         except:
             log.log_me("Unable to write pickled loginInfo to %s" % pcklDir)
             return False
     pcklAuth = open(pcklAuthFileName, 'wb')
-    os.chmod(pcklAuthFileName, int('0o600', 8))
+    os.chmod(pcklAuthFileName, int('0600', 8))
     pickle.dump(data, pcklAuth)
     pcklAuth.close()
     expireTime = data['time'] + float(loginInfo['X-RHN-Auth-Expire-Offset'])

--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -30,7 +30,7 @@ import os
 
 import socket
 import select
-
+from rhn.i18n import bstr
 import sys
 
 DEFAULT_TIMEOUT = 120
@@ -66,7 +66,7 @@ class SSLSocket:
         # Position, for tell()
         self._pos = 0
         # Buffer
-        self._buffer = b""
+        self._buffer = bstr("")
 
         # Flag to show if makefile() was called
         self._makefile_called = 0
@@ -211,7 +211,7 @@ class SSLSocket:
             self._buffer = self._buffer[amt:]
         else:
             ret = self._buffer
-            self._buffer = b""
+            self._buffer = bstr("")
 
         self._pos = self._pos + len(ret)
         return ret
@@ -266,7 +266,7 @@ class SSLSocket:
             # charcount contains the number of chars to be outputted (or None
             # if none to be outputted at this time)
             charcount = None
-            i = self._buffer.find(b'\n')
+            i = self._buffer.find(bstr('\n'))
             if i >= 0:
                 # Go one char past newline
                 charcount = i + 1


### PR DESCRIPTION
The registration system doesn't work on RHEL5 due to python 2.4 syntax error. I created some litle fixes. And I found out next one problem, that is described in this comment https://github.com/spacewalkproject/spacewalk/commit/d726a1eac0193bed1b36d84f96b2e54bf9af8d76