### PR TITLE
RPC debugging information in satellite-sync

### DIFF
--- a/backend/satellite_tools/connection.py
+++ b/backend/satellite_tools/connection.py
@@ -100,8 +100,12 @@ class StreamConnection(_Server):
 
     def __init__(self, uri, proxy=None, username=None, password=None,
                  refreshCallback=None, xml_dump_version=constants.PROTOCOL_VERSION,
-                 timeout=None):
-        _Server.__init__(self, uri, proxy=proxy, username=username,
+                 timeout=None, debug=0):
+        if (debug < 2):
+            # satellite-sync runs at debug 1 normally, but this produces some output
+            # from the rpclib server connection.  So by '1' we mean '0' here.
+            debug = 0
+        _Server.__init__(self, uri, proxy=proxy, username=username, verbose=debug,
                          password=password, refreshCallback=refreshCallback, timeout=timeout)
         self.add_header("X-RHN-Satellite-XML-Dump-Version", xml_dump_version)
 

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -105,7 +105,7 @@ class BaseWireSource:
     def _set_connection(self, url):
         "Instantiates a connection object"
 
-        serverObj = connection.StreamConnection(url, proxy=CFG.HTTP_PROXY,
+        serverObj = connection.StreamConnection(url, proxy=CFG.HTTP_PROXY, debug=CFG.DEBUG,
                                                 username=CFG.HTTP_PROXY_USERNAME, password=CFG.HTTP_PROXY_PASSWORD,
                                                 xml_dump_version=self.xml_dump_version, timeout=CFG.timeout)
         BaseWireSource.serverObj = serverObj
@@ -144,6 +144,7 @@ class BaseWireSource:
         wait = 0.33
         lastErrorMsg = ''
         cfg = config.initUp2dateConfig()
+        log(2, "Requesting '%s' from server with params (%s)" % (method, params)
         for i in range(cfg['networkRetries']):
             server = self.getServer(retryYN)
             if server is None:


### PR DESCRIPTION
Pass the debug level into the RPC library's server handler for debug levels above 1 (which is 'normal' in satellite-sync but emits data in rpclib).
