### PR TITLE
fix dropping unused entitlements when multiple orgs are available

### DIFF
--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/148-delete_rhnServerGroupType.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/148-delete_rhnServerGroupType.sql.oracle
@@ -4,7 +4,7 @@ BEGIN
 logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -15,7 +15,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -26,7 +26,7 @@ DELETE FROM rhnRegTokenGroups
   );
 
 DELETE FROM rhnServerGroupMembers
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -37,7 +37,7 @@ DELETE FROM rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -48,7 +48,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -59,7 +59,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/148-delete_rhnServerGroupType.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/148-delete_rhnServerGroupType.sql.postgresql
@@ -1,11 +1,11 @@
--- oracle equivalent source sha1 d130b6810a88f60d18168cf65494494f3ce00e6f
+-- oracle equivalent source sha1 cb70a658c37d3b3f12288856bff108af32440b92
 
 -- rhnServerGroup and dependencies
 
 SELECT logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -16,7 +16,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -27,7 +27,7 @@ DELETE FROM rhnRegTokenGroups
   );
 
 DELETE FROM rhnServerGroupMembers
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -38,7 +38,7 @@ DELETE FROM rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -49,7 +49,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -60,7 +60,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/162-delete_update_ent_references.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/162-delete_update_ent_references.sql.oracle
@@ -4,7 +4,7 @@ BEGIN
 logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -15,7 +15,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -25,17 +25,42 @@ DELETE FROM rhnRegTokenGroups
       )
   );
 
-UPDATE rhnServerGroupMembers
-  SET server_group_id = (
-    SELECT id
-      FROM rhnServerGroup
-      WHERE group_type = (
-        SELECT id
-          FROM rhnServerGroupType
-          WHERE label = 'enterprise_entitled'
-      )
-  )
-  WHERE server_group_id = (
+-- create server group for 'enterprise_entitled' everywhere
+insert into rhnServerGroup ( id, name, description, group_type, org_id )
+  select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name, sgt.id, X.org_id
+  from rhnServerGroupType sgt,
+     (select distinct msg.org_id
+        from rhnServerGroup msg
+       where msg.org_id not in (select org_id
+                                  from rhnServerGroup sg
+                                  join rhnServerGroupType sgt ON sgt.id = sg.group_type
+                                 where sgt.label = 'enterprise_entitled')
+     ) X
+  where sgt.label = 'enterprise_entitled';
+
+-- add membership to 'enterprise_entitled' for all server which
+-- are currently in the group 'sw_mgr_entitled'
+  insert into rhnServerGroupMembers (server_id, server_group_id)
+    select * from (
+      select sgm.server_id,
+        (select nsg.id
+           from rhnServerGroup nsg
+           join rhnServerGroupType nsgt on nsg.group_type = nsgt.id
+          where nsgt.label = 'enterprise_entitled'
+            and nsg.org_id = sg.org_id) new_group_id
+        from rhnServerGroupMembers sgm
+        join rhnServerGroup sg on sgm.server_group_id = sg.id
+        join rhnServerGroupType sgt on sg.group_type = sgt.id
+       where sgt.label = 'sw_mgr_entitled'
+    ) X
+    where not exists (select 1
+                       from rhnServerGroupMembers csgm
+                      where csgm.server_id = X.server_id
+                        and csgm.server_group_id = X.new_group_id);
+
+-- remove 'sw_mgr_entitled'
+DELETE FROM rhnServerGroupMembers
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -46,7 +71,7 @@ UPDATE rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -57,7 +82,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -68,7 +93,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/162-delete_update_ent_references.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/162-delete_update_ent_references.sql.postgresql
@@ -1,11 +1,11 @@
--- oracle equivalent source sha1 1e7ab38a3e0da7867b5bcdf43c1360b92a361d47
+-- oracle equivalent source sha1 fdb7fb6f76a5509db4e37e0c64f2293dc65a421c
 
 -- rhnServerGroup and dependencies
 
 SELECT logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -16,7 +16,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -26,17 +26,42 @@ DELETE FROM rhnRegTokenGroups
       )
   );
 
