### PR TITLE
Disable YaST self update for new autoinstallation trees for SLE

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/BaseTreeAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/BaseTreeAction.java
@@ -113,6 +113,10 @@ public abstract class BaseTreeAction extends BaseEditAction {
                 kopts = kopts + " install=http://" + request.getLocalName() +
                     "/ks/dist/" + form.getString(LABEL);
             }
+            // disable YaST self update for SLE
+            if (!kopts.contains("self_update=")) {
+                kopts = kopts + " self_update=0 pt.options=+self_update";
+            }
             bte.setKernelOptions(kopts);
         }
         else {


### PR DESCRIPTION
Moreover, tell linuxrc that self_update is an user option (using
pt.options) so that it'll pass it to autoyast but doesn't process it
further. Not doing this this would cause the option to end up in the
boot menu of the installed system on older SLE (11).
