### PR TITLE
fixed SyntaxError in rhupush for RHEL5

### DIFF
--- a/backend/common/rhn_pkg.py
+++ b/backend/common/rhn_pkg.py
@@ -15,6 +15,7 @@
 
 import os
 from spacewalk.common import checksum
+from rhn.i18n import bstr
 
 def get_package_header(filename=None, file_obj=None, fd=None):
     # pylint: disable=E1103
@@ -121,7 +122,7 @@ class A_Package:
 
     @staticmethod
     def _read_bytes(stream, amt):
-        ret = b''
+        ret = bstr('')
         while amt:
             buf = stream.read(min(amt, BUFFER_SIZE))
             if not buf:


### PR DESCRIPTION
>> rhnpush 
Traceback (most recent call last):
  File "/usr/bin/rhnpush", line 9, in ?
    from rhnpush import rhnpush_main
  File "/usr/share/rhn/rhnpush/rhnpush_main.py", line 48, in ?
    from spacewalk.common.rhn_pkg import InvalidPackageError, package_from_filename
  File "/usr/lib/python2.4/site-packages/spacewalk/common/rhn_pkg.py", line 124
    ret = b''
            ^
SyntaxError: invalid syntax