### PR TITLE
Don't modify request map when rendering alphabar

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTag.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.ServletRequest;
@@ -728,12 +727,10 @@ public class ListDisplayTag extends ListDisplayTagBase {
             }
         }
         else { //get vars from url
-            Map qvars = rq.getParameterMap();
-            qvars.remove("lower"); //don't repeat lower
-            Iterator iter = qvars.keySet().iterator();
+            Iterator iter = rq.getParameterMap().keySet().iterator();
             while (iter.hasNext()) {
                 String key = (String) iter.next();
-                if (key.equals("submitted")) {
+                if (key.equals("submitted") || key.equals("lower")) {
                     continue;
                 }
                 if (!PAGINATION_WASH_SET.contains(key)) {


### PR DESCRIPTION
..., since it may fail depending on the implementation of ServletRequest.

In older tomcats (6, 7), the request map was implemented as a HashMap, which survived the modification. This is not true in tomcat 8 and the modification can fail.

Moreover, the documentation of ServletRequest interface says this map is
immutable which suggests that modifying it is a bad idea.

Although this is not reproducible on Spacewalk 2.5.49 with tomcat 7.0.59, this will likely become a problem when tomcat is upgraded to 8 and shouldn't be forgotten.
