### PR TITLE
osa-dispatcher: Fix dependency issue on spacewalk restart

### DIFF
--- a/client/tools/osad/osa-dispatcher.service
+++ b/client/tools/osad/osa-dispatcher.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=OSA Dispatcher daemon
 After=syslog.target network.target jabberd.service
+After=jabberd-c2s.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
AS reported in
[BZ1336426](https://bugzilla.redhat.com/show_bug.cgi?id=1336426)
`osa-dispatcher` fails to restart correctly due to a dependency issue.
There are to mechanisms to handle this, both involving the systemd unit
for osa-dispatcher.  In the first mechanism one can simply use a systemd
dropin:

```
$ cat /etc/systemd/system/osa-dispatcher.service.d/10-dependency.conf
[Unit]
After=jabberd-c2s.service
```

The other mechanism provided here adds this dependency in the base unit.
