### PR TITLE
fix bz1340031 - yes_no: command not found

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -92,6 +92,17 @@ set_value() {
     eval "$(printf "%q=%q" "$VAR" "$ARG")"
 }
 
+yes_no() {
+    case "$1" in
+        Y|y|Y/n|n/Y|1)
+            echo 1
+            ;;
+        *)
+            echo 0
+            ;;
+    esac
+}
+
 INTERACTIVE=1
 CNAME_INDEX=0
 
@@ -201,17 +212,6 @@ default_or_input() {
         INPUT="$DEFAULT"
     fi
     eval "$(printf "%q=%q" "$VARIABLE" "$INPUT")"
-}
-
-yes_no() {
-    case "$1" in
-        Y|y|Y/n|n/Y|1)
-            echo 1
-            ;;
-        *)
-            echo 0
-            ;;
-    esac
 }
 
 config_error() {


### PR DESCRIPTION
I run installer of proxy and I see error message in output "/usr/sbin/configure-proxy.sh: line 161: yes_no: command not found".