### PR TITLE
1342977 - Prevent ORA-01878 on repository sync.

### DIFF
--- a/backend/common/Makefile
+++ b/backend/common/Makefile
@@ -29,7 +29,8 @@ SPACEWALK_FILES	=   __init__ \
 	    rhn_pkg \
 	    rhn_rpm \
 	    stringutils \
-	    usix
+	    usix \
+	    timezone_utils
 SCRIPTS = spacewalk-cfg-get
 
 # check if we can build man pages

--- a/backend/common/timezone_utils.py
+++ b/backend/common/timezone_utils.py
@@ -1,0 +1,35 @@
+"""
+Copyright (C) 2016 Oracle and/or its affiliates. All rights reserved.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, version 2
+
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+
+Utility to get system UTC offset and format as needed by DBs.
+"""
+import time
+
+
+def get_utc_offset():
+    """Return the UTC offset, allowing for DST."""
+    is_dst = time.daylight and time.localtime().tm_isdst > 0
+    utc_offset = - (time.altzone if is_dst else time.timezone)
+
+    mins = divmod(utc_offset, 60)[0]
+    hours, mins = divmod(mins, 60)
+    return '{0:+03d}:{1:02d}'.format(hours, mins)
+
+
+if __name__ == "__main__":
+    print "UTC offset (allowing for DST if in effect): %s" % get_utc_offset()

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -25,6 +25,7 @@ from backendLib import DBint, DBstring, DBdateTime, DBblob, Table, \
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnSQL.const import ORACLE, POSTGRESQL
 from spacewalk.common.rhnConfig import CFG
+from spacewalk.common import timezone_utils
 
 
 class OracleBackend(Backend):
@@ -574,12 +575,18 @@ class OracleBackend(Backend):
     def __init__(self):
         Backend.__init__(self, rhnSQL)
 
+    def setSessionTimeZoneToLocalTimeZone(self):
+        sth = self.dbmodule.prepare("alter session set time_zone = '%s'"
+                                    % timezone_utils.get_utc_offset())
+        sth.execute()
+
     def init(self):
         """
         Override parent to do explicit setting of the date format. (Oracle
         specific)
         """
         # Set date format
+        self.setSessionTimeZoneToLocalTimeZone()
         self.setDateFormat("YYYY-MM-DD HH24:MI:SS")
         return Backend.init(self)
 
@@ -592,10 +599,16 @@ class PostgresqlBackend(OracleBackend):
     avoid the few bits that are.
     """
 
+    def setSessionTimeZoneToLocalTimeZone(self):
+        sth = self.dbmodule.prepare("set session time zone '%s'"
+                                    % timezone_utils.get_utc_offset())
+        sth.execute()
+
     def init(self):
         """
         Avoid the Oracle specific stuff here in parent method.
         """
+        self.setSessionTimeZoneToLocalTimeZone()
         return Backend.init(self)
 
     # Postgres doesn't support autonomous transactions. We could use

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -59,7 +59,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
             if f == 'build_time':
                 if val is not None and isinstance(val, IntType):
                     # A UNIX timestamp
-                    val = gmtime(val)
+                    val = localtime(val)
             elif val:
                 # Convert to strings
                 if isinstance(val, UnicodeType):

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -59,7 +59,7 @@ class rpmPackage(IncompletePackage):
             if f == 'build_time':
                 if type(val) in (IntType, LongType):
                     # A UNIX timestamp
-                    val = gmtime(val)
+                    val = localtime(val)
             if f == 'payload_size':
                 if val is None:
                     # use longarchivesize header field for rpms with archive > 4GB
@@ -351,7 +351,7 @@ class rpmFile(File, ChangeLog):
         tm = self['mtime']
         if type(tm) in (IntType, LongType):
             # A UNIX timestamp
-            self['mtime'] = gmtime(tm)
+            self['mtime'] = localtime(tm)
         if type(self['filedigest']) == StringType:
             self['checksum'] = self['filedigest']
             del(self['filedigest'])
@@ -487,7 +487,7 @@ class rpmChangeLog(ChangeLog):
         tm = self['time']
         if type(tm) in (IntType, LongType):
             # A UNIX timestamp
-            self['time'] = gmtime(tm)
+            self['time'] = localtime(tm)
         # In changelog, data is either in UTF-8, or in any other
         # undetermined encoding. Assume ISO-Latin-1 if not UTF-8.
         for i in ('text', 'name'):


### PR DESCRIPTION
This prevents ORA-01878 on Oracle, and incorrect timezone insertion on
PostgreSQL when repo sync is triggered from the web UI. It also prevents
timestamps being off by one hour when spacewalk-repo-sync is run from
the cmdline.

See Bugzilla for details.

This is a symptomatic patch. The Python ORM should really be supplying
the timezone with submitted timestamps in order to prevent future
timestamps being submitted in UTC causing problems.