### PR TITLE
keep whitespaces in debian package dependencies. 

### DIFF
--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -131,8 +131,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
             l = []
             values = header[k]
             if values is not None:
-                val = string.join(values.split(), "")  # remove whitespaces
-                val = val.split(',')  # split packages
+                val = values.split(', ')  # split packages
                 i = 0
                 for v in val:
                     version = ''


### PR DESCRIPTION
A different attempt to fix Bug 1226329. In my opinion this tiny fix may be enough to solve the issue. Creation of Packages.gz looks promising.
