### PR TITLE
Fix rhncfg verify 

### DIFF
--- a/client/tools/rhncfg/config_common/repository.py
+++ b/client/tools/rhncfg/config_common/repository.py
@@ -28,8 +28,10 @@ from rhn import rpclib
 Output = rpclib.transports.Output
 
 try: # python2
+    PY3 = False
     import xmlrpclib
 except ImportError: # python3
+    PY3 = True
     import xmlrpc.client as xmlrpclib
     basestring = (str, bytes)
 
@@ -413,7 +415,10 @@ def get_server_capability(s):
     if headers is None:
         # No request done yet
         return {}
-    cap_headers = ["X-RHN-Server-Capability: %s" % val for val in headers.get_all("X-RHN-Server-Capability")]
+    if PY3:
+        cap_headers = ["X-RHN-Server-Capability: %s" % val for val in headers.get_all("X-RHN-Server-Capability")]
+    else:
+        cap_headers = headers.getallmatchingheaders("X-RHN-Server-Capability")
 
     if not cap_headers:
         return {}

--- a/client/tools/rhncfg/config_common/rhn_main.py
+++ b/client/tools/rhncfg/config_common/rhn_main.py
@@ -168,7 +168,7 @@ class BaseMain:
                     server_name = (up2date_cfg['server_list'])[0]
                     local_config.init(self.config_section, defaults=up2date_cfg, server_name=server_name)
 
-        print("Using server name", server_name)
+        print("Using server name %s" % server_name)
 
         # set the debug level through the config
         rhn_log.set_debug_level(int(local_config.get('debug_level') or 0))

--- a/client/tools/rhncfg/config_common/utils.py
+++ b/client/tools/rhncfg/config_common/utils.py
@@ -182,7 +182,7 @@ def getContentChecksum(checksum_type, contents):
 def sha256_file(filename):
     engine = hashlib.new('sha256')
 
-    fh = open(filename, "r")
+    fh = open(filename, "rb")
     while 1:
         buf = fh.read(4096)
         if not buf:


### PR DESCRIPTION
rhncfg-client causes traceback when try to verify binary file and rhncfg doesn't work correct in python 2.