### PR TITLE
spacewalk-admin: build on openSUSE

### DIFF
--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -12,7 +12,7 @@ Requires: spacewalk-base
 Requires: perl(MIME::Base64)
 Requires: lsof
 BuildRequires: /usr/bin/pod2man
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?suse_version} >= 1210
 BuildRequires: systemd
 %endif
 Obsoletes: satellite-utils < 5.3.0
@@ -20,6 +20,9 @@ Provides: satellite-utils = 5.3.0
 Obsoletes: rhn-satellite-admin < 5.3.0
 Provides: rhn-satellite-admin = 5.3.0
 BuildArch: noarch
+%if 0%{?suse_version}
+BuildRequires: spacewalk-config
+%endif
 
 %description
 Various utility scripts and data files for Spacewalk installations.
@@ -32,9 +35,13 @@ Various utility scripts and data files for Spacewalk installations.
 %install
 rm -rf $RPM_BUILD_ROOT
 
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?suse_version} >= 1210
 mv -f spacewalk-service.systemd spacewalk-service
 make -f Makefile.admin install_systemd PREFIX=$RPM_BUILD_ROOT
+%if 0%{?suse_version} >= 1210
+install -m 644 spacewalk.target.SUSE $RPM_BUILD_ROOT%{_unitdir}/spacewalk.target
+install -m 644 spacewalk-wait-for-tomcat.service.SUSE $RPM_BUILD_ROOT%{_unitdir}/spacewalk-wait-for-tomcat.service
+%endif
 %endif
 make -f Makefile.admin install PREFIX=$RPM_BUILD_ROOT
 
@@ -75,7 +82,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man8/rhn-deploy-ca-cert.pl.8*
 %{_mandir}/man8/rhn-install-ssl-cert.pl.8*
 %config(noreplace) %{_sysconfdir}/rhn/service-list
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?suse_version} >= 1210
 %{_unitdir}/spacewalk.target
 %{_unitdir}/spacewalk-wait-for-tomcat.service
 %{_unitdir}/spacewalk-wait-for-jabberd.service

--- a/spacewalk/admin/spacewalk-service
+++ b/spacewalk/admin/spacewalk-service
@@ -32,8 +32,13 @@ if [ -e /lib/systemd/system/tomcat.service ]; then
    TOMCAT="tomcat"
 fi
 
+HTTPD="httpd"
 
-SERVICES="jabberd $TOMCAT httpd osa-dispatcher rhn-search cobblerd taskomatic"
+if [ -e /lib/systemd/system/apache2.service -o -e /etc/init.d/apache2 ]; then
+   HTTPD="apache2"
+fi
+
+SERVICES="jabberd $TOMCAT $HTTPD osa-dispatcher rhn-search cobblerd taskomatic"
 if [ -f /etc/rhn/service-list ] ; then
    . /etc/rhn/service-list
 fi

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+LSOF="/usr/sbin/lsof"
+if [ -x "/usr/bin/lsof" ]; then
+    LSOF="/usr/bin/lsof"
+fi
+
 wait_for_database() {
     RETRIES=10;
     while [ $RETRIES -gt 0 ]; do
@@ -20,7 +25,7 @@ wait_for_jabberd() {
     RETRIES=10
     while [ $RETRIES -gt 0 ]
     do
-        /usr/sbin/lsof -t -i :5222 > /dev/null && break
+        $LSOF -t -i :5222 > /dev/null && break
         ((RETRIES--))
         sleep 0.5
     done
@@ -33,16 +38,18 @@ elif [ -x /etc/init.d/tomcat6 ]; then
    TOMCAT_PID=$(cat /var/run/tomcat6.pid 2>/dev/null)
 elif [ -e /lib/systemd/system/tomcat.service ]; then
    TOMCAT_PID=$(systemctl show --property=MainPID tomcat.service | sed 's/^MainPID=0*//')
+elif [ -e /usr/lib/systemd/system/tomcat.service ]; then
+   TOMCAT_PID=$(systemctl show --property=MainPID tomcat.service | sed 's/^MainPID=0*//')
 else
    echo "No tomcat service found."
    exit 0;
 fi
 
-if [ -x /usr/sbin/lsof ]; then
+if [ -x $LSOF ]; then
     echo "Waiting for tomcat to be ready ..."
     while [ -n "$TOMCAT_PID" ] ; do
-        /usr/sbin/lsof -t -i TCP:8005 | grep "^$TOMCAT_PID$" > /dev/null \
-        && /usr/sbin/lsof -t -i TCP:8009 | grep "^$TOMCAT_PID$" > /dev/null \
+        $LSOF -t -i TCP:8005 | grep "^$TOMCAT_PID$" > /dev/null \
+        && $LSOF -t -i TCP:8009 | grep "^$TOMCAT_PID$" > /dev/null \
         && break
         sleep 1
     done

--- a/spacewalk/admin/spacewalk-wait-for-tomcat.service.SUSE
+++ b/spacewalk/admin/spacewalk-wait-for-tomcat.service.SUSE
@@ -1,0 +1,10 @@
+[Unit]
+Description=Spacewalk wait for tomcat
+After=tomcat.service
+Before=apache2.service
+ConditionPathExists=!/var/run/spacewalk-wait-for-tomcat-disable
+
+[Service]
+ExecStart=/usr/sbin/spacewalk-startup-helper wait-for-tomcat
+Type=oneshot
+RemainAfterExit=yes

--- a/spacewalk/admin/spacewalk.target.SUSE
+++ b/spacewalk/admin/spacewalk.target.SUSE
@@ -1,0 +1,16 @@
+[Unit]
+Description=Spacewalk
+Requires=jabberd.service
+Requires=tomcat.service
+Requires=spacewalk-wait-for-tomcat.service
+Requires=apache2.service
+Requires=spacewalk-wait-for-jabberd.service
+Requires=osa-dispatcher.service
+Requires=Monitoring.service
+Requires=MonitoringScout.service
+Requires=rhn-search.service
+Requires=cobblerd.service
+Requires=taskomatic.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
A first step to build on openSUSE
- openSUSE uses systemd too
- workaround different names httpd.service vs. apache2.service
- workaround different paths for lsof
- workaround different paths for tomcat.service file
