### PR TITLE
fix splitting kernel options

### DIFF
--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -393,7 +393,7 @@ public abstract class CobblerObject {
 
         String[] options = StringUtils.split(kernelOpts);
         for (String option : options) {
-            String[] split = option.split("=", 1);
+            String[] split = option.split("=", 2);
             if (split.length == 1) {
                 toRet.put(split[0], new ArrayList<String>());
             }


### PR DESCRIPTION
limit -- the result threshold which means how many strings to be returned.

option.split("=", 1) returns the whole string without splitting, so we need to provide "2" to split one time.
