### PR TITLE
fix fedora macro usage

### DIFF
--- a/client/tools/rhncustominfo/rhn-custom-info.spec
+++ b/client/tools/rhncustominfo/rhn-custom-info.spec
@@ -15,7 +15,7 @@ Requires: python3-rhnlib
 Requires: rhnlib
 %endif
 
-%if 0%{?rhel} >= 5 || 0%{?fedora} < 22
+%if 0%{?rhel} >= 5 || 0%{?fedora} && 0%{?fedora} < 22
 Requires: yum-rhn-plugin
 %else
 # rpm do not support elif


### PR DESCRIPTION
if %fedora is not defined the %if will always evaluate to "true"
