### PR TITLE
Fixes in spacewalk{,-common,-oracle,-postgresql,-base-minimal} package descriptions

### DIFF
--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -12,8 +12,7 @@ BuildArch:      noarch
 
 %description
 Spacewalk is a systems management application that will
-inventory, provision, update and control your Linux and
-Solaris machines.
+inventory, provision, update and control your Linux machines.
 
 %package common
 Summary: Spacewalk Systems Management Application with Oracle database backend
@@ -87,8 +86,7 @@ Requires:       cobbler20
 
 %description common
 Spacewalk is a systems management application that will
-inventory, provision, update and control your Linux and
-Solaris machines.
+inventory, provision, update and control your Linux machines.
 
 %package oracle
 Summary: Spacewalk Systems Management Application with Oracle database backend
@@ -112,8 +110,8 @@ Requires: oracle-instantclient-sqlplus-selinux
 
 %description oracle
 Spacewalk is a systems management application that will
-inventory, provision, update and control your Linux and
-Solaris machines.
+inventory, provision, update and control your Linux machines.
+Version for Oracle database backend.
 
 %package postgresql
 Summary: Spacewalk Systems Management Application with PostgreSQL database backend
@@ -136,8 +134,8 @@ Requires: postgresql >= 8.4
 
 %description postgresql
 Spacewalk is a systems management application that will 
-inventory, provision, update and control your Linux and 
-Solaris machines.
+inventory, provision, update and control your Linux machines.
+Version for PostgreSQL database backend.
 
 %prep
 #nothing to do here

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -69,7 +69,7 @@ Requires: spacewalk-base-minimal-config
 
 %description -n spacewalk-base-minimal
 Independent Perl modules in the RHN:: name-space.
-This are very basic modules need to handle configuration files, database,
+These are very basic modules needed to handle configuration files, database,
 sessions and exceptions.
 
 %package -n spacewalk-base-minimal-config


### PR DESCRIPTION
Removed mentions of Solaris.
Mentioned difference for oracle and postgresql backends.
Fixed typos.