### PR TITLE
Only trigger virtualization notification on server save when the virtualization data is not falsy

### DIFF
--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -484,8 +484,7 @@ class Server(ServerWrapper):
 
     def handle_virtual_guest(self):
         # Handle virtualization specific bits
-        if self.virt_uuid is not None and \
-           self.virt_type is not None:
+        if self.virt_uuid and self.virt_type:
             rhnVirtualization._notify_guest(self.getid(),
                                             self.virt_uuid, self.virt_type)
 


### PR DESCRIPTION
Previously the condition check allowed triggering this event on values such like `''`.