### PR TITLE
fix TypeError: descriptor 'with_traceback'

### DIFF
--- a/client/tools/osad/src/jabber_lib.py
+++ b/client/tools/osad/src/jabber_lib.py
@@ -665,7 +665,7 @@ class JabberClient(jabber.Client, object):
             # Error in the SSL handshake - most likely mismatching CA cert
             log_error("Traceback caught:")
             log_error(extract_traceback())
-            raise_with_tb(SSLHandshakeError, sys.exc_info()[2])
+            raise_with_tb(SSLHandshakeError(), sys.exc_info()[2])
 
         # Re-init the parsers
         jabber.xmlstream.Stream.connect(self)


### PR DESCRIPTION
Traceback when certification is not valid for the spacewalk

```
>> /usr/sbin/osad --pid-file /var/run/osad.pid -N -v

Traceback (most recent call last):
  File "/usr/share/rhn/osad/jabber_lib.py", line 664, in connect
    ssl.do_handshake()
  File "/usr/lib/python3.5/site-packages/OpenSSL/SSL.py", line 1443, in do_handshake
    self._raise_ssl_error(self._ssl, result)
  File "/usr/lib/python3.5/site-packages/OpenSSL/SSL.py", line 1191, in _raise_ssl_error
    _raise_current_error()
  File "/usr/lib/python3.5/site-packages/OpenSSL/_util.py", line 48, in exception_from_error_queue
    raise exception_type(errors)
OpenSSL.SSL.Error: [('SSL routines', 'ssl3_get_server_certificate', 'certificate verify failed')]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/rhn/osad/jabber_lib.py", line 126, in main
    c = self.setup_connection(no_fork=no_fork)
  File "/usr/share/rhn/osad/jabber_lib.py", line 266, in setup_connection
    c = self._get_jabber_client(js)
  File "/usr/share/rhn/osad/jabber_lib.py", line 338, in _get_jabber_client
    c.connect()
  File "/usr/share/rhn/osad/jabber_lib.py", line 670, in connect
    raise_with_tb(SSLHandshakeError, sys.exc_info()[2])
  File "/usr/lib/python3.5/site-packages/spacewalk/common/usix.py", line 68, in raise_with_tb
    raise value.with_traceback(tb)
TypeError: descriptor 'with_traceback' requires a 'BaseException' object but received a 'traceback'
```