### PR TITLE
create the symlink directly and point to correct destination on SUSE

### DIFF
--- a/spacewalk/config/etc/pki/tls/certs/spacewalk.crt.symlink
+++ b/spacewalk/config/etc/pki/tls/certs/spacewalk.crt.symlink
@@ -1,1 +1,0 @@
-Link to ../../../httpd/conf/ssl.crt/server.crt

--- a/spacewalk/config/etc/pki/tls/private/spacewalk.key.symlink
+++ b/spacewalk/config/etc/pki/tls/private/spacewalk.key.symlink
@@ -1,1 +1,0 @@
-Link to ../../../httpd/conf/ssl.key/server.key

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -61,12 +61,15 @@ tar -C $RPM_BUILD_ROOT%{prepdir} -cf - etc \
 
 echo "" > $RPM_BUILD_ROOT/%{_sysconfdir}/rhn/rhn.conf
 
-find $RPM_BUILD_ROOT -name '*.symlink' | \
-	while read filename ; do linkname=${filename%.symlink} ; \
-		target=`sed -s 's/^Link to //' $filename` ; \
-		ln -sf $target $linkname ; \
-		rm -f $filename ; \
-	done
+mkdir -p $RPM_BUILD_ROOT/etc/pki/tls/certs/
+mkdir -p $RPM_BUILD_ROOT/etc/pki/tls/private/
+%if 0%{?suse_version}
+ln -sf  %{apacheconfdir}/ssl.key/server.key $RPM_BUILD_ROOT/etc/pki/tls/private/spacewalk.key
+ln -sf  %{apacheconfdir}/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/certs/spacewalk.crt
+%else
+ln -sf  %{apacheconfdir}/conf/ssl.key/server.key $RPM_BUILD_ROOT/etc/pki/tls/private/spacewalk.key
+ln -sf  %{apacheconfdir}/conf/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/certs/spacewalk.crt
+%endif
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
The certificates are created at a different destination on a SUSE system.
This commit creates the symlinks directly in the spec and choose the correct destination on SUSE.