-UPDATE rhnServerGroupMembers
-  SET server_group_id = (
-    SELECT id
-      FROM rhnServerGroup
-      WHERE group_type = (
-        SELECT id
-          FROM rhnServerGroupType
-          WHERE label = 'enterprise_entitled'
-      )
-  )
-  WHERE server_group_id = (
+-- create server group for 'enterprise_entitled' everywhere
+insert into rhnServerGroup ( id, name, description, group_type, org_id )
+  select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name, sgt.id, X.org_id
+  from rhnServerGroupType sgt,
+     (select distinct msg.org_id
+        from rhnServerGroup msg
+       where msg.org_id not in (select org_id
+                                  from rhnServerGroup sg
+                                  join rhnServerGroupType sgt ON sgt.id = sg.group_type
+                                 where sgt.label = 'enterprise_entitled')
+     ) X
+  where sgt.label = 'enterprise_entitled';
+
+-- add membership to 'enterprise_entitled' for all server which
+-- are currently in the group 'sw_mgr_entitled'
+  insert into rhnServerGroupMembers (server_id, server_group_id)
+    select * from (
+      select sgm.server_id,
+        (select nsg.id
+           from rhnServerGroup nsg
+           join rhnServerGroupType nsgt on nsg.group_type = nsgt.id
+          where nsgt.label = 'enterprise_entitled'
+            and nsg.org_id = sg.org_id) new_group_id
+        from rhnServerGroupMembers sgm
+        join rhnServerGroup sg on sgm.server_group_id = sg.id
+        join rhnServerGroupType sgt on sg.group_type = sgt.id
+       where sgt.label = 'sw_mgr_entitled'
+    ) X
+    where not exists (select 1
+                       from rhnServerGroupMembers csgm
+                      where csgm.server_id = X.server_id
+                        and csgm.server_group_id = X.new_group_id);
+
+-- remove 'sw_mgr_entitled'
+DELETE FROM rhnServerGroupMembers
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -45,9 +70,10 @@ UPDATE rhnServerGroupMembers
           WHERE label = 'sw_mgr_entitled'
       )
   );
+
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -58,7 +84,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -69,7 +95,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/164-remove_non_linux_references.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/164-remove_non_linux_references.sql.oracle
@@ -4,7 +4,7 @@ BEGIN
 logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -15,7 +15,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -25,17 +25,8 @@ DELETE FROM rhnRegTokenGroups
       )
   );
 
-UPDATE rhnServerGroupMembers
-  SET server_group_id = (
-    SELECT id
-      FROM rhnServerGroup
-      WHERE group_type = (
-        SELECT id
-          FROM rhnServerGroupType
-          WHERE label = 'enterprise_entitled'
-      )
-  )
-  WHERE server_group_id = (
+DELETE FROM rhnServerGroupMembers
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -46,7 +37,7 @@ UPDATE rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -57,7 +48,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -68,7 +59,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/164-remove_non_linux_references.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/164-remove_non_linux_references.sql.postgresql
@@ -1,11 +1,11 @@
--- oracle equivalent source sha1 2d283d880fe87ba1c8742c01cec850d330d04885
+-- oracle equivalent source sha1 fd8c26dc60bc3a72e5b84629b4e37e74124e3037
 
 -- rhnServerGroup and dependencies
 
 SELECT logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -16,7 +16,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -27,7 +27,7 @@ DELETE FROM rhnRegTokenGroups
   );
 
 DELETE FROM rhnServerGroupMembers
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -38,7 +38,7 @@ DELETE FROM rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -49,7 +49,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -60,7 +60,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/166-remove_virtualization_host_platform_refs.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/166-remove_virtualization_host_platform_refs.sql.oracle
@@ -4,7 +4,7 @@ BEGIN
 logging.clear_log_id();
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -15,7 +15,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -25,17 +25,42 @@ DELETE FROM rhnRegTokenGroups
       )
   );
 
