### PR TITLE
fix 'ValueError: invalid literal for int() with base 10' in python 3

### DIFF
--- a/client/tools/rhncfg/config_common/repository.py
+++ b/client/tools/rhncfg/config_common/repository.py
@@ -50,7 +50,9 @@ rpclib = rpc_wrapper
 
 def deci_to_octal(number):
     """convert a normal decimal int to another int representing the octal value"""
-    return int(oct(number))
+    # python 2.4/2.6: oct(420) -> '0644'
+    # python 3.4: oct(420) -> '0o644'
+    return int(oct(number).replace("o", ""))
 
 
 class Repository:


### PR DESCRIPTION
Function **oct** returns different string in Python 3 than Python 2. Python 3 adds prefix "0o.." instead of "0..".

0o644 versus 0644 and it is not used in Python 3. 

`>> rhncfg-manager add  -c test-channel package.rpm`

```
Traceback (most recent call last):
....
    params.update(self.make_stat_info(local_path, file_stat))
  File "/usr/share/rhn/config_common/repository.py", line 107, in make_stat_info
    ret['mode'] = deci_to_octal(ret['mode'] & int('07777', 8))
  File "/usr/share/rhn/config_common/repository.py", line 53, in deci_to_octal
    return int(oct(number))
ValueError: invalid literal for int() with base 10: '0o644'
```