### PR TITLE
Fix the string representation of PackageEvr

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.domain.rhnpackage;
 
 import com.redhat.rhn.common.util.RpmVersionComparator;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
@@ -174,14 +175,20 @@ public class PackageEvr implements Comparable {
     }
 
     /**
-     * {@inheritDoc}
+     * Return a string representation in the format "[epoch:]version-release".
+     *
+     * @return string representation of epoch, version and release
      */
+    @Override
     public String toString() {
-        String retval = "";
-        if (this.getEpoch() != null) {
-            retval = this.getEpoch() + ".";
+        StringBuilder builder = new StringBuilder();
+        if (StringUtils.isNumeric(getEpoch())) {
+            builder.append(getEpoch());
+            builder.append(":");
         }
-        retval = retval + this.getVersion() + "." + this.getRelease();
-        return retval;
+        builder.append(getVersion());
+        builder.append("-");
+        builder.append(getRelease());
+        return builder.toString();
     }
 }


### PR DESCRIPTION
This patch fixes the `toString()` method of `PackageEvr` to return a string representation that makes more sense. Also the new format looks more like what the other code actually [seems to expect] (https://github.com/spacewalkproject/spacewalk/blob/master/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java#L473).