### PR TITLE
[DISCUSSION WANTED] Upgrade Hibernate from 3.x to 5.2.2

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -50,8 +50,6 @@ import java.util.StringTokenizer;
 
 /**
  * A cached set of query/elaborator strings and the parameterMap hash maps.
- *
- * @version $Rev$
  */
 public class CachedStatement implements Serializable {
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -943,4 +943,3 @@ public class CachedStatement implements Serializable {
                 restartData.getMode(), restartData.getDr());
     }
 }
-

--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.common.util.StringUtil;
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
+import org.hibernate.jdbc.ReturningWork;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -282,7 +283,6 @@ public class CachedStatement implements Serializable {
         return res.intValue();
     }
 
-
     DataResult<Object> execute(Map<String, Object> parameters, Mode mode) {
         return execute(parameters, defaultSort, sortOrder, mode);
     }
@@ -367,6 +367,7 @@ public class CachedStatement implements Serializable {
         return elaborated;
     }
 
+    @SuppressWarnings("unchecked")
     private Collection<Object> executeElaboratorBatch(List<Object> resultList,
             Mode mode,
             Map<String, Object> parametersIn) {
@@ -381,8 +382,8 @@ public class CachedStatement implements Serializable {
 
         // If we aren't actually operating on a list, just elaborate.
         if (origQuery.indexOf("%s") == -1) {
-            return (DataResult<Object>) execute(query, qMap, parameters,
-                    mode, resultList);
+            return (DataResult<Object>) executeChecking(query, qMap, parameters, mode,
+                    resultList);
         }
 
         StringBuilder bindParams = new StringBuilder(":l0");
@@ -440,40 +441,26 @@ public class CachedStatement implements Serializable {
 
     private Object execute(String sql, Map<String, List<Integer>> parameterMap,
             Map<String, Object> parameters, Mode mode) {
-        return execute(sql, parameterMap, parameters, mode, null);
+        return executeChecking(sql, parameterMap, parameters, mode, null);
     }
 
-    // This isn't great, but I want to return either an integer count of the
-    // number of rows updated, or the DataResult.  That can only be done by
-    // returning an Object and letting the caller do the casting for us.
-    private Object execute(String sql, Map<String, List<Integer>> parameterMap,
+    /**
+     * Prepares and executes a SQL statements with parameters, handling
+     * Exceptions appropriately.
+     * @param sql SQL string to be prepared and executed
+     * @param parameterMap The Map returned setup by replaceBindParams
+     * @param parameters The Map returned setup by replaceBindParams
+     * @param mode Mode for selection queries
+     * @param dr Data result list or null
+     * @return either an integer count of the number of rows updated, or the
+     *         DataResult. Casting to int or DataResult is caller's
+     *         responsibility
+     */
+    private Object executeChecking(String sql, Map<String, List<Integer>> parameterMap,
             Map<String, Object> parameters, Mode mode, List<Object> dr) {
-        storeForRestart(sql, parameterMap, parameters, mode, dr);
-        PreparedStatement ps = null;
+
         try {
-            Connection conn = stealConnection();
-            ps = conn.prepareStatement(sql);
-
-            // allow limiting the results for better performance.
-            if (mode != null && mode instanceof SelectMode) {
-                ps.setMaxRows(((SelectMode)mode).getMaxRows());
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("execute() - Executing: " + sql);
-                log.debug("execute() - With: " + parameters);
-            }
-
-            boolean returnType = NamedPreparedStatement.execute(ps,
-                    parameterMap,
-                    setupParamMap(parameters));
-            if (log.isDebugEnabled()) {
-                log.debug("execute() - Return type: " + returnType);
-            }
-            if (returnType) {
-                return processResultSet(ps.getResultSet(), (SelectMode)mode, dr);
-            }
-            return new Integer(ps.getUpdateCount());
+            return execute(sql, parameterMap, parameters, mode, dr);
         }
         catch (SQLException e) {
             throw SqlExceptionTranslator.sqlException(e);
@@ -489,9 +476,67 @@ public class CachedStatement implements Serializable {
             log.error("Error while processing cached statement sql: " + sql, e);
             throw e;
         }
-        finally {
-            HibernateHelper.cleanupDB(ps);
+    }
+
+    /**
+     * Executes a prepared SQL statement with parameters.
+     * @param sql SQL string to be prepared and executed
+     * @param parameterMap The Map returned setup by replaceBindParams
+     * @param parameters The Map returned setup by replaceBindParams
+     * @param mode Mode for selection queries
+     * @param dr Data result list or null
+     * @return either an integer count of the number of rows updated, or the
+     *         DataResult. Casting to int or DataResult is caller's
+     *         responsibility
+     * @throws SQLException
+     */
+    private Object execute(String sql, Map<String, List<Integer>> parameterMap,
+            Map<String, Object> parameters, Mode mode,
+            List<Object> dr) throws SQLException {
+        if (log.isDebugEnabled()) {
+            log.debug("execute() - Executing: " + sql);
+            log.debug("execute() - With: " + parameters);
         }
+
+        storeForRestart(sql, parameterMap, parameters, mode, dr);
+
+        return doWithStolenConnection(connection -> {
+            PreparedStatement ps = null;
+            try {
+                ps = prepareStatement(connection, sql, mode);
+                boolean returnType = NamedPreparedStatement.execute(ps, parameterMap,
+                        setupParamMap(parameters));
+                if (log.isDebugEnabled()) {
+                    log.debug("execute() - Return type: " + returnType);
+                }
+                if (returnType) {
+                    return processResultSet(ps.getResultSet(), (SelectMode) mode, dr);
+                }
+                return new Integer(ps.getUpdateCount());
+            }
+            finally {
+                HibernateHelper.cleanupDB(ps);
+            }
+        });
+    }
+
+    /**
+     * Executes a prepared SQL statement with parameters.
+     * @param connection JDBC connection object in which create the statement
+     * @param sql SQL string to be prepared and executed
+     * @param mode Mode for selection queries
+     * @return the prepared statement
+     * @throws SQLException
+     */
+    private PreparedStatement prepareStatement(Connection connection, String sql, Mode mode)
+        throws SQLException, HibernateException {
+        PreparedStatement ps = connection.prepareStatement(sql);
+
+        // allow limiting the results for better performance.
+        if (mode != null && mode instanceof SelectMode) {
+            ps.setMaxRows(((SelectMode) mode).getMaxRows());
+        }
+        return ps;
     }
 
     private Map<String, Object> processOutputParams(CallableStatement cs,
@@ -518,35 +563,30 @@ public class CachedStatement implements Serializable {
 
     Map<String, Object> executeCallable(Map<String, Object> inParams,
             Map<String, Integer> outParams) {
-        CallableStatement cs = null;
-        try {
-            Connection conn = stealConnection();
-            cs = conn.prepareCall(query);
-
-            // Do we need to check the return code?  The original code in
-            // ConnInvocHandler didn't, but I'm not sure that is correct. rbb
-            NamedPreparedStatement.execute(cs, qMap, inParams,
-                    outParams);
-            return processOutputParams(cs, outParams);
-        }
-        catch (SQLException e) {
-            throw SqlExceptionTranslator.sqlException(e);
-        }
-        catch (HibernateException he) {
-            throw new
-            HibernateRuntimeException(
-                    "HibernateException executing CachedStatement", he);
-
-        }
-        catch (RuntimeException e) {
-            if (e.getCause() instanceof SQLException) {
-                throw SqlExceptionTranslator.sqlException((SQLException) e.getCause());
+        return doWithStolenConnection(connection -> {
+            CallableStatement cs = null;
+            try {
+                cs = connection.prepareCall(query);
+                NamedPreparedStatement.execute(cs, qMap, inParams, outParams);
+                return processOutputParams(cs, outParams);
             }
-            throw e;
-        }
-        finally {
-            HibernateHelper.cleanupDB(cs);
-        }
+            catch (SQLException e) {
+                throw SqlExceptionTranslator.sqlException(e);
+            }
+            catch (HibernateException he) {
+                throw new HibernateRuntimeException(
+                        "HibernateException executing CachedStatement", he);
+            }
+            catch (RuntimeException e) {
+                if (e.getCause() instanceof SQLException) {
+                    throw SqlExceptionTranslator.sqlException((SQLException) e.getCause());
+                }
+                throw e;
+            }
+            finally {
+                HibernateHelper.cleanupDB(cs);
+            }
+        });
     }
 
     private DataResult<Object> processResultSet(ResultSet rs, SelectMode mode,
@@ -879,19 +919,14 @@ public class CachedStatement implements Serializable {
     }
 
     /**
-     * Get the DB connection from Hibernate. Since we will use it
-     * to run queries/stored procs, this will also flush the session
-     * to ensure that stored procs will see all the in-memory changes
+     * Get the DB connection from Hibernate and run some work on it. Since we
+     * will use it to run queries/stored procs, this will also flush the session
+     * to ensure that stored procs will see changes made in the Hibenate cache
      */
-    private Connection stealConnection() throws HibernateException {
-        Connection conn;
+    private <T> T doWithStolenConnection(ReturningWork<T> work) throws HibernateException {
         Session session = HibernateFactory.getSession();
-        // We are doing stuff behind Hibernate's back and
-        // need to make sure the DB reflects all changes
-        // made in memory
         session.flush();
-        conn = session.connection();
-        return conn;
+        return session.doReturningWork(work);
     }
 
     private void storeForRestart(String sql,
@@ -905,7 +940,7 @@ public class CachedStatement implements Serializable {
      * @return what the previous query returned or null.
      */
     public Object restartQuery() {
-        return restartData == null ? null : execute(restartData.getSql(),
+        return restartData == null ? null : executeChecking(restartData.getSql(),
                 restartData.getParameterMap(), restartData.getParameters(),
                 restartData.getMode(), restartData.getDr());
     }

--- a/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
@@ -28,7 +28,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 
 import org.apache.log4j.Logger;
-import org.hibernate.Session;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -333,52 +332,53 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
     }
 
 
+    @Override
     protected void setUp() throws Exception {
-        Session session = HibernateFactory.getSession();
-        Connection c = session.connection();
-        Statement stmt = c.createStatement();
-        try {
-            if (ConfigDefaults.get().isOracle()) {
-                stmt.execute("create table adv_datasource " +
+        HibernateFactory.getSession().doWork(connection -> {
+            Statement statement = connection.createStatement();
+            try {
+                if (ConfigDefaults.get().isOracle()) {
+                    statement.execute("create table adv_datasource " +
                         "( " +
                         "  foobar VarChar2(32)," +
                         "  test_column VarChar2(25)," +
                         "  pin    number, " +
                         "  id     number" +
                         "         constraint adv_datasource_pk primary key" +
-                        ")");
-            }
-            else {
-                stmt.execute("create table adv_datasource " +
+                        ")"
+                    );
+                }
+                else {
+                    statement.execute("create table adv_datasource " +
                         "( " +
                         "  foobar VarChar," +
                         "  test_column VarChar," +
                         "  pin    numeric, " +
                         "  id     numeric" +
                         "         constraint adv_datasource_pk primary key" +
-                        ");");
+                        ");"
+                    );
+                }
+                connection.commit();
             }
-            c.commit();
-        }
-        finally {
-            HibernateHelper.cleanupDB(stmt);
-        }
+            finally {
+                HibernateHelper.cleanupDB(statement);
+            }
+        });
     }
 
     protected void tearDown() throws Exception {
-        Session session = null;
-        Connection c = null;
-        Statement stmt = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            stmt = c.createStatement();
-            forceQuery(c, "drop table adv_datasource");
-            c.commit();
-        }
-        finally {
-            HibernateHelper.cleanupDB(stmt);
-        }
+        HibernateFactory.getSession().doWork(connection -> {
+            Statement statement = null;
+            try {
+                statement = connection.createStatement();
+                forceQuery(connection, "drop table adv_datasource");
+                connection.commit();
+            }
+            finally {
+                HibernateHelper.cleanupDB(statement);
+            }
+        });
     }
 
     private static void forceQuery(Connection c, String query) {

--- a/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
@@ -399,5 +399,3 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
         System.out.println(dr);
     }
 }
-
-

--- a/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/test/AdvDataSourceTest.java
@@ -43,9 +43,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-/*
- * $Rev$
- */
 public class AdvDataSourceTest extends RhnBaseTestCase {
 
     private static Logger log = Logger.getLogger(AdvDataSourceTest.class);

--- a/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
@@ -279,13 +279,16 @@ class ConnectionManager {
                     LOG.debug("YYY Opening Hibernate Session");
                 }
                 info = new SessionInfo(sessionFactory.openSession());
-                // Automatically start a transaction
-                info.setTransaction(info.getSession().beginTransaction());
             }
             catch (HibernateException e) {
                 throw new HibernateRuntimeException("couldn't open session", e);
             }
             SESSION_TLS.set(info);
+        }
+
+        // Automatically start a transaction
+        if (info.getTransaction() == null) {
+            info.setTransaction(info.getSession().beginTransaction());
         }
 
         return info.getSession();

--- a/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
@@ -26,6 +26,7 @@ import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -302,7 +303,8 @@ class ConnectionManager {
         Session session = info.getSession();
         try {
             Transaction txn = info.getTransaction();
-            if (txn != null && !txn.wasCommitted() && !txn.wasRolledBack()) {
+            if (txn != null && txn.getStatus().isNotOneOf(
+                    TransactionStatus.COMMITTED, TransactionStatus.ROLLED_BACK)) {
                 try {
                     txn.commit();
                 }

--- a/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
@@ -24,7 +24,6 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
@@ -175,13 +174,6 @@ class ConnectionManager {
                     ConfigDefaults.get().getJdbcConnectionString());
 
             config.addProperties(hibProperties);
-            // Force the use of our txn factory
-            if (config.getProperty(Environment.TRANSACTION_STRATEGY) != null) {
-                throw new IllegalArgumentException("The property " +
-                        Environment.TRANSACTION_STRATEGY +
-                        " can not be set in a configuration file;" +
-                        " it is set to a fixed value by the code");
-            }
 
             for (Iterator<String> i = hbms.iterator(); i.hasNext();) {
                 String hbmFile = i.next();

--- a/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
@@ -38,8 +38,7 @@ import java.util.Set;
 
 /**
  * Manages the lifecycle of the Hibernate SessionFactory and associated
- * thread-scoped Hibernate sessions
- * @version $Rev$
+ * thread-scoped Hibernate sessions.
  */
 class ConnectionManager {
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
@@ -185,6 +185,5 @@ public class ForceRecreationListType implements UserCollectionType {
         public boolean needsRecreate(CollectionPersister persister) {
             return true;
         }
-
     }
 }

--- a/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
@@ -60,10 +60,6 @@ import java.util.Map;
  * a whole was unique we wouldn't have had to deal with this......
  * but positions can be null twice for the same server, so we
  * cannot enforce that constraint..
- *
- *
- * ForceRecreationListType
- * @version $Rev$
  */
 public class ForceRecreationListType implements UserCollectionType {
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
@@ -70,6 +70,7 @@ public class ForceRecreationListType implements UserCollectionType {
     /**
      * {@inheritDoc}
      */
+    @Override
     public PersistentCollection instantiate(SharedSessionContractImplementor session,
             CollectionPersister persister) throws HibernateException {
         return new ForceRecreationList(session);
@@ -78,6 +79,7 @@ public class ForceRecreationListType implements UserCollectionType {
     /**
      * {@inheritDoc}
      */
+    @Override
     public PersistentCollection wrap(SharedSessionContractImplementor session,
             Object collection) {
         return new ForceRecreationList(session, (List) collection);
@@ -88,6 +90,7 @@ public class ForceRecreationListType implements UserCollectionType {
      *
      * {@inheritDoc}
      */
+    @Override
     public Iterator getElementsIterator(Object collection) {
         return ((List) collection).iterator();
     }
@@ -96,6 +99,7 @@ public class ForceRecreationListType implements UserCollectionType {
      *
      * {@inheritDoc}
      */
+    @Override
     public boolean contains(Object collection, Object entity) {
         return ((List) collection).contains(entity);
     }
@@ -104,6 +108,7 @@ public class ForceRecreationListType implements UserCollectionType {
      *
      * {@inheritDoc}
      */
+    @Override
     public Object indexOf(Object collection, Object entity) {
         int l = ((List) collection).indexOf(entity);
         if (l < 0) {
@@ -116,6 +121,7 @@ public class ForceRecreationListType implements UserCollectionType {
      *
      * {@inheritDoc}
      */
+    @Override
     public Object replaceElements(Object original, Object target,
             CollectionPersister persister, Object owner, Map copyCache,
             SharedSessionContractImplementor session) throws HibernateException {
@@ -131,6 +137,7 @@ public class ForceRecreationListType implements UserCollectionType {
      * @param anticipatedSize sample size
      * @return an empty  list.
      */
+    @Override
     public Object instantiate(int anticipatedSize) {
         if (anticipatedSize > 0) {
             return new ArrayList(anticipatedSize);

--- a/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
@@ -15,9 +15,9 @@
 package com.redhat.rhn.common.hibernate;
 
 import org.hibernate.HibernateException;
-import org.hibernate.collection.PersistentCollection;
-import org.hibernate.collection.PersistentList;
-import org.hibernate.engine.SessionImplementor;
+import org.hibernate.collection.internal.PersistentList;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.usertype.UserCollectionType;
 
@@ -70,7 +70,7 @@ public class ForceRecreationListType implements UserCollectionType {
     /**
      * {@inheritDoc}
      */
-    public PersistentCollection instantiate(SessionImplementor session,
+    public PersistentCollection instantiate(SharedSessionContractImplementor session,
             CollectionPersister persister) throws HibernateException {
         return new ForceRecreationList(session);
     }
@@ -78,7 +78,7 @@ public class ForceRecreationListType implements UserCollectionType {
     /**
      * {@inheritDoc}
      */
-    public PersistentCollection wrap(SessionImplementor session,
+    public PersistentCollection wrap(SharedSessionContractImplementor session,
             Object collection) {
         return new ForceRecreationList(session, (List) collection);
 
@@ -118,7 +118,7 @@ public class ForceRecreationListType implements UserCollectionType {
      */
     public Object replaceElements(Object original, Object target,
             CollectionPersister persister, Object owner, Map copyCache,
-            SessionImplementor session) throws HibernateException {
+            SharedSessionContractImplementor session) throws HibernateException {
         List result = (List) target;
         result.clear();
         result.addAll((Collection) original);
@@ -163,7 +163,7 @@ public class ForceRecreationListType implements UserCollectionType {
          *
          * @param session session implementation
          */
-        public ForceRecreationList(SessionImplementor session) {
+        ForceRecreationList(SharedSessionContractImplementor session) {
             super(session);
         }
 
@@ -171,7 +171,7 @@ public class ForceRecreationListType implements UserCollectionType {
          * @param session session implementation
          * @param list  list to persist
          */
-        public ForceRecreationList(SessionImplementor session, List list) {
+        ForceRecreationList(SharedSessionContractImplementor session, List list) {
             super(session, list);
         }
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -53,8 +53,6 @@ import java.util.Set;
  * <p>
  * Abstract methods define what the subclass must implement to determine what is
  * specific to that Factory's instance.
- *
- * @version $Rev$
  */
 public abstract class HibernateFactory {
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -22,13 +22,13 @@ import com.redhat.rhn.common.db.datasource.SelectMode;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.hibernate.EntityMode;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.MappingException;
 import org.hibernate.Query;
 import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metadata.ClassMetadata;
 
 import java.io.ByteArrayOutputStream;
@@ -423,7 +423,7 @@ public abstract class HibernateFactory {
     public static Object reload(Object obj) throws HibernateException {
         // assertNotNull(obj);
         ClassMetadata cmd = connectionManager.getMetadata(obj);
-        Serializable id = cmd.getIdentifier(obj, EntityMode.POJO);
+        Serializable id = cmd.getIdentifier(obj, (SessionImplementor) getSession());
         Session session = getSession();
         session.flush();
         session.evict(obj);
@@ -562,7 +562,7 @@ public abstract class HibernateFactory {
         if (data.length == 0) {
             return null;
         }
-        return Hibernate.createBlob(data);
+        return Hibernate.getLobCreator(getSession()).createBlob(data);
 
     }
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/test/NestedTransactionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/test/NestedTransactionFactoryTest.java
@@ -84,5 +84,4 @@ public class NestedTransactionFactoryTest extends RhnBaseTestCase {
         WebSessionFactory.save(s);
         return s;
     }
-
 }

--- a/java/code/src/com/redhat/rhn/common/hibernate/test/NestedTransactionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/test/NestedTransactionFactoryTest.java
@@ -20,8 +20,6 @@ import com.redhat.rhn.domain.session.WebSessionFactory;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
 import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.TransactionException;
 
 /**
  * UnnestedTransactionFactoryTest
@@ -30,23 +28,6 @@ import org.hibernate.TransactionException;
 public class NestedTransactionFactoryTest extends RhnBaseTestCase {
 
     private static final long EXP_TIME = 60 * 60 * 1000;
-
-
-    public void aTestNesting() throws HibernateException {
-        //System.out.println("XXX BEGIN testNesting");
-        Session session = HibernateFactory.getSession();
-        try {
-            //System.out.println("XXX beginTransaction1");
-            session.beginTransaction();
-            //System.out.println("XXX END testNesting, fail");
-            fail("Created nested transaction, which is verboten");
-        }
-        catch (TransactionException e) {
-            // Expected
-            //System.out.println("XXX expected transaction");
-        }
-        //System.out.println("XXX END testNesting");
-    }
 
     public void testRollback() throws HibernateException {
         WebSession s = createWebSession();

--- a/java/code/src/com/redhat/rhn/common/hibernate/test/NestedTransactionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/test/NestedTransactionFactoryTest.java
@@ -21,10 +21,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 
 import org.hibernate.HibernateException;
 
-/**
- * UnnestedTransactionFactoryTest
- * @version $Rev$
- */
 public class NestedTransactionFactoryTest extends RhnBaseTestCase {
 
     private static final long EXP_TIME = 60 * 60 * 1000;

--- a/java/code/src/com/redhat/rhn/common/hibernate/test/TestFactoryWrapperTest.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/test/TestFactoryWrapperTest.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.domain.test.TestInterface;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
 import org.apache.log4j.Logger;
-import org.hibernate.Session;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -164,48 +163,45 @@ public class TestFactoryWrapperTest extends RhnBaseTestCase {
     }
 
     protected static void oneTimeSetup() throws Exception {
-        Connection c = null;
-        Statement stmt = null;
-        Session session = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            stmt = c.createStatement();
-            stmt.executeQuery("select 1 from persist_test");
-        }
-        catch (SQLException e) {
-            // let's clean up anything that MAY have been left
-            // over
-            forceQuery(c, "drop table persist_test");
-            forceQuery(c, "drop sequence persist_sequence");
+        HibernateFactory.getSession().doWork(connection -> {
+            Statement statement = null;
+            try {
+                statement = connection.createStatement();
+                statement.executeQuery("select 1 from persist_test");
+            }
+            catch (SQLException e) {
+                // let's clean up anything that MAY have been left
+                // over
+                forceQuery(connection, "drop table persist_test");
+                forceQuery(connection, "drop sequence persist_sequence");
 
-            // Couldn't select 1, so the table didn't exist, create it
-            if (ConfigDefaults.get().isOracle()) {
-                stmt.execute("create sequence persist_sequence");
-                stmt.execute("create table persist_test " +
-                        "( " +
-                        "  foobar VarChar2(32)," +
-                        "  test_column VarChar2(5)," +
-                        "  pin    number, " +
-                        "  hidden VarChar(32), " +
-                        "  id     number" +
-                        "         constraint persist_test_pk primary key," +
-                        "  created timestamp with local time zone" +
-                        ")");
-                stmt.execute("insert into persist_test (foobar, id) " +
-                        "values ('Blarg', persist_sequence.nextval)");
-                stmt.execute("insert into persist_test (foobar, id) " +
-                        "values ('duplicate', persist_sequence.nextval)");
-                stmt.execute("insert into persist_test (foobar, id) " +
-                        "values ('duplicate', persist_sequence.nextval)");
-                stmt.execute("insert into persist_test (foobar, hidden, id) " +
-                        "values ('duplicate', 'xxxxx', persist_sequence.nextval)");
-
+                // Couldn't select 1, so the table didn't exist, create it
+                if (ConfigDefaults.get().isOracle()) {
+                    statement.execute("create sequence persist_sequence");
+                    statement.execute("create table persist_test " +
+                            "( " +
+                            "  foobar VarChar2(32)," +
+                            "  test_column VarChar2(5)," +
+                            "  pin    number, " +
+                            "  hidden VarChar(32), " +
+                            "  id     number" +
+                            "         constraint persist_test_pk primary key," +
+                            "  created timestamp with local time zone" +
+                            ")"
+                    );
+                    statement.execute("insert into persist_test (foobar, id) " +
+                            "values ('Blarg', persist_sequence.nextval)");
+                    statement.execute("insert into persist_test (foobar, id) " +
+                            "values ('duplicate', persist_sequence.nextval)");
+                    statement.execute("insert into persist_test (foobar, id) " +
+                            "values ('duplicate', persist_sequence.nextval)");
+                    statement.execute("insert into persist_test (foobar, hidden, id) " +
+                            "values ('duplicate', 'xxxxx', persist_sequence.nextval)");
             }
             else {
-                c.rollback();
-                stmt.execute("create sequence persist_sequence");
-                stmt.execute("create table persist_test " +
+                connection.rollback();
+                statement.execute("create sequence persist_sequence");
+                statement.execute("create table persist_test " +
                         "( " +
                         "  foobar VarChar(32)," +
                         "  test_column VarChar(5)," +
@@ -214,40 +210,39 @@ public class TestFactoryWrapperTest extends RhnBaseTestCase {
                         "  id     numeric" +
                         "         constraint persist_test_pk primary key," +
                         "  created timestamp with time zone" +
-                        ")");
-                stmt.execute("insert into persist_test (foobar, id) " +
+                        ")"
+                );
+                statement.execute("insert into persist_test (foobar, id) " +
                         "values ('Blarg', nextval('persist_sequence'))");
-                stmt.execute("insert into persist_test (foobar, id) " +
+                statement.execute("insert into persist_test (foobar, id) " +
                         "values ('duplicate', nextval('persist_sequence'))");
-                stmt.execute("insert into persist_test (foobar, id) " +
+                statement.execute("insert into persist_test (foobar, id) " +
                         "values ('duplicate', nextval('persist_sequence'))");
-                stmt.execute("insert into persist_test (foobar, hidden, id) " +
+                statement.execute("insert into persist_test (foobar, hidden, id) " +
                         "values ('duplicate', 'xxxxx', nextval('persist_sequence'))");
-            }
+                }
 
-            c.commit();
-        }
-        finally {
-            HibernateHelper.cleanupDB(stmt);
-        }
+                connection.commit();
+            }
+            finally {
+                HibernateHelper.cleanupDB(statement);
+            }
+        });
     }
 
     protected static void oneTimeTeardown() throws Exception {
-
-        Connection c = null;
-        Statement stmt = null;
-        Session session = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            stmt = c.createStatement();
-            // Couldn't select 1, so the table didn't exist, create it
-            forceQuery(c, "drop sequence persist_sequence");
-            forceQuery(c, "drop table persist_test");
-        }
-        finally {
-            HibernateHelper.cleanupDB(stmt);
-        }
+        HibernateFactory.getSession().doWork(connection -> {
+            Statement statement = null;
+            try {
+                statement = connection.createStatement();
+                // Couldn't select 1, so the table didn't exist, create it
+                forceQuery(connection, "drop sequence persist_sequence");
+                forceQuery(connection, "drop table persist_test");
+            }
+            finally {
+                HibernateHelper.cleanupDB(statement);
+            }
+        });
     }
 
     private static void forceQuery(Connection c, String query) {

--- a/java/code/src/com/redhat/rhn/common/hibernate/test/TestFactoryWrapperTest.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/test/TestFactoryWrapperTest.java
@@ -35,9 +35,6 @@ import junit.extensions.TestSetup;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-/*
- * $Rev$
- */
 public class TestFactoryWrapperTest extends RhnBaseTestCase {
     private static Logger log = Logger.getLogger(TestFactoryWrapperTest.class);
 

--- a/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
@@ -57,8 +57,7 @@ class ActionExecutor implements Runnable {
                     while (evtdb.getTransaction().isActive()) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("DB message, waiting for txn: active: " +
-                                    evtdb.getTransaction().isActive() + " commited: " +
-                                    evtdb.getTransaction().wasCommitted());
+                                    evtdb.getTransaction().isActive());
                         }
                         Thread.sleep(10);
                     }

--- a/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
@@ -21,9 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Utility class which encapsulates the logic necessary to dispatch actions
- *
- * @version $Rev $
+ * Utility class which encapsulates the logic necessary to dispatch actions.
  */
 class ActionExecutor implements Runnable {
 

--- a/java/code/src/com/redhat/rhn/common/translation/test/ExceptionsWrapperTest.java
+++ b/java/code/src/com/redhat/rhn/common/translation/test/ExceptionsWrapperTest.java
@@ -33,9 +33,6 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-/*
- * $Rev$
- */
 public class ExceptionsWrapperTest extends TestCase {
 
     private static final Logger LOG = Logger.getLogger(ExceptionsWrapperTest.class);

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -85,7 +85,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 <!-- ConfigUploadAction: 15 -->
                 <subclass name="com.redhat.rhn.domain.action.config.ConfigUploadAction"
                     discriminator-value="15" lazy="true">
-                    <set name="rhnActionConfigChannel" cascade="all" lazy="false">
+                    <set name="configChannelAssociations" cascade="all" lazy="false" table="rhnActionConfigChannel">
                         <key column="action_id"/>
                         <composite-element
                             class="com.redhat.rhn.domain.action.config.ConfigChannelAssociation">
@@ -104,7 +104,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                         </many-to-one>
                                 </composite-element>
                     </set>
-                    <set name="rhnActionConfigFileName" cascade="all" lazy="true">
+                    <set name="configFileNameAssociations" cascade="all" lazy="true" table="rhnActionConfigFileName">
                         <key column="action_id"/>
                         <composite-element
                             class="com.redhat.rhn.domain.action.config.ConfigFileNameAssociation">
@@ -133,11 +133,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                         class="com.redhat.rhn.domain.action.config.ConfigDateFileAction"
                                         />
                         </set>
-                        <!-- in order to use the composite-element mapping here we have
-                                 to make sure the name of the variable is the same as the table name
-                                 since Hibernate doesnt support name and table attributes for the set
-                                 element.  Ugly, but its less code -->
-                        <set name="rhnActionConfigChannel" cascade="all" lazy="true">
+                        <set name="configChannelAssociations" cascade="all" lazy="true" table="rhnActionConfigChannel">
                                 <key column="action_id"/>
                                 <composite-element
                                         class="com.redhat.rhn.domain.action.config.ConfigChannelAssociation">

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadAction.java
@@ -30,35 +30,37 @@ import java.util.Set;
  */
 public class ConfigUploadAction extends Action {
 
-    private Set rhnActionConfigChannel;
-    private Set rhnActionConfigFileName;
+    private Set<ConfigChannelAssociation> configChannelAssociations;
+    private Set<ConfigFileNameAssociation> configFileNameAssociations;
 
     /**
-     * @return Returns the rhnActionConfigChannel.
+     * @return Returns the config channel associations.
      */
-    public Set getRhnActionConfigChannel() {
-        return rhnActionConfigChannel;
+    public Set<ConfigChannelAssociation> getConfigChannelAssociations() {
+        return configChannelAssociations;
     }
 
     /**
-     * @param rhnActionConfigChannelIn The rhnActionConfigChannel to set.
+     * @param configChannelAssociationsIn The config channel associations to set.
      */
-    public void setRhnActionConfigChannel(Set rhnActionConfigChannelIn) {
-        rhnActionConfigChannel = rhnActionConfigChannelIn;
+    public void setConfigChannelAssociations(
+            Set<ConfigChannelAssociation> configChannelAssociationsIn) {
+        configChannelAssociations = configChannelAssociationsIn;
     }
 
     /**
-     * @return Returns the rhnActionConfigFileName.
+     * @return Returns the config file name associations.
      */
-    public Set getRhnActionConfigFileName() {
-        return rhnActionConfigFileName;
+    public Set<ConfigFileNameAssociation> getConfigFileNameAssociations() {
+        return configFileNameAssociations;
     }
 
     /**
-     * @param rhnActionConfigFileNameIn The rhnActionConfigFileName to set.
+     * @param configFileNameAssociationsIn The config file name associations to set.
      */
-    public void setRhnActionConfigFileName(Set rhnActionConfigFileNameIn) {
-        rhnActionConfigFileName = rhnActionConfigFileNameIn;
+    public void setConfigFileNameAssociations(
+            Set<ConfigFileNameAssociation> configFileNameAssociationsIn) {
+        configFileNameAssociations = configFileNameAssociationsIn;
     }
 
     /**
@@ -74,11 +76,11 @@ public class ConfigUploadAction extends Action {
         newCA.setServer(server);
         newCA.setModified(new Date());
         newCA.setCreated(new Date());
-        if (rhnActionConfigChannel == null) {
-            rhnActionConfigChannel = new HashSet();
+        if (configChannelAssociations == null) {
+            configChannelAssociations = new HashSet<>();
         }
         newCA.setParentAction(this);
-        rhnActionConfigChannel.add(newCA);
+        configChannelAssociations.add(newCA);
     }
 
     /**
@@ -92,11 +94,11 @@ public class ConfigUploadAction extends Action {
         newFNA.setServer(server);
         newFNA.setModified(new Date());
         newFNA.setCreated(new Date());
-        if (rhnActionConfigFileName == null) {
-            rhnActionConfigFileName = new HashSet();
+        if (configFileNameAssociations == null) {
+            configFileNameAssociations = new HashSet<>();
         }
         newFNA.setParentAction(this);
-        rhnActionConfigFileName.add(newFNA);
+        configFileNameAssociations.add(newFNA);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadAction.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 /**
  * ConfigUpload - Class representing ActionType.TYPE_CONFIGFILES_MTIME_UPLOAD: 15
- * @version $Rev$
  */
 public class ConfigUploadAction extends Action {
 

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadAction.java
@@ -109,5 +109,4 @@ public class ConfigUploadAction extends Action {
         }
         return formatter;
     }
-
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
@@ -57,8 +57,8 @@ public class ConfigUploadActionFormatter extends ActionFormatter {
          * relationships, it can't happen scheduled from the web UI,
          * and these really are *just* notes.
          */
-        displayChannels(buffy, action.getRhnActionConfigChannel());
-        displayFileNames(buffy, action.getRhnActionConfigFileName());
+        displayChannels(buffy, action.getConfigChannelAssociations());
+        displayFileNames(buffy, action.getConfigFileNameAssociations());
         return buffy.toString();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
@@ -132,5 +132,4 @@ public class ConfigUploadActionFormatter extends ActionFormatter {
             }
         }
     }
-
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
@@ -26,11 +26,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-
-/**
- * ConfigUploadActionFormatter
- * @version $Rev$
- */
 public class ConfigUploadActionFormatter extends ActionFormatter {
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadMtimeAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadMtimeAction.java
@@ -23,10 +23,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-
 /**
  * ConfigUploadMtimeAction - Class representing ActionType.TYPE_CONFIGFILES_MTIME_UPLOAD: 23
- * @version $Rev$
  */
 public class ConfigUploadMtimeAction extends Action {
 

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadMtimeAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadMtimeAction.java
@@ -132,5 +132,4 @@ public class ConfigUploadMtimeAction extends Action {
     public void setConfigDateDetails(ConfigDateDetails configDateDetailsIn) {
         this.configDateDetails = configDateDetailsIn;
     }
-
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadMtimeAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadMtimeAction.java
@@ -32,7 +32,7 @@ public class ConfigUploadMtimeAction extends Action {
 
     private Set configDateFileActions;
 
-    private Set rhnActionConfigChannel;
+    private Set<ConfigChannelAssociation> configChannelAssociations;
 
     private ConfigDateDetails configDateDetails;
 
@@ -66,7 +66,7 @@ public class ConfigUploadMtimeAction extends Action {
      * @return Returns the configChannels associated with this Action
      */
     public ConfigChannel[] getConfigChannels() {
-        Iterator i = rhnActionConfigChannel.iterator();
+        Iterator i = configChannelAssociations.iterator();
         Set retval = new HashSet();
         while (i.hasNext()) {
             ConfigChannelAssociation ca = (ConfigChannelAssociation)i.next();
@@ -79,7 +79,7 @@ public class ConfigUploadMtimeAction extends Action {
      * @return Returns the servers associated with this Action
      */
     public Server[] getServers() {
-        Iterator i = rhnActionConfigChannel.iterator();
+        Iterator i = configChannelAssociations.iterator();
         Set retval = new HashSet();
         while (i.hasNext()) {
             ConfigChannelAssociation ca = (ConfigChannelAssociation)i.next();
@@ -100,24 +100,26 @@ public class ConfigUploadMtimeAction extends Action {
         newCA.setServer(serverIn);
         newCA.setModified(new Date());
         newCA.setCreated(new Date());
-        if (rhnActionConfigChannel == null) {
-            rhnActionConfigChannel = new HashSet();
+        if (configChannelAssociations == null) {
+            configChannelAssociations = new HashSet();
         }
         newCA.setParentAction(this);
-        rhnActionConfigChannel.add(newCA);
+        configChannelAssociations.add(newCA);
     }
 
     /**
-     * @return Returns the rhnActionConfigChannel.
+     * @return Returns the config channel associations.
      */
-    public Set getRhnActionConfigChannel() {
-        return rhnActionConfigChannel;
+    public Set<ConfigChannelAssociation> getConfigChannelAssociations() {
+        return configChannelAssociations;
     }
+
     /**
-     * @param rhnActionConfigChannelIn The rhnActionConfigChannel to set.
+     * @param configChannelAssociationsIn The config channel associations to set.
      */
-    public void setRhnActionConfigChannel(Set rhnActionConfigChannelIn) {
-        this.rhnActionConfigChannel = rhnActionConfigChannelIn;
+    public void setConfigChannelAssociations(
+            Set<ConfigChannelAssociation> configChannelAssociationsIn) {
+        this.configChannelAssociations = configChannelAssociationsIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadActionTest.java
@@ -40,7 +40,8 @@ public class ConfigUploadActionTest extends RhnBaseTestCase {
         assertTrue(lookedUp instanceof ConfigUploadAction);
 
         //see that we have an expected collection
-        Set set = ((ConfigUploadAction)lookedUp).getRhnActionConfigFileName();
+        Set<ConfigFileNameAssociation> set =
+                ((ConfigUploadAction) lookedUp).getConfigFileNameAssociations();
         assertNotNull(set);
         assertEquals(2, set.size());
 

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadActionTest.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import java.util.Set;
 
-
 public class ConfigUploadActionTest extends RhnBaseTestCase {
 
     public void testLookup() throws Exception {
@@ -50,5 +49,4 @@ public class ConfigUploadActionTest extends RhnBaseTestCase {
         assertTrue(o instanceof ConfigFileNameAssociation);
         assertEquals(((ConfigFileNameAssociation)o).getParentAction(), lookedUp);
     }
-
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadMtimeActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadMtimeActionTest.java
@@ -31,10 +31,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-/**
- * ConfigUploadActionTest
- * @version $Rev$
- */
 public class ConfigUploadMtimeActionTest extends RhnBaseTestCase {
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadMtimeActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigUploadMtimeActionTest.java
@@ -63,12 +63,11 @@ public class ConfigUploadMtimeActionTest extends RhnBaseTestCase {
         assertNotNull(cfa.getServers());
         Server serv = cfa.getServers()[0];
         assertNotNull(serv.getId());
-        assertNotNull(((ConfigChannelAssociation)
-                cfa.getRhnActionConfigChannel().toArray()[0]).getParentAction().getId());
-        assertNotNull(((ConfigChannelAssociation)
-                cfa.getRhnActionConfigChannel().toArray()[0]).getServer().getId());
-        assertNotNull(((ConfigChannelAssociation)
-                cfa.getRhnActionConfigChannel().toArray()[0]).getConfigChannel().getId());
+        ConfigChannelAssociation association =
+                cfa.getConfigChannelAssociations().iterator().next();
+        assertNotNull(association.getParentAction().getId());
+        assertNotNull(association.getServer().getId());
+        assertNotNull(association.getConfigChannel().getId());
         // Check the ConfigDateDetails
         assertNotNull(cfa.getConfigDateDetails().getActionId());
     }
@@ -108,10 +107,10 @@ public class ConfigUploadMtimeActionTest extends RhnBaseTestCase {
         assertNotNull(sameAction.getConfigDateFileActions().toArray()[0]);
         assertNotNull(sameAction.getConfigDateFileActions().toArray()[1]);
 
-        assertNotNull(sameAction.getRhnActionConfigChannel());
-        assertEquals(2, sameAction.getRhnActionConfigChannel().size());
-        assertNotNull(sameAction.getRhnActionConfigChannel().toArray()[0]);
-        assertNotNull(sameAction.getRhnActionConfigChannel().toArray()[1]);
+        assertNotNull(sameAction.getConfigChannelAssociations());
+        assertEquals(2, sameAction.getConfigChannelAssociations().size());
+        assertNotNull(sameAction.getConfigChannelAssociations().toArray()[0]);
+        assertNotNull(sameAction.getConfigChannelAssociations().toArray()[1]);
 
         assertNotNull(sameAction.getConfigDateDetails());
         assertEquals(sameAction.getName(), testAction.getName());

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -54,7 +54,6 @@ import java.util.regex.Pattern;
 
 /**
  * KickstartData - Class representation of the table RhnKSData.
- * @version $Rev: 1 $
  */
 public class KickstartData {
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -206,14 +206,6 @@ public class KickstartData {
         return this.active;
     }
 
-
-    /**
-     * Getter for active
-     * @return String to get
-     */
-    public boolean getActive() {
-        return isActive();
-    }
     /**
      * Setter for active
      * @param activeIn to set

--- a/java/code/src/com/redhat/rhn/domain/kickstart/test/CancelKickstartTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/test/CancelKickstartTest.java
@@ -29,7 +29,6 @@ import com.redhat.rhn.testing.TestUtils;
 
 /**
  * CancelKickstartTest - test to verify that we cancel kickstarts and the actions correctly.
- * @version $Rev$
  */
 public class CancelKickstartTest extends BaseTestCaseWithUser {
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/test/CancelKickstartTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/test/CancelKickstartTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.domain.kickstart.test;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.channel.Channel;
@@ -49,8 +48,6 @@ public class CancelKickstartTest extends BaseTestCaseWithUser {
         cancelsession.markFailed("failed : " + TestUtils.randomString());
         KickstartFactory.saveKickstartSession(cancelsession);
         flushAndEvict(cancelsession);
-        flushAndEvict(cancelsession.getAction());
-        HibernateFactory.getSession().flush();
         Action lookupreload = ActionFactory.lookupById(aid1);
         lookupreload = (Action) reload(lookupreload);
         assertTrue(lookupreload.getServerActions() == null ||

--- a/java/code/src/com/redhat/rhn/domain/kickstart/test/CancelKickstartTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/test/CancelKickstartTest.java
@@ -52,5 +52,4 @@ public class CancelKickstartTest extends BaseTestCaseWithUser {
         assertTrue(lookupreload.getServerActions() == null ||
                 lookupreload.getServerActions().size() == 0);
     }
-
 }

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -112,7 +112,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     private Set<ServerHistoryEvent> history;
     private Set<InstalledPackage> packages;
     private ProxyInfo proxyInfo;
-    private Set<? extends ServerGroup> groups;
+    private Set<ServerGroup> groups;
     private Set<Capability> capabilities;
     private CrashCount crashCount;
     private Set<Crash> crashes;
@@ -139,7 +139,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     /**
      * @return Returns the groups.
      */
-    protected Set<? extends ServerGroup> getGroups() {
+    protected Set<ServerGroup> getGroups() {
         return groups;
     }
 
@@ -147,7 +147,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     /**
      * @param groupsIn The groups to set.
      */
-    protected void setGroups(Set<? extends ServerGroup> groupsIn) {
+    protected void setGroups(Set<ServerGroup> groupsIn) {
         groups = groupsIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -58,8 +58,6 @@ import java.util.TreeSet;
 
 /**
  * Server - Class representation of the table rhnServer.
- *
- * @version $Rev$
  */
 public class Server extends BaseDomainHelper implements Identifiable {
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/DeviceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/DeviceTest.java
@@ -22,9 +22,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.hibernate.Session;
-
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -54,32 +51,27 @@ public class DeviceTest extends RhnBaseTestCase {
 
     private void verifyInDb(Long id, String value) throws Exception {
         // Now lets manually test to see if the user got updated
-        Session session = null;
-        Connection c = null;
-        ResultSet rs = null;
-        PreparedStatement ps = null;
-        String rawValue = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            assertNotNull(c);
-            ps = c.prepareStatement(
-                "SELECT PROP1 FROM RHNDEVICE " +
-                "  WHERE ID = " + id);
-            rs = ps.executeQuery();
-            rs.next();
-            rawValue = rs.getString("PROP1");
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
-        finally {
-            rs.close();
-            ps.close();
-        }
-
-        assertNotNull(rawValue);
-        assertEquals(value, rawValue);
+        HibernateFactory.getSession().doWork(connection -> {
+            ResultSet rs = null;
+            PreparedStatement ps = null;
+            String rawValue = null;
+            try {
+                ps = connection.prepareStatement(
+                        "SELECT prop1 FROM rhnDevice WHERE id = " + id);
+                rs = ps.executeQuery();
+                rs.next();
+                rawValue = rs.getString("prop1");
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+            finally {
+                rs.close();
+                ps.close();
+            }
+            assertNotNull(rawValue);
+            assertEquals(value, rawValue);
+        });
     }
 
     public static Device createTestDevice() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/server/test/DeviceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/DeviceTest.java
@@ -25,10 +25,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-/**
- * DeviceTest
- * @version $Rev$
- */
 public class DeviceTest extends RhnBaseTestCase {
 
     public static final String DESCRIPTION = "Test Device";

--- a/java/code/src/com/redhat/rhn/domain/server/test/DeviceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/DeviceTest.java
@@ -93,6 +93,5 @@ public class DeviceTest extends RhnBaseTestCase {
         assertNotNull(hd.getId());
 
         return hd;
-
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/test/DmiTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/DmiTest.java
@@ -112,6 +112,4 @@ public class DmiTest extends RhnBaseTestCase {
 
         return dmi;
     }
-
-
 }

--- a/java/code/src/com/redhat/rhn/domain/server/test/DmiTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/DmiTest.java
@@ -22,9 +22,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.hibernate.Session;
-
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.HashMap;
@@ -67,34 +64,30 @@ public class DmiTest extends RhnBaseTestCase {
 
     private void verifyInDb(Long id, Map params) throws Exception {
         // Now lets manually test to see if the user got updated
-        Session session = null;
-        Connection c = null;
-        ResultSet rs = null;
-        PreparedStatement ps = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            assertNotNull(c);
-            ps = c.prepareStatement(
-                "SELECT * FROM RHNSERVERDMI " +
-                "  WHERE ID = " + id);
-            rs = ps.executeQuery();
-            rs.next();
+        HibernateFactory.getSession().doWork(connection -> {
+            ResultSet rs = null;
+            PreparedStatement ps = null;
+            try {
+                ps = connection.prepareStatement(
+                    "SELECT * FROM rhnServerDmi WHERE id = " + id);
+                rs = ps.executeQuery();
+                rs.next();
 
-            assertEquals(id.longValue(), rs.getLong("ID"));
-            assertEquals(params.get("vendor"), rs.getString("VENDOR"));
-            assertEquals(params.get("system"), rs.getString("SYSTEM"));
-            assertEquals(params.get("product"), rs.getString("PRODUCT"));
-            assertEquals(params.get("biosvendor"), rs.getString("BIOS_VENDOR"));
-            assertEquals(params.get("biosversion"), rs.getString("BIOS_VERSION"));
-            assertEquals(params.get("biosrelease"), rs.getString("BIOS_RELEASE"));
-            assertEquals(params.get("asset"), rs.getString("ASSET"));
-            assertEquals(params.get("board"), rs.getString("BOARD"));
-        }
-        finally {
-            rs.close();
-            ps.close();
-        }
+                assertEquals(id.longValue(), rs.getLong("ID"));
+                assertEquals(params.get("vendor"), rs.getString("VENDOR"));
+                assertEquals(params.get("system"), rs.getString("SYSTEM"));
+                assertEquals(params.get("product"), rs.getString("PRODUCT"));
+                assertEquals(params.get("biosvendor"), rs.getString("BIOS_VENDOR"));
+                assertEquals(params.get("biosversion"), rs.getString("BIOS_VERSION"));
+                assertEquals(params.get("biosrelease"), rs.getString("BIOS_RELEASE"));
+                assertEquals(params.get("asset"), rs.getString("ASSET"));
+                assertEquals(params.get("board"), rs.getString("BOARD"));
+            }
+            finally {
+                rs.close();
+                ps.close();
+            }
+        });
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/DmiTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/DmiTest.java
@@ -27,10 +27,6 @@ import java.sql.ResultSet;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * DeviceTest
- * @version $Rev$
- */
 public class DmiTest extends RhnBaseTestCase {
 
     public static final String VENDOR = "ZEUS computers";

--- a/java/code/src/com/redhat/rhn/domain/server/test/RamTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/RamTest.java
@@ -21,9 +21,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.hibernate.Session;
-
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -57,31 +54,23 @@ public class RamTest extends RhnBaseTestCase {
     }
 
 
-    private void verifyInDb(Long serverId, long ram, long swap)
-        throws Exception {
-        // Now lets manually test to see if the user got updated
-        Session session = null;
-        Connection c = null;
-        ResultSet rs = null;
-        PreparedStatement ps = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            assertNotNull(c);
-            ps = c.prepareStatement(
-                "SELECT ID, RAM, SWAP FROM RHNRAM " +
- "  WHERE SERVER_ID = " + serverId);
-            rs = ps.executeQuery();
-            rs.next();
+    private void verifyInDb(Long serverId, long ram, long swap) throws Exception {
+        HibernateFactory.getSession().doWork(connection -> {
+            ResultSet rs = null;
+            PreparedStatement ps = null;
+            try {
+                ps = connection.prepareStatement("SELECT id, ram, swap FROM rhnRam " +
+                   "  WHERE server_id = " + serverId);
+                rs = ps.executeQuery();
+                rs.next();
 
-            assertEquals(ram, rs.getLong("RAM"));
-            assertEquals(swap, rs.getLong("SWAP"));
-        }
-        finally {
-            rs.close();
-            ps.close();
-        }
+                assertEquals(ram, rs.getLong("RAM"));
+                assertEquals(swap, rs.getLong("SWAP"));
+            }
+            finally {
+                rs.close();
+                ps.close();
+            }
+        });
     }
-
-
 }

--- a/java/code/src/com/redhat/rhn/domain/server/test/RamTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/RamTest.java
@@ -24,10 +24,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-/**
- * DeviceTest
- * @version $Rev$
- */
 public class RamTest extends RhnBaseTestCase {
 
     public void testRam() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/user/test/UserFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/user/test/UserFactoryTest.java
@@ -15,15 +15,6 @@
 
 package com.redhat.rhn.domain.user.test;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TimeZone;
-
-import org.hibernate.Session;
-
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.org.Org;
@@ -43,6 +34,12 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestStatics;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimeZone;
 
 /** JUnit test case for the User
  *  class.
@@ -213,32 +210,30 @@ public class UserFactoryTest extends RhnBaseTestCase {
         flushAndEvict(usr);
 
         // Now lets manually test to see if the user got updated
-        Connection c = null;
-        ResultSet rs = null;
-        PreparedStatement ps = null;
-        Session session = null;
-        String rawValue = null;
-        try {
-            session = HibernateFactory.getSession();
-            c = session.connection();
-            assertNotNull(c);
-            ps = c.prepareStatement(
-                "SELECT FIRST_NAMES FROM WEB_USER_PERSONAL_INFO" +
-                "  WHERE WEB_USER_ID = " + id);
-            rs = ps.executeQuery();
-            rs.next();
-            rawValue = rs.getString("FIRST_NAMES");
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
-        finally {
-            rs.close();
-            ps.close();
-        }
+        HibernateFactory.getSession().doWork(connection -> {
+            ResultSet rs = null;
+            PreparedStatement ps = null;
+            String rawValue = null;
+            try {
+                ps = connection.prepareStatement("SELECT first_names " +
+                    "FROM web_user_personal_info " +
+                    "WHERE web_user_id = " + id
+                );
+                rs = ps.executeQuery();
+                rs.next();
+                rawValue = rs.getString("first_names");
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+            finally {
+                rs.close();
+                ps.close();
+            }
 
-        usr = UserFactory.lookupById(id);
-        assertEquals(usr.getFirstNames(), rawValue);
+            User actualUser = UserFactory.lookupById(id);
+            assertEquals(actualUser.getFirstNames(), rawValue);
+        });
     }
 
 

--- a/java/code/src/com/redhat/rhn/domain/user/test/UserFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/user/test/UserFactoryTest.java
@@ -41,11 +41,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
-/** JUnit test case for the User
- *  class.
- * @version $Rev$
+/**
+ * JUnit test case for the User class.
  */
-
 public class UserFactoryTest extends RhnBaseTestCase {
     private UserFactory factory;
 

--- a/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
@@ -285,7 +285,5 @@ public class RhnSetActionTest extends RhnBaseTestCase {
         public Long getId() {
             return this.id;
         }
-
     }
-
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
@@ -43,7 +43,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * RhnSetActionTest
- * @version $Rev$
  */
 public class RhnSetActionTest extends RhnBaseTestCase {
     private static Logger log = Logger.getLogger(RhnSetActionTest.class);

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
@@ -248,5 +248,4 @@ public class FileListConfirmSubmitAction extends RhnListDispatchAction {
                 mapping.findForward(RhnHelper.DEFAULT_FORWARD),
                 "sid", sid.toString());
     }
-
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
@@ -53,10 +53,8 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
 /**
  * ImportFileConfirmSubmitAction, for sdc configuration
- * @version $Rev$
  */
 public class FileListConfirmSubmitAction extends RhnListDispatchAction {
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
@@ -114,7 +114,7 @@ public class FileListConfirmSubmitAction extends RhnListDispatchAction {
 
         //Create a success message
         if (upload != null) {
-            createSuccessMessage(upload, upload.getRhnActionConfigFileName().size(),
+            createSuccessMessage(upload, upload.getConfigFileNameAssociations().size(),
                     "config.import.success", request, null);
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -48,7 +48,6 @@ import com.redhat.rhn.domain.rhnpackage.profile.ProfileFactory;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.CPU;
-import com.redhat.rhn.domain.server.CPUArch;
 import com.redhat.rhn.domain.server.CustomDataValue;
 import com.redhat.rhn.domain.server.Device;
 import com.redhat.rhn.domain.server.Dmi;
@@ -64,6 +63,7 @@ import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
+import com.redhat.rhn.domain.server.test.CPUTest;
 import com.redhat.rhn.domain.server.test.GuestBuilder;
 import com.redhat.rhn.domain.server.test.NetworkInterfaceTest;
 import com.redhat.rhn.domain.server.test.NetworkTest;
@@ -1273,14 +1273,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         cpu.setModel("model_string");
         cpu.setStepping("stepping_string");
 
-        CPUArch arch = new CPUArch();
-        arch.setName("i986");
-        arch.setLabel("i986");
-        arch.setCreated(new Date());
-        TestUtils.saveAndReload(arch);
-
         cpu.setServer(server);
-        cpu.setArch(arch);
+        cpu.setArch(ServerFactory.lookupCPUArchByName(CPUTest.ARCH_NAME));
         server.setCpu(cpu);
 
         CPU cpuMap = (CPU) handler.getCpu(admin,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -128,9 +128,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * SystemHandlerTest
- */
 public class SystemHandlerTest extends BaseHandlerTestCase {
 
     private SystemHandler handler = new SystemHandler();

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -396,7 +396,7 @@ public class ActionManager extends BaseManager {
         }
 
         //if this is a pointless action, don't do it.
-        if (a.getRhnActionConfigFileName().size() < 1) {
+        if (a.getConfigFileNameAssociations().size() < 1) {
             return null;
         }
 

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -91,9 +91,6 @@ import java.util.Set;
  * ActionManager - the singleton class used to provide Business Operations
  * on Actions where those operations interact with other top tier Business
  * Objects.
- *
- * Operations that require the Action make changes to
- * @version $Rev$
  */
 public class ActionManager extends BaseManager {
     private static Logger log = Logger.getLogger(ActionManager.class);

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/test/ErrataCacheManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/test/ErrataCacheManagerTest.java
@@ -39,9 +39,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.hibernate.Session;
-
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.HashMap;
@@ -109,19 +106,20 @@ public class ErrataCacheManagerTest extends RhnBaseTestCase {
         assertEquals(1, rows);
 
         // verify what was inserted
-        Session session = HibernateFactory.getSession();
-        Connection conn = session.connection();
-        Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery(
-                "select * from rhnServerNeededPackageCache where server_id = " +
-                sid.toString());
-        assertTrue(rs.next());
-        assertEquals(sid.longValue(), rs.getLong("server_id"));
-        assertEquals(eid.longValue(), rs.getLong("errata_id"));
-        assertEquals(pid.longValue(), rs.getLong("package_id"));
+        HibernateFactory.getSession().doWork(connection -> {
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery(
+                "SELECT * FROM rhnServerNeededPackageCache WHERE server_id = " +
+                sid.toString()
+            );
+            assertTrue(rs.next());
+            assertEquals(sid.longValue(), rs.getLong("server_id"));
+            assertEquals(eid.longValue(), rs.getLong("errata_id"));
+            assertEquals(pid.longValue(), rs.getLong("package_id"));
 
-        // make sure we don't have more
-        assertFalse(rs.next());
+            // make sure we don't have more
+            assertFalse(rs.next());
+        });
     }
 
     public static Map createServerNeededPackageCache(User userIn,
@@ -176,33 +174,34 @@ public class ErrataCacheManagerTest extends RhnBaseTestCase {
         Long pid = pkg.getId();
 
         // insert record into table
-        int rows = ErrataCacheManager.insertNeededErrataCache(
-                sid, eid, pid);
-        assertEquals(1, rows);
+        HibernateFactory.getSession().doWork(connection -> {
+            int rows = ErrataCacheManager.insertNeededErrataCache(sid, eid, pid);
+            assertEquals(1, rows);
 
-        // verify what was inserted
-        Session session = HibernateFactory.getSession();
-        Connection conn = session.connection();
-        Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery(
-                "select * from rhnServerNeededPackageCache where server_id = " +
-                sid.toString());
-        assertTrue(rs.next());
-        assertEquals(sid.longValue(), rs.getLong("server_id"));
-        assertEquals(eid.longValue(), rs.getLong("errata_id"));
-        assertEquals(pid.longValue(), rs.getLong("package_id"));
+            // verify what was inserted
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery(
+                "SELECT * FROM rhnServerNeededPackageCache WHERE server_id = " +
+                sid.toString()
+            );
+            assertTrue(rs.next());
+            assertEquals(sid.longValue(), rs.getLong("server_id"));
+            assertEquals(eid.longValue(), rs.getLong("errata_id"));
+            assertEquals(pid.longValue(), rs.getLong("package_id"));
 
-        // make sure we don't have more
-        assertFalse(rs.next());
+            // make sure we don't have more
+            assertFalse(rs.next());
 
-        // now let's delete the above record
-        rows = ErrataCacheManager.deleteNeededPackageCache(sid, eid, pid);
-        assertEquals(1, rows);
+            // now let's delete the above record
+            rows = ErrataCacheManager.deleteNeededPackageCache(sid, eid, pid);
+            assertEquals(1, rows);
 
-        rs = stmt.executeQuery(
-                "select * from rhnServerNeededPackageCache where server_id = " +
-                sid.toString());
-        assertFalse(rs.next());
+            rs = stmt.executeQuery(
+                "SELECT * FROM rhnServerNeededPackageCache WHERE server_id = "
+                + sid.toString()
+            );
+            assertFalse(rs.next());
+        });
     }
 
     public static Server createServerNeedintErrataCache(User userIn) throws Exception {
@@ -241,18 +240,19 @@ public class ErrataCacheManagerTest extends RhnBaseTestCase {
         assertEquals(1, rows);
 
         // verify what was inserted
-        Session session = HibernateFactory.getSession();
-        Connection conn = session.connection();
-        Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery(
-                "select * from rhnServerNeededErrataCache where server_id = " +
-                sid.toString());
-        assertTrue(rs.next());
-        assertEquals(sid.longValue(), rs.getLong("server_id"));
-        assertEquals(eid.longValue(), rs.getLong("errata_id"));
+        HibernateFactory.getSession().doWork(connection -> {
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery(
+                "SELECT * FROM rhnServerNeededErrataCache WHERE server_id = " +
+                sid.toString()
+            );
+            assertTrue(rs.next());
+            assertEquals(sid.longValue(), rs.getLong("server_id"));
+            assertEquals(eid.longValue(), rs.getLong("errata_id"));
 
-        // make sure we don't have more
-        assertFalse(rs.next());
+            // make sure we don't have more
+            assertFalse(rs.next());
+        });
     }
 
     public void testDeleteNeededErrataCache() throws Exception {
@@ -267,31 +267,33 @@ public class ErrataCacheManagerTest extends RhnBaseTestCase {
         Package p = e.getPackages().iterator().next();
 
         // insert record into table
-        int rows = ErrataCacheManager.insertNeededErrataCache(sid, eid, p.getId());
-        assertEquals(1, rows);
+        HibernateFactory.getSession().doWork(connection -> {
+            int rows = ErrataCacheManager.insertNeededErrataCache(sid, eid, p.getId());
+            assertEquals(1, rows);
 
-        // verify what was inserted
-        Session session = HibernateFactory.getSession();
-        Connection conn = session.connection();
-        Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery(
-                "select * from rhnServerNeededErrataCache where server_id = " +
-                sid.toString());
-        assertTrue(rs.next());
-        assertEquals(sid.longValue(), rs.getLong("server_id"));
-        assertEquals(eid.longValue(), rs.getLong("errata_id"));
+            // verify what was inserted
+            Statement statement = connection.createStatement();
+            ResultSet rs = statement.executeQuery(
+                "SELECT * FROM rhnServerNeededErrataCache WHERE server_id = " +
+                sid.toString()
+            );
+            assertTrue(rs.next());
+            assertEquals(sid.longValue(), rs.getLong("server_id"));
+            assertEquals(eid.longValue(), rs.getLong("errata_id"));
 
-        // make sure we don't have more
-        assertFalse(rs.next());
+            // make sure we don't have more
+            assertFalse(rs.next());
 
-        // now let's delete the above record
-        rows = ErrataCacheManager.deleteNeededErrataCache(sid, eid);
-        assertEquals(1, rows);
+            // now let's delete the above record
+            rows = ErrataCacheManager.deleteNeededErrataCache(sid, eid);
+            assertEquals(1, rows);
 
-        rs = stmt.executeQuery(
-                "select * from rhnServerNeededErrataCache where server_id = " +
-                sid.toString());
-        assertFalse(rs.next());
+            rs = statement.executeQuery(
+                "SELECT * FROM rhnServerNeededErrataCache WHERE server_id = " +
+                sid.toString()
+            );
+            assertFalse(rs.next());
+        });
     }
 
     public void testPackagesNeedingUpdates() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/test/ErrataCacheManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/test/ErrataCacheManagerTest.java
@@ -338,5 +338,4 @@ public class ErrataCacheManagerTest extends RhnBaseTestCase {
         assertFalse(dr.isEmpty());
         assertTrue(dr.size() >= 1);
     }
-
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/test/ErrataCacheManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/test/ErrataCacheManagerTest.java
@@ -47,7 +47,6 @@ import java.util.Map;
 
 /**
  * ErrataFactoryTest
- * @version $Rev$
  */
 public class ErrataCacheManagerTest extends RhnBaseTestCase {
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
@@ -34,8 +34,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * CobblerProfileComand - class to contain logic to communicate with cobbler
- * @version $Rev$
+ * CobblerProfileComand - class to contain logic to communicate with cobbler.
  */
 public abstract class CobblerProfileCommand extends CobblerCommand {
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
@@ -126,7 +126,7 @@ public abstract class CobblerProfileCommand extends CobblerCommand {
                     getVirtualizationType().getLabel());
         }
 
-        profile.setEnableMenu(ksData.getActive());
+        profile.setEnableMenu(ksData.isActive());
 
         profile.save();
     }

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -1421,9 +1421,6 @@ public class PackageManager extends BaseManager {
         catch (Exception e) {
             HibernateFactory.rollbackTransaction();
         }
-        finally {
-            HibernateFactory.closeSession();
-        }
     }
 
     private static void updateRepoEntry(Long packageId, String xml, String type) {

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -73,7 +73,6 @@ import com.redhat.rhn.manager.system.IncompatibleArchException;
 
 /**
  * PackageManager
- * @version $Rev$
  */
 public class PackageManager extends BaseManager {
     private static final Logger LOG = Logger.getLogger(PackageManager.class);

--- a/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
@@ -27,11 +27,8 @@ import org.apache.log4j.Logger;
 
 import java.util.List;
 
-
 /**
  * Class responsible for executing one-time upgrade logic
- *
- * @version $Rev$
  */
 public class UpgradeCommand extends BaseTransactionCommand {
 

--- a/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
@@ -57,7 +57,6 @@ public class UpgradeCommand extends BaseTransactionCommand {
      */
     public void store() {
         try {
-            HibernateFactory.getSession().beginTransaction();
             upgrade();
         }
         catch (Exception e) {

--- a/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
@@ -105,5 +105,4 @@ public class UpgradeCommand extends BaseTransactionCommand {
 
         }
     }
-
 }

--- a/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
@@ -50,7 +50,7 @@ public class UpgradeCommand extends BaseTransactionCommand {
 
 
     /**
-     * Excutes the upgrade step in an own transaction
+     * Executes the upgrade step in an own transaction
      */
     public void store() {
         try {
@@ -68,7 +68,7 @@ public class UpgradeCommand extends BaseTransactionCommand {
 
 
     /**
-     * Excutes the upgrade step
+     * Executes the upgrade step
      */
     public void upgrade() {
         List upgradeTasks = TaskFactory.getTaskListByNameLike(UPGRADE_TASK_NAME);

--- a/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/UpgradeCommand.java
@@ -53,24 +53,12 @@ public class UpgradeCommand extends BaseTransactionCommand {
 
 
     /**
-     * Excute the upgrade step
+     * Excutes the upgrade step in an own transaction
      */
     public void store() {
         try {
             HibernateFactory.getSession().beginTransaction();
-            List upgradeTasks = TaskFactory.getTaskListByNameLike(UPGRADE_TASK_NAME);
-            // Loop over upgrade tasks and execute the steps.
-            for (int i = 0; i < upgradeTasks.size(); i++) {
-                Task t = (Task) upgradeTasks.get(i);
-                // Use WARN because we want this logged.
-                if (t != null) {
-                    log.warn("got upgrade task: " + t.getName());
-                    if (t.getName().equals(UPGRADE_KS_PROFILES)) {
-                        processKickstartProfiles();
-                        TaskFactory.remove(t);
-                    }
-                }
-            }
+            upgrade();
         }
         catch (Exception e) {
             log.error("Problem upgrading!", e);
@@ -79,6 +67,26 @@ public class UpgradeCommand extends BaseTransactionCommand {
         }
         finally {
             handleTransaction();
+        }
+    }
+
+
+    /**
+     * Excutes the upgrade step
+     */
+    public void upgrade() {
+        List upgradeTasks = TaskFactory.getTaskListByNameLike(UPGRADE_TASK_NAME);
+        // Loop over upgrade tasks and execute the steps.
+        for (int i = 0; i < upgradeTasks.size(); i++) {
+            Task t = (Task) upgradeTasks.get(i);
+            // Use WARN because we want this logged.
+            if (t != null) {
+                log.warn("got upgrade task: " + t.getName());
+                if (t.getName().equals(UPGRADE_KS_PROFILES)) {
+                    processKickstartProfiles();
+                    TaskFactory.remove(t);
+                }
+            }
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/UpgradeCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/UpgradeCommandTest.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import java.util.List;
 
-
 public class UpgradeCommandTest extends BaseTestCaseWithUser {
 
     public void testUpgradeProfiles() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/UpgradeCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/UpgradeCommandTest.java
@@ -46,7 +46,7 @@ public class UpgradeCommandTest extends BaseTestCaseWithUser {
         commitHappened();
 
         UpgradeCommand cmd = new UpgradeCommand();
-        cmd.store();
+        cmd.upgrade();
 
         // Check to see if the upgrade command created the default profile.
         ksession =

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -94,9 +94,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * SystemManagerTest
- */
+
 public class SystemManagerTest extends RhnBaseTestCase {
 
     public static final Long NUM_CPUS = new Long(5);

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -82,8 +82,8 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import org.cobbler.test.MockConnection;
-import org.hibernate.Hibernate;
 import org.hibernate.Session;
+import org.hibernate.type.IntegerType;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -135,7 +135,7 @@ public class SystemManagerTest extends RhnBaseTestCase {
         Integer count = (Integer) session.createSQLQuery("Select count(*) as cnt " +
                                                          "  from rhnSnapshot " +
                                                          " where server_id = " + sid)
-                                         .addScalar("cnt", Hibernate.INTEGER)
+                                         .addScalar("cnt", IntegerType.INSTANCE)
                                          .uniqueResult();
         return count;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvocationInterceptor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvocationInterceptor.java
@@ -48,5 +48,4 @@ public class TaskoXmlRpcInvocationInterceptor implements
         HibernateFactory.rollbackTransaction();
         HibernateFactory.closeSession();
     }
-
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvocationInterceptor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvocationInterceptor.java
@@ -22,7 +22,6 @@ import redstone.xmlrpc.XmlRpcInvocationInterceptor;
 
 /**
  * TaskoXmlRpcInvocationInterceptor
- * @version $Rev$
  */
 public class TaskoXmlRpcInvocationInterceptor implements
         XmlRpcInvocationInterceptor {

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvocationInterceptor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcInvocationInterceptor.java
@@ -31,9 +31,6 @@ public class TaskoXmlRpcInvocationInterceptor implements
      * {@inheritDoc}
      */
     public Object after(XmlRpcInvocation invocation, Object returnValue) {
-        if (HibernateFactory.getSession().getTransaction().isActive()) {
-            HibernateFactory.commitTransaction();
-        }
         HibernateFactory.closeSession();
         return returnValue;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -32,10 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
 /**
- *
- * @version $Rev $
- *
+ * Generates metadata files for channels.
  */
 public class ChannelRepodataWorker implements QueueWorker {
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -115,7 +115,6 @@ public class ChannelRepodataWorker implements QueueWorker {
                 }
 
                 dequeueChannel();
-                HibernateFactory.commitTransaction();
             }
             else {
                 HibernateFactory.commitTransaction();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -240,8 +240,5 @@ public class ChannelRepodataWorker implements QueueWorker {
             HibernateFactory.rollbackTransaction();
             return;
         }
-        finally {
-            HibernateFactory.closeSession();
-        }
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/PackageCleanupTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/PackageCleanupTest.java
@@ -19,32 +19,20 @@ import com.redhat.rhn.taskomatic.task.PackageCleanup;
 import com.redhat.rhn.taskomatic.task.RhnJob;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
-import org.hibernate.Session;
-
 import java.io.File;
 import java.sql.Statement;
 
 public class PackageCleanupTest extends RhnBaseTestCase {
 
-
-
     protected void setUp() throws Exception {
-        Session session = HibernateFactory.getSession();
-        StringBuffer sql = new StringBuffer();
-        sql.append("insert into rhnPackageFileDeleteQueue (path) ");
-        sql.append("values ('test-pkg-delete-me.rpm')");
-        Statement stmt = null;
-        try {
-            stmt = session.connection().createStatement();
-            stmt.execute(sql.toString());
-        }
-        finally {
-            if (stmt != null) {
-                stmt.close();
+        HibernateFactory.getSession().doWork(connection -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("INSERT INTO rhnPackageFileDeleteQueue(path) " +
+                        "VALUES ('test-pkg-delete-me.rpm')"
+                );
             }
-        }
-        File f = new File("/tmp/test-pkg-delete-me.rpm");
-        f.createNewFile();
+        });
+        new File("/tmp/test-pkg-delete-me.rpm").createNewFile();
     }
 
     public void testPackageCleanup() throws Exception {

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -482,6 +482,7 @@ echo "wrapper.java.classpath.28=/usr/share/java/log4j-1.jar" >> conf/default/rhn
 echo "wrapper.java.classpath.28=/usr/share/java/log4j.jar" >> conf/default/rhn_taskomatic_daemon.conf
 %endif
 %if 0%{?fedora}
+echo "hibernate.id.new_generator_mappings = false" >> conf/default/rhn_hibernate.conf
 echo "wrapper.java.classpath.49=/usr/share/java/hibernate3/hibernate-core-3.jar
 wrapper.java.classpath.61=/usr/share/java/hibernate-jpa-2.0-api.jar
 wrapper.java.classpath.62=/usr/share/java/hibernate3/hibernate-ehcache-3.jar
@@ -10127,4 +10128,3 @@ Feature: Support channel-permissions on ISS
 - 576907 - making same display changes for system sync (tlestach@redhat.com)
 - Move systemlogs directory out of /var/satellite (joshua.roys@gtri.gatech.edu)
 - 580227 - displaying dates in the same format (tlestach@redhat.com)
-

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -306,8 +306,19 @@ Requires: hibernate3-ehcache >= 3.6.10
 Requires: javassist
 Requires: java-devel >= 0:1.7.0
 %else
+%if 0%{?suse_version}
+Requires: hibernate5
+Requires: hibernate-commons-annotations
+Requires: hibernate-jpa-2.1-api
+Requires: ehcache >= 2.10.1
+Requires: classmate
+Requires: javassist
+Requires: jboss-logging
+Requires: statistics
+%else
 Requires: hibernate3 >= 0:3.2.4
 Requires: java-1.7.0-openjdk-devel
+%endif
 %endif
 %if 0%{?fedora} || 0%{?rhel} >= 7
 Requires: apache-commons-cli

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -58,17 +58,23 @@ Requires: xalan-j2 >= 0:2.6.0
 Requires: xerces-j2
 %if 0%{?fedora}
 Requires: classpathx-jaf
-Requires: hibernate3 >= 3.6.10
-Requires: hibernate3-c3p0 >= 3.6.10
-Requires: hibernate3-ehcache >= 3.6.10
+Requires: hibernate5
+Requires: hibernate-commons-annotations
+Requires: hibernate-jpa-2.1-api
+Requires: ehcache-core >= 2.10.1
+Requires: classmate
 Requires: javassist
-Requires: java-devel >= 1:1.7.0
-BuildRequires: ehcache-core
-BuildRequires: hibernate3 >= 0:3.6.10
-BuildRequires: hibernate3-c3p0 >= 3.6.10
-BuildRequires: hibernate3-ehcache >= 3.6.10
-BuildRequires: javassist
-BuildRequires: java-devel >= 1:1.7.0
+Requires: jboss-logging
+Requires: statistics
+Requires: java-devel >= 1:1.8.0
+BuildRequires: hibernate5
+BuildRequires: hibernate-commons-annotations
+BuildRequires: hibernate-jpa-2.1-api
+BuildRequires: ehcache-core >= 2.10.1
+BuildRequires: classmate
+BuildRequires: jboss-logging
+BuildRequires: statistics
+BuildRequires: java-devel >= 1:1.8.0
 %else
 Requires: hibernate3 = 0:3.2.4
 Requires: java-1.7.0-openjdk-devel
@@ -484,14 +490,16 @@ echo "wrapper.java.classpath.28=/usr/share/java/log4j.jar" >> conf/default/rhn_t
 %if 0%{?fedora}
 echo "hibernate.id.new_generator_mappings = false" >> conf/default/rhn_hibernate.conf
 echo "wrapper.java.classpath.49=/usr/share/java/hibernate3/hibernate-core-3.jar
-wrapper.java.classpath.61=/usr/share/java/hibernate-jpa-2.0-api.jar
-wrapper.java.classpath.62=/usr/share/java/hibernate3/hibernate-ehcache-3.jar
-wrapper.java.classpath.63=/usr/share/java/hibernate3/hibernate-c3p0-3.jar
+wrapper.java.classpath.61=/usr/share/java/hibernate-jpa-2.1-api.jar
+wrapper.java.classpath.62=/usr/share/java/hibernate3/hibernate-ehcache-5.jar
+wrapper.java.classpath.63=/usr/share/java/hibernate3/hibernate-c3p0-5.jar
 wrapper.java.classpath.64=/usr/share/java/hibernate*/hibernate-commons-annotations.jar
 wrapper.java.classpath.65=/usr/share/java/slf4j/api.jar
 wrapper.java.classpath.66=/usr/share/java/jboss-logging.jar
 wrapper.java.classpath.67=/usr/share/java/javassist.jar
-wrapper.java.classpath.68=/usr/share/java/ehcache-core.jar" >> conf/default/rhn_taskomatic_daemon.conf
+wrapper.java.classpath.68=/usr/share/java/ehcache-core.jar
+wrapper.java.classpath.69=/usr/share/java/classmate.jar
+wrapper.java.classpath.70=/usr/share/java/statistics.jar" >> conf/default/rhn_taskomatic_daemon.conf
 %else
 echo "hibernate.cache.provider_class=org.hibernate.cache.OSCacheProvider" >> conf/default/rhn_hibernate.conf
 echo "wrapper.java.classpath.49=/usr/share/java/hibernate3.jar" >> conf/default/rhn_taskomatic_daemon.conf
@@ -628,11 +636,10 @@ fi
 %{jardir}/concurrent*.jar
 %{jardir}/dom4j.jar
 %{jardir}/dwr.jar
-%{jardir}/hibernate3*
 %if 0%{?fedora}
 %{jardir}/ehcache-core.jar
 %{jardir}/*_hibernate-commons-annotations.jar
-%{jardir}/hibernate-jpa-2.0-api*.jar
+%{jardir}/hibernate-jpa-2.1-api*.jar
 %{jardir}/javassist.jar
 %{jardir}/slf4j_api.jar
 %{jardir}/slf4j_log4j12*.jar
@@ -640,6 +647,11 @@ fi
 %{_javadir}/mchange-commons.jar
 %{_javadir}/jboss-logging.jar
 %{jardir}/*jboss-logging.jar
+%{jardir}/hibernate-core-5.jar
+%{jardir}/hibernate-c3p0-5.jar
+%{jardir}/hibernate-ehcache-5.jar
+%{jardir}/classmate.jar
+%{jardir}/statistics.jar
 
 %if 0%{?fedora} >= 21
 %{_javadir}/c3p0.jar


### PR DESCRIPTION
## Feeling

![pulling](https://cloud.githubusercontent.com/assets/250541/18199503/ca2dc46c-7100-11e6-9c86-0590428b8c21.gif)
## Contents

This PR upgrades the codebase to the latest stable Hibernate. Specifically:
- it updates our usage of the API where parts were removed/changed after deprecation
- it updates our usage of the API when semantics changed, as detected by the jUnit test suite
- it offers some cleanups

It is assumed that Hibernate 5 and its dependencies are available in packaged form. For SUSE Manager we used [tetra](https://github.com/moio/tetra) and resulting specfiles and packages are being uploaded [in an Open Build Service project](https://build.opensuse.org/project/monitor/home:SilvioMoioli:spacewalk-hibernate5) for your reference - this is likely not appropriate for Fedora/RHEL so some specfile work is still needed.

Another assumption is that Java 8 is available. We have been using it extensively even in production for SUSE Manager since long time and did not really find regressions. Moreover I was told that it was also coming to the Spacewalk codebase, so I did not port this code back to Java 7 syntax yet.
## Reliability

This was mainly tested against the jUnit testsuite (Oracle and Postgres, on 3.0 and HEAD branches of SUSE Manager). A SUSE Manager server with one client and one minion was also set up (by manually exchanging jars) and it was verified that main functionality works: clients and minions were onboarded, channels could be added and packages were installed from them.

Soon a full integration test will be available.
## Reviewer notes

History is clean so commit-by-commit reviewing should be easier.

Please note that after these patches a number of warnings appear in Hibernate logs. This is because a number of features were deprecated but not yet removed - migration to those newer constructs should be evaluated separately:
- HHH90000012: Recognized obsolete hibernate namespace
- HHH90000009: The outer-join attribute on <many-to-many> has been deprecated
- HHH90000005: Defining an entity with no physical id attribute is no longer supported
- HHH90000014: Found use of deprecated sequence-based id generator
- HHH020003: Could not find a specific ehcache configuration
- HHH90000016: Found use of deprecated 'collection property' syntax in HQL/JPQL query
- HHH90000022: Hibernate's legacy org.hibernate.Criteria API is deprecated

Also note that this PR is mostly for discussion purposes, I did not spend a lot of time making sure it is 100% working in Spacewalk. If Java 8 and Hibernate packages are available and if this is considered interesting by the core development team, please ping me so that we can make sure the migration works out smoothly.
