### PR TITLE
Make heading match navigation: "Managed Systems"

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -13339,7 +13339,7 @@ any of these revisions.  Are you sure you want to do this?</source>
       </trans-unit>
       <!-- managedsystems.jsp -->
       <trans-unit id="managedsystems.jsp.toolbar">
-        <source>Systems</source>
+        <source>Managed Systems</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/configuration/system/ManagedSystems.do</context>
         </context-group>


### PR DESCRIPTION
This very small patch is just supposed to make the page heading match the link text in the left navigation, this is the affected page URL:

- https://(server)/rhn/configuration/system/ManagedSystems.do

Let me know if you want me to touch the translations as well, I could at least adapt the `<source>` tags for all languages if needed.