### PR TITLE
Sort proxy clients

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2305,6 +2305,7 @@ SELECT SP.server_id ID, S.name
   FROM rhnServer S, rhnServerPath SP
  WHERE SP.proxy_server_id = :sid
    AND S.id = SP.server_id
+ ORDER BY S.name
   </query>
   <elaborator name="system_overview"/>
   <elaborator name="entitlements"/>

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
@@ -14,7 +14,9 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -38,6 +40,7 @@ import com.redhat.rhn.manager.system.SystemManager;
  * @version $Rev$
  */
 public class ProxyClientsAction extends RhnAction implements Listable<SystemOverview> {
+    private static final String ACCESS_MAP = "accessMap";
 
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
@@ -74,7 +77,21 @@ public class ProxyClientsAction extends RhnAction implements Listable<SystemOver
         Long sid = context.getRequiredParam(RequestContext.SID);
         DataResult<SystemOverview> clients = SystemManager.listClientsThroughProxy(sid);
         clients.elaborate();
+
+        setAccessMap(context, clients);
         return clients;
     }
 
+    private void setAccessMap(RequestContext context, List<SystemOverview> systems) {
+        Map<Long, Boolean> accessMap = new HashMap<Long, Boolean>();
+        User user = context.getCurrentUser();
+
+        for (SystemOverview sys : systems) {
+            if (SystemManager.isAvailableToUser(user, sys.getId())) {
+                accessMap.put(sys.getId(), true);
+            }
+        }
+
+        context.getRequest().setAttribute(ACCESS_MAP, accessMap);
+    }
 }

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/proxyclients.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/proxyclients.jsp
@@ -23,7 +23,16 @@
 
       <rhn:listdisplay>
         <rhn:column header="systemlist.jsp.system">
-          <c:out value="${current.name}" escapeXml="true" />
+          <c:choose>
+            <c:when test = "${not empty requestScope.accessMap[current.id]}">
+              <a href="/rhn/systems/details/Overview.do?sid=${current.id}">
+                <c:out value="${current.name}" escapeXml="true" />
+              </a>
+            </c:when>
+            <c:otherwise>
+              <c:out value="${current.name}" escapeXml="true" />
+            </c:otherwise>
+          </c:choose>
         </rhn:column>
 
         <rhn:column header="systemlist.jsp.entitlement">


### PR DESCRIPTION
## Summary
1. Sort the proxy clients list (by name)
2. Have the client names as links to the corresponding system details pages
### Sort the proxy clients list

The simplest way to do this is in the DB query, since this list has a specific query exclusively used here.
### Client names as links to system details

Since the user may not have access to some of the clients in the list, only the ones which the user has access must be shown as links.
### Example

[ActivatedSystemsAction.java@62-89](https://github.com/SUSE/spacewalk/blob/Manager/java/code/src/com/redhat/rhn/frontend/action/token/ActivatedSystemsAction.java#L62-L89)
[activationkeys/systems/list.jsp@40-49](https://github.com/SUSE/spacewalk/blob/Manager/java/code/webapp/WEB-INF/pages/activationkeys/systems/list.jsp#L40-L49)
