### PR TITLE
Traceback: comparison method violates its general contract

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/DynamicComparator.java
+++ b/java/code/src/com/redhat/rhn/common/util/DynamicComparator.java
@@ -84,14 +84,16 @@ public class DynamicComparator implements Comparator  {
                 return order * getCollator().compare(val1, val2);
             }
             // a < b = -1, a > b = 1 , a== b =0
-
+            if (val1 == null && val2 == null) {
+                return 0;
+            }
             if (val1 == null && val2 != null) {
                 return order * -1;
             }
-            else if (val1 != null && val2 == null) {
+            if (val1 != null && val2 == null) {
                 return order * 1;
             }
-            else if (val1 == val2) {
+            if (val1 == val2) {
                 return 0;
             }
             return order * val1.compareTo(val2);

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigFileTypeComparator.java
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigFileTypeComparator.java
@@ -33,15 +33,15 @@ public class ConfigFileTypeComparator implements Comparator {
     public int compare(Object arg0, Object arg1) {
         ConfigFile one = (ConfigFile) arg0;
         ConfigFile other = (ConfigFile) arg1;
-
-        if (one == null) {
+        if (one == null && other == null) {
+            return 0;
+        }
+        if (one == null && other != null) {
             return -1;
         }
-
-        if (other == null) {
+        if (one != null && other == null) {
             return 1;
         }
-
         if (one.equals(other)) {
             return 0;
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigChannelSetComparator.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigChannelSetComparator.java
@@ -34,10 +34,13 @@ public class ConfigChannelSetComparator implements Comparator {
         Long second = ((RhnSetElement)o2).getElementTwo();
 
         //Nulls always come last.
+        if (first == null && second == null) {
+            return 0;
+        }
         if (first == null) {
             return 1;
         }
-        else if (second == null) {
+        if (second == null) {
             return -1;
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -854,14 +854,26 @@ public class SystemSearchHelper {
             }
             Map sMap1 = (Map)results.get(serverId1);
             Map sMap2 = (Map)results.get(serverId2);
-            if ((sMap1 == null) || (sMap2 == null)) {
+            if ((sMap1 == null) && (sMap2 == null)) {
                 return 0;
             }
-            if ((!sMap1.containsKey("score")) || (!sMap2.containsKey("score"))) {
-                return 0;
+            if ((sMap1 == null) && (sMap2 != null)) {
+                return -1;
+            }
+            if ((sMap1 != null) && (sMap2 == null)) {
+                return 1;
             }
             Double score1 = (Double)sMap1.get("score");
             Double score2 = (Double)sMap2.get("score");
+            if ((score1 == null) && (score2 == null)) {
+                return 0;
+            }
+            if ((score1 == null) && (score2 != null)) {
+                return -1;
+            }
+            if ((score1 != null) && (score2 == null)) {
+                return 1;
+            }
             if (Math.abs(score1 - score2) < .001) {
                 // Lucene might give slight score differences to entries which are
                 // practically identical except for maybe registration time, etc.
@@ -905,14 +917,26 @@ public class SystemSearchHelper {
             }
             Map sMap1 = (Map)results.get(serverId1);
             Map sMap2 = (Map)results.get(serverId2);
-            if ((sMap1 == null) || (sMap2 == null)) {
+            if ((sMap1 == null) && (sMap2 == null)) {
                 return 0;
             }
-            if ((!sMap1.containsKey("score")) || (!sMap2.containsKey("score"))) {
-                return 0;
+            if ((sMap1 == null) && (sMap2 != null)) {
+                return -1;
+            }
+            if ((sMap1 != null) && (sMap2 == null)) {
+                return 1;
             }
             Double score1 = (Double)sMap1.get("score");
             Double score2 = (Double)sMap2.get("score");
+            if ((score1 == null) && (score2 == null)) {
+                return 0;
+            }
+            if ((score1 == null) && (score2 != null)) {
+                return -1;
+            }
+            if ((score1 != null) && (score2 == null)) {
+                return 1;
+            }
             /*
              * Note:  We want a list which goes from highest score to lowest score,
              * so we are reversing the order of comparison.
@@ -979,15 +1003,26 @@ public class SystemSearchHelper {
             }
             Map sMap1 = (Map)results.get(serverId1);
             Map sMap2 = (Map)results.get(serverId2);
-            if ((sMap1 == null) || (sMap2 == null)) {
+            if ((sMap1 == null) && (sMap2 == null)) {
                 return 0;
             }
-            if ((!sMap1.containsKey("matchingFieldValue")) ||
-                    (!sMap2.containsKey("matchingFieldValue"))) {
-                return 0;
+            if ((sMap1 == null) && (sMap2 != null)) {
+                return -1;
+            }
+            if ((sMap1 != null) && (sMap2 == null)) {
+                return 1;
             }
             String val1 = (String)sMap1.get("matchingFieldValue");
             String val2 = (String)sMap2.get("matchingFieldValue");
+            if ((val1 == null) && (val2 == null)) {
+                return 0;
+            }
+            if ((val1 == null) && (val2 != null)) {
+                return -1;
+            }
+            if ((val1 != null) && (val2 == null)) {
+                return 1;
+            }
             try {
                 Long lng1 = Long.parseLong(val1);
                 Long lng2 = Long.parseLong(val2);


### PR DESCRIPTION
Since java 1.7, it's mandatory to deal with Comparator interface specific way, according to [this link](https://docs.oracle.com/javase/7/docs/api/java/util/Comparator.html). It wasn't done like that in Spacewalk, which results in "comparison method violates its general contract". I tried to fix as much occurrences as possible.