### PR TITLE
Disable changing Managers for Vendor Channels

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channels/ManagersSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channels/ManagersSetupAction.java
@@ -64,6 +64,7 @@ public class ManagersSetupAction extends RhnAction implements Listable {
         }
 
         request.setAttribute("channel_name", currentChan.getName());
+        request.setAttribute("is_custom", currentChan.isCustom());
         request.setAttribute(RequestContext.CID, cid);
 
         Map params = makeParamMap(request);

--- a/java/code/webapp/WEB-INF/pages/common/fragments/manage/managers.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/manage/managers.jspf
@@ -9,14 +9,22 @@
     <rhn:csrf />
 
     <rl:list>
-
-        <rl:decorator name="SelectableDecorator"/>
+        <c:if test="${is_custom}">
+            <rl:decorator name="SelectableDecorator"/>
+        </c:if>
         <rl:decorator name="PageSizeDecorator"/>
 
         <c:if test='${not current.disabled}'>
-        <rl:selectablecolumn value="${current.id}"
-            selected="${current.selected}">
-        </rl:selectablecolumn>
+            <c:if test="${is_custom}">
+                <rl:selectablecolumn value="${current.id}"
+                    selected="${current.selected}">
+                </rl:selectablecolumn>
+            </c:if>
+            <c:if test="${not is_custom}">
+                <rl:column>
+                    <input type="checkbox" disabled="1" />
+                </rl:column>
+            </c:if>
         </c:if>
         <c:if test='${current.disabled}'>
             <rl:column>
@@ -58,11 +66,12 @@
     </rl:list>
 
     <hr />
-    <div class="text-right">
-        <html:submit styleClass="btn btn-default" property="dispatch">
-                <bean:message key="message.Update" />
-        </html:submit>
-    </div>
-    <rhn:submitted/>
-
+    <c:if test="${is_custom}">
+        <div class="text-right">
+            <html:submit styleClass="btn btn-default" property="dispatch">
+                    <bean:message key="message.Update" />
+            </html:submit>
+        </div>
+        <rhn:submitted/>
+    </c:if>
 </rl:listset>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/manage/managers.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/manage/managers.jspf
@@ -65,8 +65,8 @@
 
     </rl:list>
 
-    <hr />
     <c:if test="${is_custom}">
+        <hr />
         <div class="text-right">
             <html:submit styleClass="btn btn-default" property="dispatch">
                     <bean:message key="message.Update" />


### PR DESCRIPTION
This UI editable makes only sense for custom channels. For Vendor Channels a readonly
variant is sufficient.
