### PR TITLE
Show user a meaningful page after requesting details of non-existing Action Chain

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -308,6 +308,9 @@
         <context-group name="ctx">
           <context context-type="sourcefile">Lookup error page</context>
         </context-group>
+        <trans-unit id="lookup.jsp.title.actionchain">
+          <source>We're sorry, but the Action Chain could not be found.</source>
+        </trans-unit>
         <trans-unit id="lookup.jsp.title.user">
           <source>We're sorry, but the user could not be found.</source>
         </trans-unit>
@@ -364,6 +367,9 @@
         </trans-unit>
         <trans-unit id="lookup.jsp.summary">
           <source>This error may have occurred in one of three ways:</source>
+        </trans-unit>
+        <trans-unit id="lookup.jsp.actionchain.reason1">
+          <source>The Action Chain requested does not exist. This is most likely if the Action Chain has been already scheduled and deleted.</source>
         </trans-unit>
         <trans-unit id="lookup.jsp.reason1.user">
           <source>The user requested does not exist.  This is most likely if you arrived at this page through bookmarks or some other non-hyperlink.</source>


### PR DESCRIPTION
Previously the page threw Internal Server Error.

* Before
![before](https://cloud.githubusercontent.com/assets/1412268/18199962/ef3488ac-7102-11e6-9532-82e5e0717323.png)

* After
![after](https://cloud.githubusercontent.com/assets/1412268/18199973/f6dbcba6-7102-11e6-9406-1d0a3fadc9f7.png)
