### PR TITLE
fix remote command doesn't work in Python 3

### DIFF
--- a/client/tools/rhncfg/actions/configfiles.py
+++ b/client/tools/rhncfg/actions/configfiles.py
@@ -23,8 +23,6 @@ from config_common.transactions import DeployTransaction, FailedRollback
 
 from config_client import rpc_cli_repository
 
-from string import split
-
 sys.path.append('/usr/share/rhn')
 from up2date_client import config
 
@@ -47,7 +45,7 @@ ACTION_VERSION = 2
 _permission_root_dir = '/etc/sysconfig/rhn/allowed-actions'
 def _local_permission_check(action_type):
     # action_type ala configfiles.deploy
-    atype_structure = split(action_type, '.')
+    atype_structure = action_type.split('.')
 
     for i in range(len(atype_structure)):
         all_structure = atype_structure[:i]

--- a/client/tools/rhncfg/actions/script.py
+++ b/client/tools/rhncfg/actions/script.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 # this is ugly, hopefully it will be natively supported in up2date
-from configfiles import _local_permission_check, _perm_error
+from actions.configfiles import _local_permission_check, _perm_error
 from config_common import local_config
 from config_common.rhn_log import set_logfile, log_to_file
 
@@ -72,7 +72,7 @@ def _create_script_file(script, uid=None, gid=None):
     else:
         # Tried a couple of times, failed; bail out raising the latest error
         raise
-    sf = os.fdopen(fd, 'w')
+    sf = os.fdopen(fd, 'wb')
     sf.write(script.encode("utf-8"))
     sf.close()
 


### PR DESCRIPTION
this patch fixs following errors:

1.  sf.write(script.encode("utf-8")) <class 'TypeError'>: must be str, not bytes

2.  *** ImportError: cannot import name 'split'

3.  up2date_client.getMethod.GetMethodException: Could not import module actions.script