### PR TITLE
fix rhnpush using package_from_filename() function

### DIFF
--- a/backend/common/rhn_pkg.py
+++ b/backend/common/rhn_pkg.py
@@ -56,13 +56,15 @@ def package_from_stream(stream, packaging):
     return a_pkg
 
 
-def package_from_filename(stream, filename):
+def package_from_filename(filename, stream=None):
     if filename.endswith('.deb'):
         packaging = 'deb'
     elif filename.endswith('.rpm'):
         packaging = 'rpm'
     else:
         packaging = 'mpm'
+    if not stream:
+        stream = open(filename, mode='rb')
     return package_from_stream(stream, packaging)
 
 BUFFER_SIZE = 16384

--- a/backend/satellite_tools/repo_plugins/__init__.py
+++ b/backend/satellite_tools/repo_plugins/__init__.py
@@ -74,7 +74,7 @@ class ContentPackage:
         if self.path is None:
             raise rhnFault(50, "Unable to load package", explain=0)
         self.file = open(self.path, 'rb')
-        self.a_pkg = rhn_pkg.package_from_filename(self.file, self.path)
+        self.a_pkg = rhn_pkg.package_from_filename(self.path, stream=self.file)
         self.a_pkg.read_header()
         self.a_pkg.payload_checksum()
         self.file.close()


### PR DESCRIPTION
changes 02be9116b3954b5448c45b46db742fbe745efaec

rhnpush uses multiple times package_from_filename() in old style.
I think it is easier to append the new parameter to the function and make it optional.
This should fix also rhnpush.
