### PR TITLE
Fix: add a missing url mapping

### DIFF
--- a/java/code/webapp/WEB-INF/nav/sitenav-authenticated.xml
+++ b/java/code/webapp/WEB-INF/nav/sitenav-authenticated.xml
@@ -94,6 +94,7 @@
         <rhn-tab-url>/rhn/kickstart/TreeEdit.do</rhn-tab-url>
         <rhn-tab-url>/rhn/kickstart/TreeCreate.do</rhn-tab-url>
         <rhn-tab-url>/rhn/kickstart/TreeDelete.do</rhn-tab-url>
+        <rhn-tab-url>/rhn/kickstart/tree/EditVariables.do</rhn-tab-url>
       </rhn-tab>
       <rhn-tab name="File Preservation" acl="user_role(config_admin)" url="/rhn/systems/provisioning/preservation/PreservationList.do">
         <rhn-tab-url>/rhn/systems/provisioning/preservation/PreservationListEdit.do</rhn-tab-url>


### PR DESCRIPTION
This PR fix the correct `sidenav` highlighted label for the `rhn/kickstart/tree/EditVariables.do` URL since the mapping was missing.

Before:
![before](https://cloud.githubusercontent.com/assets/7080830/13987932/1df15f86-f10a-11e5-86f8-286651ddf9a7.png)

  
After:
![after](https://cloud.githubusercontent.com/assets/7080830/13987933/1e154b12-f10a-11e5-8ca6-f3b6ae38fb06.png)
