### PR TITLE
1332224 - service osad doesn't work with selinux

### DIFF
--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -1377,7 +1377,7 @@ def generate_random_string(length=20):
     s = hashlib.new('sha1')
     s.update(bstr("%.8f" % time.time()))
     s.update(bstr("%s" % os.getpid()))
-    devrandom = open('/dev/urandom', "rb+")
+    devrandom = open('/dev/urandom', "rb")
     result = []
     cur_length = 0
     while 1:


### PR DESCRIPTION
I fix problem with avc message

type=AVC msg=audit(1462198745.064:6466): avc:  denied  { write } for  pid=20175 comm="osad" name="urandom" dev="devtmpfs" ino=6936 scontext=system_u:system_r:osad_t:s0 tcontext=system_u:object_r:urandom_device_t:s0 tclass=chr_file permissive=0