### PR TITLE
dnf - wrong print traceback

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+++ b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
@@ -101,8 +101,7 @@ class Spacewalk(dnf.Plugin):
             try:
                 login_info = up2date_client.up2dateAuth.getLoginInfo(timeout=self.conf.timeout)
             except up2dateErrors.RhnServerException as e:
-                logger.error("%s\n%s\n%s", COMMUNICATION_ERROR, RHN_DISABLED,
-                                           ustr(e))
+                logger.error("%s\n%s\n%s", COMMUNICATION_ERROR, RHN_DISABLED, e)
                 return
 
             if not login_info:
@@ -114,8 +113,7 @@ class Spacewalk(dnf.Plugin):
                 svrChannels = up2date_client.rhnChannel.getChannelDetails(
                                                               timeout=self.conf.timeout)
             except up2dateErrors.CommunicationError as e:
-                logger.error("%s\n%s\n%s", COMMUNICATION_ERROR, RHN_DISABLED,
-                                           ustr(e))
+                logger.error("%s\n%s\n%s", COMMUNICATION_ERROR, RHN_DISABLED, e)
                 return
             except up2dateErrors.NoChannelsError:
                 logger.error("%s\n%s", NOT_SUBSCRIBED_ERROR, CHANNELS_DISABLED)
@@ -175,8 +173,7 @@ class Spacewalk(dnf.Plugin):
             up2date_client.rhnPackageInfo.updatePackageProfile(
                                                         timeout=self.conf.timeout)
         except up2dateErrors.RhnServerException as e:
-            logger.error("%s\n%s\n%s", COMMUNICATION_ERROR, PROFILE_NOT_SENT,
-                                       ustr(e))
+            logger.error("%s\n%s\n%s", COMMUNICATION_ERROR, PROFILE_NOT_SENT, e)
 
 
     def _read_channels_file(self):


### PR DESCRIPTION
When satellite is not available the dnf don't print correct traceback.

```
...
  File "/usr/lib/python3.4/site-packages/dnf/plugin.py", line 82, in fn
    dnf.util.mapall(operator.methodcaller(method), self.plugins)
  File "/usr/lib/python3.4/site-packages/dnf/util.py", line 157, in mapall
    return list(map(fn, *seq))
  File "/usr/lib/python3.4/site-packages/dnf-plugins/spacewalk.py", line 83, in config
    self.activate_channels(self.cli.demands.sack_activation)
  File "/usr/lib/python3.4/site-packages/dnf-plugins/spacewalk.py", line 105, in activate_channels
    ustr(e))
  File "/usr/lib/python3.4/site-packages/rhn/i18n.py", line 32, in ustr
    return str(obj, 'utf8', errors='ignore')
TypeError: coercing to str: need a bytes-like object, CommunicationError found

```