### PR TITLE
convert binary data to string to possible compare data in Python 3

### DIFF
--- a/client/tools/rhnpush/uploadLib.py
+++ b/client/tools/rhnpush/uploadLib.py
@@ -35,6 +35,7 @@ from spacewalk.common import rhn_mpm
 from spacewalk.common.rhn_pkg import package_from_filename, get_package_header
 from spacewalk.common.usix import raise_with_tb
 from up2date_client import rhnserver
+from rhn.i18n import sstr
 
 try:
     from rhn import rpclib
@@ -436,7 +437,7 @@ class UploadClass:
             # Some feedback
             if self.options.verbose:
                 ReportError("Uploading batch:")
-                for p in uploadedPackages.values()[0]:
+                for p in list(uploadedPackages.values())[0]:
                     ReportError("\t\t%s" % p)
 
             if source:
@@ -456,7 +457,7 @@ class UploadClass:
                     key = tuple(p[:5])
                     if key not in uploadedPackages:
                         # XXX Hmm
-                        self.warn("XXX XXX %s" % str(p))
+                        self.warn(1, "XXX XXX %s" % str(p))
                     filename, checksum = uploadedPackages[key]
                     # Some debugging
                     if self.options.verbose:
@@ -546,17 +547,16 @@ class UploadClass:
         # Get the name, version, release, epoch, arch
         lh = []
         for k in ['name', 'version', 'release', 'epoch']:
-            lh.append(a_pkg.header[k])
-        # Fix the epoch
-        if lh[3] is None:
-            lh[3] = ""
-        else:
-            lh[3] = str(lh[3])
+            if k == 'epoch' and not a_pkg.header[k]:
+            # Fix the epoch
+                lh.append(sstr(""))
+            else:
+                lh.append(sstr(a_pkg.header[k]))
 
         if source:
             lh.append('src')
         else:
-            lh.append(a_pkg.header['arch'])
+            lh.append(sstr(a_pkg.header['arch']))
 
         # Build the header hash to be sent
         info = {'header': Binary(a_pkg.header.unload()),

--- a/client/tools/rhnpush/uploadLib.py
+++ b/client/tools/rhnpush/uploadLib.py
@@ -316,7 +316,7 @@ class UploadClass:
                 del same_names_hash[remote_nvrea]
                 continue
 
-            for local_nvrea in same_names_hash.keys():
+            for local_nvrea in list(same_names_hash.keys()):
                 # XXX is_mpm sould be set accordingly
                 ret = packageCompare(local_nvrea, remote_nvrea,
                                      is_mpm=0)


### PR DESCRIPTION
On line 458 it is compared list of strings with list of binary, it is mistake and rhnpush doesn't work correct in Python 3. It is possible to convert binary to string.

``` if key not in uploadedPackages:
 ...
if ('test-package', '0.2', '2', None) in [b'test-package', b'0.2', b'2', None]
```