### PR TITLE
1345843 - sane output when diff of binary config files

### DIFF
--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -555,4 +555,5 @@ def format_file_results(row, server=None):
         'filetype': row['label'],
         'selinux_ctx': row['selinux_ctx'] or '',
         'modified': m_date,
+        'is_binary': row['is_binary'] or '',
     }

--- a/client/tools/rhncfg/config_client/rhncfgcli_diff.py
+++ b/client/tools/rhncfg/config_client/rhncfgcli_diff.py
@@ -32,6 +32,7 @@ class Handler(handler_base.HandlerBase):
     def _process_file(self, *args):
         src, dst= args [:2]
         type = args[3]
+        file_info = args[4]
 
         if type == 'symlink':
             if not os.path.exists(dst):
@@ -48,6 +49,26 @@ class Handler(handler_base.HandlerBase):
             if srclink != destlink:
                 print("Symbolic links differ. Channel: '%s' -> '%s'   System: '%s' -> '%s' " % (dst,srclink, dst, destlink))
         elif type == 'file':
-            sys.stdout.write(''.join(diff(src, dst, srcname=dst, dstname=dst,
-                display_diff=
-                (self.options.display_diff or get_config('display_diff')))))
+            if 'is_binary' in file_info and file_info['is_binary'] == 'Y':
+                src_content = dst_content = None
+                content_differs = False
+                src_file = open(src, 'rb')
+                src_content = src_file.read()
+                src_file.close()
+                if os.access(dst, os.R_OK):
+                    dst_file = open(dst, 'rb')
+                    dst_content = dst_file.read()
+                    dst_file.close()
+                if not dst_content or len(src_content) != len(dst_content):
+                    content_differs = True
+                else:
+                    for i in range(len(src_content)):
+                        if src_content[i] != dst_content[i]:
+                            content_differs = True
+                            break
+                if content_differs:
+                    sys.stdout.write("Binary file content differs.\n")
+            else:
+                sys.stdout.write(''.join(diff(src, dst, srcname=dst, dstname=dst,
+                    display_diff=
+                    (self.options.display_diff or get_config('display_diff')))))

--- a/client/tools/rhncfg/config_management/rhncfg_diff.py
+++ b/client/tools/rhncfg/config_management/rhncfg_diff.py
@@ -136,15 +136,40 @@ class Handler(handler_base.HandlerBase):
             if src_link != os.readlink(local_file):
                 return "Symbolic links differ. Channel: '%s' -> '%s'   System: '%s' -> '%s' \n " % (path,src_link, path, dest_link)
             return ""
-        fromlines = sstr(info['file_contents']).splitlines(1)
-        tolines = open(local_file, 'r').readlines()
-        diff_output = difflib.unified_diff(fromlines, tolines, info['path'], local_file)
-        first_row = second_row = ''
-        try:
-            first_row = next(diff_output)
-            second_row = next(diff_output)
-        except StopIteration:
-            pass
+
+        response_output = ""
+        content_differs = False
+        if 'is_binary' in info and info['is_binary'] == 'Y':
+            from_content = info['file_contents']
+            to_file = open(local_file, 'rb')
+            to_content = to_file.read()
+            to_file.close()
+            if len(from_content) != len(to_content):
+                content_differs = True
+            else:
+                for i in range(len(from_content)):
+                    if from_content[i] != to_content[i]:
+                         content_differs = True
+                         break
+            if content_differs:
+                response_output = "Binary file content differs\n"
+        else:
+            fromlines = sstr(info['file_contents']).splitlines(1)
+            tofile = open(local_file, 'r')
+            tolines = tofile.readlines()
+            tofile.close()
+            diff_output = difflib.unified_diff(fromlines, tolines, info['path'], local_file)
+            first_row = second_row = ''
+            try:
+                first_row = next(diff_output)
+                # if content was same, exception thrown so following
+                # lines don't execute
+                content_differs = True
+                second_row = next(diff_output)
+                response_output = ''.join(list(diff_output))
+            except StopIteration:
+                pass
+
         file_stat = os.lstat(local_file)
         local_info = r.make_stat_info(local_file, file_stat)
         # rhel4 do not support selinux
@@ -152,7 +177,7 @@ class Handler(handler_base.HandlerBase):
             local_info['selinux_ctx'] = ''
         if 'selinux_ctx' not in info:
             info['selinux_ctx'] = ''
-        if not first_row and not self.__attributes_differ(info, local_info):
+        if not content_differs and not self.__attributes_differ(info, local_info):
             return ""
         else:
             template = "--- %s\t%s\tattributes: %s %s %s %s\tconfig channel: %s\trevision: %s"
@@ -165,4 +190,4 @@ class Handler(handler_base.HandlerBase):
             second_row = template % (local_file, f_date(datetime.fromtimestamp(local_info['mtime'])), ostr_to_sym(local_info['mode'], 'file'),
                         local_info['user'], local_info['group'], local_info['selinux_ctx'], 'local file', None
             )
-        return first_row + '\n' + second_row + '\n' + ''.join(list(diff_output))
+        return first_row + '\n' + second_row + '\n' + response_output


### PR DESCRIPTION
Please be brutally honest in criticizing any issues!

There was a question about why I didn't use filecmp.cmp to compare the files.  This could be done for the rhncfg-client diff code as it gets 2 file paths to compare.  The rhncfg-manager diff code, however, is passed the actual content received from the server.  I could easily do the rhncfg-client diff implementation with filecmp.cmp.  Doing it for rhncfg-manager diff implementation would require first writing a temp file and then removing the temp file after the filecmp.cmp.  I'm inclined to leave as-is so the same approach to file compare is used in both places, but could easily be moved to change this opinion.  :)