### PR TITLE
call 'queue channel change' only once per channel change

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -17,24 +17,6 @@
  */
 package com.redhat.rhn.domain.errata;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-
-import org.apache.commons.collections.IteratorUtils;
-import org.apache.log4j.Logger;
-import org.hibernate.HibernateException;
-import org.hibernate.Query;
-import org.hibernate.Session;
-
 import com.redhat.rhn.common.db.DatabaseException;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -66,6 +48,24 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidChannelException;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.log4j.Logger;
+import org.hibernate.HibernateException;
+import org.hibernate.Query;
+import org.hibernate.Session;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 /**
  * ErrataFactory - the singleton class used to fetch and store
@@ -336,9 +336,7 @@ public class ErrataFactory extends HibernateFactory {
 
 
     private static void postPublishActions(Channel chan, User user) {
-        ChannelManager.refreshWithNewestPackages(chan, "web.errata_push");
-        ChannelManager.queueChannelChange(chan.getLabel(),
-                "java::publishErrataPackagesToChannel", user.getLogin());
+        ChannelManager.refreshWithNewestPackages(chan, "java::publishErrataPackagesToChannel");
     }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -14,20 +14,6 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.channel.software;
 
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.StopWatch;
-import org.apache.log4j.Logger;
-
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -93,6 +79,20 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
 import com.redhat.rhn.taskomatic.task.errata.ErrataCacheWorker;
+
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.StopWatch;
+import org.apache.log4j.Logger;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * ChannelSoftwareHandler
@@ -1386,12 +1386,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
             ChannelManager.removePackages(channel, packagesToRemove, loggedInUser);
 
             // refresh the channel
-            ChannelManager.refreshWithNewestPackages(channel, "api");
-
-            // Mark the affected channel to have it's metadata evaluated, where necessary
-            // (RHEL5+, mostly)
-            ChannelManager.queueChannelChange(channel.getLabel(), "java::removeErrata",
-                    loggedInUser.getLogin());
+            ChannelManager.refreshWithNewestPackages(channel, "java::removeErrata");
 
             List<Long> cids = new ArrayList<Long>();
             cids.add(channel.getId());
@@ -2244,12 +2239,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         }
         mergeTo.getPackages().addAll(differentPackages);
         ChannelFactory.save(mergeTo);
-        ChannelManager.refreshWithNewestPackages(mergeTo, "api");
-
-        // Mark the affected channel to have it's metadata evaluated, where necessary
-        // (RHEL5+, mostly)
-        ChannelManager.queueChannelChange(mergeTo.getLabel(), "java::mergePackages",
-            loggedInUser.getLogin());
+        ChannelManager.refreshWithNewestPackages(mergeTo, "java::mergePackages");
 
         List<Long> cids = new ArrayList<Long>();
         cids.add(mergeTo.getId());


### PR DESCRIPTION
looks like ChannelManager.queueChannelChange is called twice for one
channel change:
 - 1st time within the ChannelManager.refreshWithNewestPackages
 - 2nd time explicitelly
I do not think queueChannelChange needs to be called twice