### PR TITLE
fixing incorrect name of variable

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -84,11 +84,11 @@ def __unsubscribeServers(labels):
         print(str(channel_counts[i]).ljust(8))
 
     pb = ProgressBar(prompt='Unsubscribing:    ', endTag=' - complete',
-                     finalSize=len(list), finalBarLength=40, stream=sys.stdout)
+                     finalSize=len(server_channel_list), finalBarLength=40, stream=sys.stdout)
     pb.printAll(1)
 
     unsubscribe_server_proc = rhnSQL.Procedure("rhn_channel.unsubscribe_server")
-    for i in list:
+    for i in server_channel_list:
         unsubscribe_server_proc(i['server_id'], i['channel_id'])
         pb.addTo(1)
         pb.printIncrement()


### PR DESCRIPTION
> spacewalk-remove-channel -v -u -c test-channel

```
ERROR: unhandled exception occurred: (object of type 'type' has no len()).
Traceback (most recent call last):
  File "/usr/bin/spacewalk-remove-channel", line 182, in <module>
    sys.exit(main() or 0)
  File "/usr/bin/spacewalk-remove-channel", line 154, in main
    if __serverCheck(channels.keys(), options.unsubscribe):
  File "/usr/lib/python2.6/site-packages/spacewalk/satellite_tools/contentRemove.py", line 42, in __serverCheck
    return __unsubscribeServers(labels)
  File "/usr/lib/python2.6/site-packages/spacewalk/satellite_tools/contentRemove.py", line 87, in __unsubscribeServers
    finalSize=len(list), finalBarLength=40, stream=sys.stdout)
TypeError: object of type 'type' has no len()
2016/06/13 22:27:09 -04:00 rhnSQL/driver_cx_Oracle.connect('Connecting to database', 'spaceuser@//localhost:1521/XE')

The following channels will have their systems unsubscribed:
test-x86_64-0   
```