### PR TITLE
spacewalk-client-cert: build on openSUSE

### DIFF
--- a/client/tools/spacewalk-client-cert/spacewalk-client-cert.spec
+++ b/client/tools/spacewalk-client-cert/spacewalk-client-cert.spec
@@ -35,7 +35,12 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %config  /etc/sysconfig/rhn/clientCaps.d/client-cert
 %{_datadir}/rhn/actions/clientcert.*
-
+%if 0%{?suse_version}
+%dir /etc/sysconfig/rhn
+%dir /etc/sysconfig/rhn/clientCaps.d
+%dir %{_datadir}/rhn
+%dir %{_datadir}/rhn/actions
+%endif
 
 %changelog
 * Tue Apr 26 2016 Gennadii Altukhov <galt@redhat.com> 2.5.1-1


### PR DESCRIPTION
add some directories to the filelist which are required for openSUSE
