### PR TITLE
Fix: Taskomatic periodically crashes, terminated with SIGKILL when JVM appears hung

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/core/BaseDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/BaseDaemon.java
@@ -37,6 +37,7 @@ public abstract class BaseDaemon implements WrapperListener {
     public static final int LOG_INFO = WrapperManager.WRAPPER_LOG_LEVEL_INFO;
     public static final int LOG_ERROR = WrapperManager.WRAPPER_LOG_LEVEL_ERROR;
     public static final int LOG_FATAL = WrapperManager.WRAPPER_LOG_LEVEL_FATAL;
+    public static final int LOG_STATUS = WrapperManager.WRAPPER_LOG_LEVEL_STATUS;
 
     public static final int SUCCESS = Integer.MIN_VALUE;
 

--- a/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
@@ -18,7 +18,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
-import org.apache.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,21 +75,23 @@ public class TaskomaticDaemon  extends BaseDaemon {
     }
 
     protected int onStartup(CommandLine commandLine) {
-        Logger log = Logger.getLogger(this.getClass());
         Map overrides = null;
         int retval = BaseDaemon.SUCCESS;
 
         //since the cobbler sync tasks rely on tomcat to be up
         //   let sleep until it is up
+        logMessage(BaseDaemon.LOG_STATUS, "Waiting for tomcat...", null);
         while (!isTomcatUp()) {
             try {
-                log.info("Tomcat is not up yet, sleeping 4 seconds");
+                logMessage(BaseDaemon.LOG_STATUS, "Tomcat is not up yet, sleeping 4 seconds", null);
                 Thread.sleep(4000);
             }
             catch (Exception e) {
                 e.printStackTrace();
             }
         }
+        logMessage(BaseDaemon.LOG_STATUS, "Tomcat up...", null);
+
         if (commandLine != null) {
             overrides = parseOverrides(commandLine);
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
@@ -20,12 +20,9 @@ import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-
-import redstone.xmlrpc.XmlRpcClient;
 
 /**
  * Implementation of the Taskomatic schedule task execution system.
@@ -77,20 +74,6 @@ public class TaskomaticDaemon  extends BaseDaemon {
     protected int onStartup(CommandLine commandLine) {
         Map overrides = null;
         int retval = BaseDaemon.SUCCESS;
-
-        //since the cobbler sync tasks rely on tomcat to be up
-        //   let sleep until it is up
-        logMessage(BaseDaemon.LOG_STATUS, "Waiting for tomcat...", null);
-        while (!isTomcatUp()) {
-            try {
-                logMessage(BaseDaemon.LOG_STATUS, "Tomcat is not up yet, sleeping 4 seconds", null);
-                Thread.sleep(4000);
-            }
-            catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-        logMessage(BaseDaemon.LOG_STATUS, "Tomcat up...", null);
 
         if (commandLine != null) {
             overrides = parseOverrides(commandLine);
@@ -173,20 +156,5 @@ public class TaskomaticDaemon  extends BaseDaemon {
         if (this.masterOptionsMap.get(longopt) == null) {
             this.masterOptionsMap.put(longopt, option);
         }
-    }
-
-    private boolean isTomcatUp() {
-        boolean toRet = false;
-        try {
-            XmlRpcClient client = new XmlRpcClient("http://localhost/rpc/api", false);
-            Object obj = client.invoke("api.getVersion", Collections.EMPTY_LIST);
-            if (obj instanceof String) {
-                toRet = true;
-            }
-        }
-        catch (Exception e) {
-            toRet = false;
-        }
-        return toRet;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
@@ -85,9 +85,9 @@ public class TaskomaticDaemon  extends BaseDaemon {
                     try {
                         kernel.startup();
                     }
-                    catch (TaskomaticException e) {
+                    catch (Throwable e) {
                         logMessage(BaseDaemon.LOG_FATAL, e.getMessage(), e);
-
+                        System.exit(-1);
                     }
                 }
             };

--- a/java/conf/default/rhn_taskomatic_daemon.conf
+++ b/java/conf/default/rhn_taskomatic_daemon.conf
@@ -133,3 +133,7 @@ wrapper.syslog.loglevel=STATUS
 # Title to use when running as a console
 wrapper.console.title=RHN Taskomatic
 
+# Under high load, the service wrapper may incorrectly interpret
+# the inability to get a response in time from taskomatic and kill
+# it
+wrapper.ping.timeout=0

--- a/java/scripts/taskomatic.service
+++ b/java/scripts/taskomatic.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Taskomatic
-After=local-fs.target cobblerd.service sendmail.service
+After=local-fs.target cobblerd.service sendmail.service httpd.service postgresql.service
+Requires=postgresql.service httpd.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Taskomatic uses tanukiwrapper. Tanukiwrapper is a C process that spawns the JVM and does the following extra actions:

* Forward jvm output to the logfile
* Ping the jvm, via a protocol/socket implemented in the `WrapperListener` interface which forces the java daemon to be implemented using a event loop architecture where all tasks happen in threads started from the event loop.

However, there are various problems:

* TaskomaticDaemon checks for tomcat being up inside the event loop, which makes Tanuki think the jvm is stuck. Problem is that after trying a few times, tanuki will leave taskomatic in dead state.
* There is no need to check for tomcat because Taskomatic depends on cobbler API that it is routed via apache and not tomcat (not sure the reasoning behind 6fdefd2bff03a67b04d76c0f7e3cd667434db410). We can express this better using systemd dependencies.
* Under high load, tanuki thinks the JVM is dead when it is not, and kills it. This can be reproduced simulating high load.

So this patchset:

* Removes the check for tomcat at startup of taskomatic
* Disables the ping timeout for Tanukiwrapper
* The last commit 	59d3949 prevents that if a database restart or similar prevents quartz of initializing correctly, that you dont end with a zombie taskomatic that looks running from tanuki point of view but it is not scheduling anything (eg. when SchedulerKernel throws a PostgreSQL exception).

We are also working in getting completely rid of Tanuki and have systemd manage taskomatic directly. You will see a PR into that direction in the future, but this patchset should make the situation better meanwhile.