### PR TITLE
spacecmd: catch all exceptions in do_login()

### DIFF
--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -282,8 +282,9 @@ def do_login(self, args):
     try:
         self.api_version = self.client.api.getVersion()
         logging.debug('Server API Version = %s', self.api_version)
-    except xmlrpclib.Fault, e:
+    except:
         if self.options.debug > 0:
+            e = sys.exc_info()[0]
             logging.exception(e)
 
         logging.error('Failed to connect to %s', server_url)


### PR DESCRIPTION
In `do_login()`, the first use of self.client is wrapped in try/except block that only catches `xmlrpclib.Fault`. All other exceptions are uncaught and terminate spacecmd with a traceback. This includes any exceptions that may be thrown from socket lib, like for example with refused TCP connections:
```
$ spacecmd -s httpd.is.down.here.example.com
Welcome to spacecmd, a command-line interface to Spacewalk.

Type: 'help' for a list of commands
      'help <cmd>' for command-specific help
      'quit' to quit

Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 166, in <module>
    if not shell.do_login(''):
  File "/usr/lib/python2.7/site-packages/spacecmd/misc.py", line 284, in do_login
    self.api_version = self.client.api.getVersion()
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1233, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1587, in __request
    verbose=self.__verbose
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1273, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1301, in single_request
    self.send_content(h, request_body)
  File "/usr/lib64/python2.7/xmlrpclib.py", line 1448, in send_content
    connection.endheaders(request_body)
  File "/usr/lib64/python2.7/httplib.py", line 1013, in endheaders
    self._send_output(message_body)
  File "/usr/lib64/python2.7/httplib.py", line 864, in _send_output
    self.send(msg)
  File "/usr/lib64/python2.7/httplib.py", line 826, in send
    self.connect()
  File "/usr/lib64/python2.7/httplib.py", line 1227, in connect
    HTTPConnection.connect(self)
  File "/usr/lib64/python2.7/httplib.py", line 807, in connect
    self.timeout, self.source_address)
  File "/usr/lib64/python2.7/socket.py", line 571, in create_connection
    raise err
socket.error: [Errno 111] Connection refused
$
```
... or when the remote server is dropping all SYNs:
```
$ spacecmd -s firewall.in.between.example.com
(...)
  File "/usr/lib64/python2.7/httplib.py", line 807, in connect
    self.timeout, self.source_address)
  File "/usr/lib64/python2.7/socket.py", line 571, in create_connection
    raise err
socket.error: [Errno 110] Connection timed out
$
```
.. or even when user aborts such a connection with SIGINT:
```
$ spacecmd -s firewall.in.between.example.com
Welcome to spacecmd, a command-line interface to Spacewalk.

Type: 'help' for a list of commands
      'help <cmd>' for command-specific help
      'quit' to quit

^C
Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 166, in <module>
    if not shell.do_login(''):
(...)
  File "/usr/lib64/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
KeyboardInterrupt
$
```
This is even worse when abrtd is running, as people may get less-than-useful emails about events like this.

Fix it by catching any exception `self.client.api.getVersion()` might get us, and using `sys.exc_info()[0]` to get its contents (so it still gets displayed with --debug)
