### PR TITLE
change default checksum type to sha256 for debian packages.

### DIFF
--- a/backend/common/rhn_deb.py
+++ b/backend/common/rhn_deb.py
@@ -29,7 +29,7 @@ from spacewalk.common.rhn_pkg import A_Package, InvalidPackageError
 # bare-except and broad-except
 # pylint: disable=W0702,W0703
 
-DEB_CHECKSUM_TYPE = 'md5'       # FIXME: this should be a configuration option
+DEB_CHECKSUM_TYPE = 'sha256'       # FIXME: this should be a configuration option
 
 
 class deb_Header:


### PR DESCRIPTION
Usage of SHA256 is recommended in https://wiki.debian.org/RepositoryFormat#Size.2C_MD5sum.2C_SHA1.2C_SHA256.2C_SHA512
This should also fix RH BZ 1348321