### PR TITLE
1232596 - still require openscap-utils on RHEL5

### DIFF
--- a/client/rhel/spacewalk-oscap/spacewalk-oscap.spec
+++ b/client/rhel/spacewalk-oscap/spacewalk-oscap.spec
@@ -12,7 +12,11 @@ BuildArch:	noarch
 BuildRequires:	python-devel
 BuildRequires:	rhnlib
 BuildRequires:  libxslt
+%if 0%{?rhel} && 0%{?rhel} < 6
+Requires: openscap-utils >= 1.0.8-1
+%else
 Requires:	openscap-scanner
+%endif
 Requires:	libxslt
 Requires:       rhnlib
 Requires:       rhn-check


### PR DESCRIPTION
cherry picked from commit db3287fe19df204a3c9841eb915bdce8ecf37da6

I'm not sure if this is the right way to cherry pick a commit into a release version :) Currently the spacewalk-oscap package is broken on rhel5 because it requires a non-existent package. It's been fixed in 2.5 but not in the current release. I think it should be done to have an actual working stable package for rhel5.

Greetings
Klaas