### PR TITLE
Improve debian package handling

### DIFF
--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -157,7 +157,7 @@ def hash_object_id(object_id, factor):
     return num_id.rjust(factor, '0')
 
 
-# reg exp for splitting package names.
+# reg exp for splitting rpm package names.
 re_rpmName = re.compile("^(.*)-([^-]*)-([^-]*)$")
 
 
@@ -166,6 +166,25 @@ def parseRPMName(pkgName):
         OUT: Four strings (in a tuple): name, epoch, version, release.
     """
     reg = re_rpmName.match(pkgName)
+    if reg is None:
+        return None, None, None, None
+    n, v, r = reg.group(1, 2, 3)
+    e = None
+    ind = r.find(':')
+    if ind >= 0:  # epoch found
+        e = r[ind + 1:]
+        r = r[0:ind]
+    return str(n), e, str(v), str(r)
+
+# reg exp for splitting deb package names.
+re_debName = re.compile("^(.*)_([^-]+)-(.*)$")
+
+
+def parseDEBName(pkgName):
+    """ IN:  Package string in, n_v.v-r.r-r, format.
+        OUT: Four strings (in a tuple): name, epoch, version, release.
+    """
+    reg = re_debName.match(pkgName)
     if reg is None:
         return None, None, None, None
     n, v, r = reg.group(1, 2, 3)

--- a/backend/common/rhn_deb.py
+++ b/backend/common/rhn_deb.py
@@ -84,7 +84,7 @@ class deb_Header:
                 self.hdr['release'] = "X"
             else:
                 self.hdr['version'] = version_tmpArr[0]
-                self.hdr['release'] = version_tmpArr[1]
+                self.hdr['release'] = "-".join (version_tmpArr[1:])
         except Exception:
             e = sys.exc_info()[1]
             raise_with_tb(InvalidPackageError(e), sys.exc_info()[2])

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -20,7 +20,7 @@ import string
 import base64
 import posixpath
 
-from spacewalk.common.rhnLib import parseRPMName
+from spacewalk.common.rhnLib import parseRPMName, parseDEBName
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 
@@ -64,6 +64,8 @@ def parseRPMFilename(pkgFilename):
     if string.lower(pkg[-1]) not in ['rpm', 'deb']:
         raise rhnFault(21, 'neither an rpm nor a deb package name: %s' % pkgFilename)
 
+    dist = string.lower(pkg[-1])
+
     # Valid architecture next?
     if check_package_arch(pkg[-2]) is None:
         raise rhnFault(21, 'Incompatible architecture found: %s' % pkg[-2])
@@ -72,7 +74,12 @@ def parseRPMFilename(pkgFilename):
 
     # Nuke that arch.rpm.
     pkg = string.join(pkg[:-2], '.')
-    ret = list(parseRPMName(pkg))
+
+    if dist == "deb":
+        ret = list(parseDEBName(pkg))
+    else:
+        ret = list(parseRPMName(pkg))
+
     if ret:
         ret.append(_arch)
     return ret

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -135,7 +135,7 @@ public class DebPackageWriter {
                     pkgDto.getId(), "Breaks");
 
             out.write("Filename: XMLRPC/GET-REQ/" + channelLabel + "/getPackage/" +
-                    pkgDto.getName() + "-" + pkgDto.getVersion() + "-" +
+                    pkgDto.getName() + "_" + pkgDto.getVersion() + "-" +
                     pkgDto.getRelease() + "." + pkgDto.getArchLabel() + ".deb");
             out.newLine();
 


### PR DESCRIPTION
This pull request basically allows the import of debian packages with more complex package names and reintroduces the '_' as separator of debian package name and package version (at least for the spacewalk debian client).

Currently the import mechanism of debian packages can only process simple package names and  one '-' in the version field. I.e. the following package name is not imported correctly: libcunit1_2.1-0.dfsg-10_amd64.deb. This pull request tries to remove this restriction. 
Nevertheless, allowing more complex package names requires some additional modifications which are also addressed by this pull request:
Debian packages use '_' to distinguish between package name and package version. Therefore, the packages.gz file needs some modification and the parseRPMFilename function should be able to distinguish between rpm and deb file names. 
