### PR TITLE
replace has_key to work in python 3

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/actions/errata.py
+++ b/client/rhel/dnf-plugin-spacewalk/actions/errata.py
@@ -38,7 +38,7 @@ def update(errataidlist, cache_only=None):
     current_packages_with_arch = {}
     current_packages ={}
     for p in pkgUtils.getInstalledPackageList(getArch=1):
-        current_packages_with_arch[p['name']+p['arch']] = p
+        current_packages_with_arch[p['name'] + p['arch']] = p
         current_packages[p['name']] = p
 
     u = {}
@@ -49,23 +49,23 @@ def update(errataidlist, cache_only=None):
     if len(packagelist[0]) > 4:
         # Newer sats send down arch, filter using name+arch
         for p in packagelist:
-            if current_packages_with_arch.has_key(p[0]+p[4]):
-                u[p[0]+p[4]] = p
-            elif current_packages_with_arch.has_key(p[0]+"noarch"):
-                u[p[0]+p[4]] = p
-            elif p[4] == "noarch" and current_packages.has_key(p[0]):
+            if "%s%s" % (p[0], p[4]) in current_packages_with_arch:
+                u[p[0] + p[4]] = p
+            elif "%snoarch" % p[0] in current_packages_with_arch:
+                u[p[0] + p[4]] = p
+            elif p[4] == "noarch" and p[0] in current_packages:
                 u[p[0]] = p
     else:
         # 5.2 and older sats + hosted dont send arch
         for p in packagelist:
-            if current_packages.has_key(p[0]):
+            if p[0] in current_packages:
                 u[p[0]] = p
 
 
     # XXX: Fix me - once we keep all errata packages around,
     # this is the WRONG thing to do - we want to keep the specific versions
     # that the user has asked for.
-    packagelist = map(lambda a: u[a], u.keys())
+    packagelist = list(u.values())
 
     if packagelist == []:
         data = {}


### PR DESCRIPTION
I tried to apply erratum and I received following traceback. The has_key is not possible to use in python 3

```
>> rhn_check -vv 
...
D: rpcServer: Calling XMLRPC errata.getErrataInfo
D: Sending back response((6,), 'Fatal error in Python code occurred', {})
D: do_call packages.checkNeedUpdate('rhnsd=1',){}
D: local action status: (0, 'rpm database not modified since last update (or package list recently updated)', {})
D: rpcServer: Calling XMLRPC registration.welcome_message
[root@test08-64 ~]# tail -f /var/log/up2date 
  File "/usr/sbin/rhn_check", line 364, in __do_call
    retval = method(*params, **kwargs)
  File "/usr/share/rhn/actions/errata.py", line 54, in update
    if current_packages_with_arch.has_key(p[0]+p[4]):
<class 'AttributeError'>: 'dict' object has no attribute 'has_key'
[Tue May 10 16:16:54 2016] up2date D: Sending back response((6,), 'Fatal error in Python code occurred', {})
[Tue May 10 16:16:55 2016] up2date D: do_call packages.checkNeedUpdate('rhnsd=1',){}
[Tue May 10 16:16:55 2016] up2date D: local action status: (0, 'rpm database not modified since last update (or package list recently updated)', {})
[Tue May 10 16:16:55 2016] up2date D: rpcServer: Calling XMLRPC registration.welcome_message

```