### PR TITLE
fix bz343653 upload binary file by rhncfg-manager d

### DIFF
--- a/client/tools/rhncfg/config_common/repository.py
+++ b/client/tools/rhncfg/config_common/repository.py
@@ -193,7 +193,7 @@ class Repository:
 
         if load_contents:
             try:
-                file_contents = open(local_path, "r").read()
+                file_contents = open(local_path, "rb").read()
             except IOError:
                 e = sys.exc_info()[1]
                 raise_with_tb(cfg_exceptions.RepositoryLocalFileError(
@@ -413,7 +413,8 @@ def get_server_capability(s):
     if headers is None:
         # No request done yet
         return {}
-    cap_headers = headers.getallmatchingheaders("X-RHN-Server-Capability")
+    cap_headers = ["X-RHN-Server-Capability: %s" % val for val in headers.get_all("X-RHN-Server-Capability")]
+
     if not cap_headers:
         return {}
     regexp = re.compile(

--- a/client/tools/rhncfg/config_management/rhncfg_add.py
+++ b/client/tools/rhncfg/config_management/rhncfg_add.py
@@ -14,7 +14,7 @@
 #
 
 import os
-
+import sys
 from config_common import handler_base, utils, cfg_exceptions
 from config_common.rhn_log import log_debug, die, log_error
 


### PR DESCRIPTION
1343653 - Uploading binary file by rhncfg-manager doesn't work in Fedora 23