### PR TITLE
Fix for single number version parsing issue with Debian MergeList files

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -266,7 +266,8 @@ public class DebPackageWriter {
             return ">>";
         }
         else if (sense == 8) {
-            return "=";
+            // Workaround for apt parsing issue with single-number versions - i.e; (=1) (breaks) vs (= 1) (works)
+            return "= ";
         }
         else if (sense == 10) {
             return "<=";


### PR DESCRIPTION
Currently, packages with single number versions (i.e; 1, 2, etc) break with
depends/breaks lines that do not include a space before or after the version
number.

i.e;
apt (=1) breaks
apt (= 1) works
apt (=1 ) works

Apt/dpkg has no issue with (= 1.0), so this seems to be the simplest workaround
for the issue.