-UPDATE rhnServerGroupMembers
-  SET server_group_id = (
-    SELECT id
-      FROM rhnServerGroup
-      WHERE group_type = (
-        SELECT id
-          FROM rhnServerGroupType
-          WHERE label = 'virtualization_host'
-      )
-  )
-  WHERE server_group_id = (
+-- create server group for 'virtualization_host' everywhere
+insert into rhnServerGroup ( id, name, description, group_type, org_id )
+  select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name, sgt.id, X.org_id
+  from rhnServerGroupType sgt,
+     (select distinct msg.org_id
+        from rhnServerGroup msg
+       where msg.org_id not in (select org_id
+                                  from rhnServerGroup sg
+                                  join rhnServerGroupType sgt ON sgt.id = sg.group_type
+                                 where sgt.label = 'virtualization_host')
+     ) X
+  where sgt.label = 'virtualization_host';
+
+-- add membership to 'virtualization_host' for all server which
+-- are currently in the group 'virtualization_host_platform'
+  insert into rhnServerGroupMembers (server_id, server_group_id)
+    select * from (
+      select sgm.server_id,
+        (select nsg.id
+           from rhnServerGroup nsg
+           join rhnServerGroupType nsgt on nsg.group_type = nsgt.id
+          where nsgt.label = 'virtualization_host'
+            and nsg.org_id = sg.org_id) new_group_id
+        from rhnServerGroupMembers sgm
+        join rhnServerGroup sg on sgm.server_group_id = sg.id
+        join rhnServerGroupType sgt on sg.group_type = sgt.id
+       where sgt.label = 'virtualization_host_platform'
+    ) X
+    where not exists (select 1
+                       from rhnServerGroupMembers csgm
+                      where csgm.server_id = X.server_id
+                        and csgm.server_group_id = X.new_group_id);
+
+-- remove 'virtualization_host_platform'
+DELETE FROM rhnServerGroupMembers
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -46,7 +71,7 @@ UPDATE rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -57,7 +82,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -68,7 +93,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/166-remove_virtualization_host_platform_refs.sql.postgresql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.4-to-spacewalk-schema-2.5/166-remove_virtualization_host_platform_refs.sql.postgresql
@@ -1,9 +1,11 @@
--- oracle equivalent source sha1 3062dd19d000fdb1884097b21443a7488e49899c
+-- oracle equivalent source sha1 e4d10e2ff0e864db3d6264989c7be9808ace88d5
+
+SELECT logging.clear_log_id();
 
 -- rhnServerGroup and dependencies
 
 DELETE FROM rhnOrgExtGroupMapping
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -14,7 +16,7 @@ DELETE FROM rhnOrgExtGroupMapping
   );
 
 DELETE FROM rhnRegTokenGroups
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -24,17 +26,42 @@ DELETE FROM rhnRegTokenGroups
       )
   );
 
-UPDATE rhnServerGroupMembers
-  SET server_group_id = (
-    SELECT id
-      FROM rhnServerGroup
-      WHERE group_type = (
-        SELECT id
-          FROM rhnServerGroupType
-          WHERE label = 'virtualization_host'
-      )
-  )
-  WHERE server_group_id = (
+-- create server group for 'virtualization_host' everywhere
+insert into rhnServerGroup ( id, name, description, group_type, org_id )
+  select nextval('rhn_server_group_id_seq'), sgt.name, sgt.name, sgt.id, X.org_id
+  from rhnServerGroupType sgt,
+     (select distinct msg.org_id
+        from rhnServerGroup msg
+       where msg.org_id not in (select org_id
+                                  from rhnServerGroup sg
+                                  join rhnServerGroupType sgt ON sgt.id = sg.group_type
+                                 where sgt.label = 'virtualization_host')
+     ) X
+  where sgt.label = 'virtualization_host';
+
+-- add membership to 'virtualization_host' for all server which
+-- are currently in the group 'virtualization_host_platform'
+  insert into rhnServerGroupMembers (server_id, server_group_id)
+    select * from (
+      select sgm.server_id,
+        (select nsg.id
+           from rhnServerGroup nsg
+           join rhnServerGroupType nsgt on nsg.group_type = nsgt.id
+          where nsgt.label = 'virtualization_host'
+            and nsg.org_id = sg.org_id) new_group_id
+        from rhnServerGroupMembers sgm
+        join rhnServerGroup sg on sgm.server_group_id = sg.id
+        join rhnServerGroupType sgt on sg.group_type = sgt.id
+       where sgt.label = 'virtualization_host_platform'
+    ) X
+    where not exists (select 1
+                       from rhnServerGroupMembers csgm
+                      where csgm.server_id = X.server_id
+                        and csgm.server_group_id = X.new_group_id);
+
+-- remove 'virtualization_host_platform'
+DELETE FROM rhnServerGroupMembers
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -45,7 +72,7 @@ UPDATE rhnServerGroupMembers
   );
 
 DELETE FROM rhnSnapshotServerGroup
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -56,7 +83,7 @@ DELETE FROM rhnSnapshotServerGroup
   );
 
 DELETE FROM rhnUserDefaultSystemGroups
-  WHERE system_group_id = (
+  WHERE system_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (
@@ -67,7 +94,7 @@ DELETE FROM rhnUserDefaultSystemGroups
   );
 
 DELETE FROM rhnUserServerGroupPerms
-  WHERE server_group_id = (
+  WHERE server_group_id in (
     SELECT id
       FROM rhnServerGroup
       WHERE group_type = (


### PR DESCRIPTION
If multiple organizations are available the schema migration failed with syntax errors.
