### PR TITLE
python 2 compatibility fix

### DIFF
--- a/client/tools/rhncfg/config_common/repository.py
+++ b/client/tools/rhncfg/config_common/repository.py
@@ -413,7 +413,10 @@ def get_server_capability(s):
     if headers is None:
         # No request done yet
         return {}
-    cap_headers = ["X-RHN-Server-Capability: %s" % val for val in headers.get_all("X-RHN-Server-Capability")]
+    if hasattr(headers, 'get_all'):
+        cap_headers = ["X-RHN-Server-Capability: %s" % val for val in headers.get_all("X-RHN-Server-Capability")]
+    else:
+        cap_headers = headers.getallmatchingheaders("X-RHN-Server-Capability")
 
     if not cap_headers:
         return {}


### PR DESCRIPTION
get_all exists only in python 3

fixes 33069a7ef07e28a5a9527a94320711af565cbd70
