### PR TITLE
Fix encodestring

### DIFF
--- a/client/tools/spacewalk-abrt/src/spacewalk_abrt/abrt.py
+++ b/client/tools/spacewalk-abrt/src/spacewalk_abrt/abrt.py
@@ -18,6 +18,7 @@ import base64
 import os
 import sys
 import errno
+from rhn.i18n import bstr
 
 RHNROOT = '/usr/share/rhn'
 if RHNROOT not in sys.path:
@@ -117,7 +118,7 @@ def report(problem_dir):
         crash_file_data = {'filename': os.path.basename(i),
                            'path': path,
                            'filesize': filesize,
-                           'filecontent': base64.encodestring(""),
+                           'filecontent': base64.encodestring(bstr("")),
                            'content-encoding': 'base64'}
         if server.abrt.is_crashfile_upload_enabled(systemid) and filesize <= server.abrt.get_crashfile_uploadlimit(systemid):
             f = open(path, 'r')


### PR DESCRIPTION
fix this error:

```
Traceback (most recent call last):
...
  File "/usr/share/rhn/spacewalk_abrt/abrt.py", line 169, in sync
    report(problem_dir)
  File "/usr/share/rhn/spacewalk_abrt/abrt.py", line 120, in report
    'filecontent': base64.encodestring(""),
  File "/usr/lib64/python3.4/base64.py", line 548, in encodestring
    return encodebytes(s)
  File "/usr/lib64/python3.4/base64.py", line 536, in encodebytes
    _input_type_check(s)
  File "/usr/lib64/python3.4/base64.py", line 522, in _input_type_check
    raise TypeError(msg) from err
<class 'TypeError'>: expected bytes-like object, not str

```