### PR TITLE
  bz#1316708 - added the capability for spacewalk-debug to capture the pg_catalog information from PostgreSQL

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -251,6 +251,11 @@ if [ -d /var/log/spacewalk/schema-upgrade ] ; then
 	cp -pr /var/log/spacewalk/schema-upgrade/* $DIR/schema-upgrade-logs
 fi
 
+if [ -d $PGSQL_ROOT/var/lib/pgsql ] ; then
+    echo "    * copying Postgresql procedures information"
+    echo "select proname, prosrc from pg_catalog.pg_proc;" | /usr/bin/spacewalk-sql --select-mode - &> $DIR/database/pg_catalog.pg_proc.log
+fi
+
 if [ -f /var/log/audit/audit.log ] ; then
 	echo "    * copying audit.log"
 	mkdir -p $DIR/audit-log


### PR DESCRIPTION
Included pg_catalog.pg_proc on the spacewalk-debug logs which is very useful for troubleshooting
