### PR TITLE
Rhn hidden taglib provide

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RhnHiddenTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RhnHiddenTag.java
@@ -20,6 +20,7 @@ import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.TagSupport;
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 
 import com.redhat.rhn.frontend.html.HiddenInputTag;
 import com.redhat.rhn.frontend.html.HtmlTag;
@@ -35,6 +36,7 @@ public class RhnHiddenTag extends TagSupport {
 
     private static final long serialVersionUID = -8385317358288103720L;
 
+    private String id;
     private String name;
     private String value;
 
@@ -50,6 +52,20 @@ public class RhnHiddenTag extends TagSupport {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @param inId the id to set
+     */
+    public void setId(String inId) {
+        this.id = inId;
+    }
+
+    /**
+     * @return the id
+     */
+    public String getId() {
+        return id;
     }
 
     /**
@@ -84,6 +100,9 @@ public class RhnHiddenTag extends TagSupport {
             out = pageContext.getOut();
 
             HtmlTag baseTag = new HiddenInputTag();
+            if (!StringUtils.isBlank(getId())) {
+                baseTag.setAttribute("id", getId());
+            }
             baseTag.setAttribute("name", getName());
             baseTag.setAttribute("value", StringEscapeUtils.escapeHtml(getValue()));
             buf.append(baseTag.render());

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/RhnHiddenTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/RhnHiddenTagTest.java
@@ -83,4 +83,22 @@ public class RhnHiddenTagTest extends RhnBaseTestCase {
           fail(je.toString());
       }
     }
+
+    public void testTagWithId() {
+        String expected = "<input type=\"hidden\"" +
+                          " id=\"tid\"" +
+                          " name=\"test\"" +
+                          " value=\"foo\"" +
+                          " />";
+        ht.setName("test");
+        ht.setId("tid");
+        ht.setValue("foo\"><script>alert(1);</script>");
+        ht.setValue("foo");
+        try {
+            verifyTag(expected);
+        }
+        catch (JspException je) {
+            fail(je.toString());
+        }
+    }
 }


### PR DESCRIPTION
rhn:hidden need to handle id as well.
This should fix buttons on the provisioning schedule page.

complete commit 63e3ccec4130622059e9f89fd96bcc83269383d1

@ggainey please check