### PR TITLE
Allow sorting on advisory name in errata lists

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -23,7 +23,7 @@ ORDER BY E.advisory_name
 
 <mode name="relevant_errata" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="user_id">
-SELECT E.id, E.update_date, E.synopsis AS ADVISORY_SYNOPSIS
+SELECT E.id, E.update_date, E.advisory_name, E.synopsis AS ADVISORY_SYNOPSIS
   FROM rhnErrata E,
        (SELECT SNEC.errata_id
           FROM rhnServerNeededCache SNEC
@@ -38,7 +38,7 @@ ORDER BY  E.update_date DESC, E.id
 
 <mode name="relevant_errata_by_type" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="user_id, type">
-SELECT E.id, E.update_date, E.synopsis as advisory_synopsis
+SELECT E.id, E.update_date, E.advisory_name, E.synopsis as advisory_synopsis
   FROM rhnErrata E,
        (SELECT SNEC.errata_id, COUNT(SNEC.server_id) C
           FROM rhnServerNeededErrataCache SNEC
@@ -54,7 +54,7 @@ ORDER BY  E.update_date DESC, E.id
 
 <mode name="relevant_errata_by_type_with_cves" class="com.redhat.rhn.frontend.dto.SecurityErrataOverview">
   <query params="user_id, type">
-SELECT E.id, E.update_date, E.synopsis as advisory_synopsis
+SELECT E.id, E.update_date, E.advisory_name, E.synopsis as advisory_synopsis
   FROM rhnErrata E,
        (SELECT SNEC.errata_id, COUNT(SNEC.server_id) C
           FROM rhnServerNeededErrataCache SNEC
@@ -71,7 +71,7 @@ ORDER BY  E.update_date DESC, E.id
 
 <mode name="all_errata" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="org_id">
-SELECT DISTINCT E.id, E.update_date, E.synopsis AS ADVISORY_SYNOPSIS
+SELECT DISTINCT E.id, E.update_date, E.advisory_name, E.synopsis AS ADVISORY_SYNOPSIS
   FROM  rhnErrata E, rhnChannelErrata CE, rhnChannel C,
         rhnChannelFamilyMembers CFM,
         rhnOrgChannelFamilyPermissions OCF
@@ -87,7 +87,7 @@ SELECT DISTINCT E.id, E.update_date, E.synopsis AS ADVISORY_SYNOPSIS
 
 <mode name="all_errata_by_type" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="org_id, type">
-SELECT DISTINCT E.id, E.update_date, E.synopsis AS ADVISORY_SYNOPSIS
+SELECT DISTINCT E.id, E.update_date, E.advisory_name, E.synopsis AS ADVISORY_SYNOPSIS
   FROM  rhnErrata E, rhnChannelErrata CE, rhnChannel C,
         rhnChannelFamilyMembers CFM,
         rhnOrgChannelFamilyPermissions OCF
@@ -104,7 +104,7 @@ SELECT DISTINCT E.id, E.update_date, E.synopsis AS ADVISORY_SYNOPSIS
 
 <mode name="all_errata_by_type_with_cves" class="com.redhat.rhn.frontend.dto.SecurityErrataOverview">
   <query params="org_id, type">
-SELECT DISTINCT E.id, E.update_date, E.synopsis as advisory_synopsis
+SELECT DISTINCT E.id, E.update_date, E.advisory_name, E.synopsis as advisory_synopsis
   FROM  rhnErrata E, rhnChannelErrata CE, rhnChannel C,
         rhnChannelFamilyMembers CFM,
         rhnOrgChannelFamilyPermissions OCF

--- a/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -17,7 +17,10 @@
                 <rhn:icon type="errata-enhance" title="erratalist.jsp.productenhancementadvisory" />
             </c:if>
         </rl:column>
-        <rl:column headerkey="erratalist.jsp.advisory">
+        <rl:column headerkey="erratalist.jsp.advisory"
+                   sortable="true"
+                   sortattr="advisoryName"
+                   defaultsort="asc">
             <a href="/rhn/errata/details/Details.do?eid=${current.id}">${current.advisoryName}</a>
         </rl:column>
         <rl:column headerkey="erratalist.jsp.synopsis"

--- a/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -30,26 +30,12 @@
                    styleclass="text-align: center;">
             <a href="/rhn/errata/details/SystemsAffected.do?eid=${current.id}">${current.affectedSystemCount}</a>
         </rl:column>
-
-                <c:if test="${displayCves}">
-                         <rl:column headerkey="erratalist.jsp.updated"
-                                sortable="true"
-                                sortattr="updateDateObj"
-                                styleclass="text-align: center;">
-                                    ${current.updateDate}
-                                </rl:column>
-                </c:if>
-                <c:if test="${not displayCves}">
-                          <rl:column headerkey="erratalist.jsp.updated"
-                                sortable="true"
-                                sortattr="updateDateObj"
-                                styleclass="text-align: center;">
-                                    ${current.updateDate}
-                                </rl:column>
-                </c:if>
-
-
-
+        <rl:column headerkey="erratalist.jsp.updated"
+                   sortable="true"
+                   sortattr="updateDateObj"
+                   styleclass="text-align: center;">
+            ${current.updateDate}
+        </rl:column>
 
         <c:if test="${displayCves}">
 


### PR DESCRIPTION
This PR basically changes three things:

1. Tiny refactoring on relevant-errata-list.jspf
2. Allows sorting on advisory names
3. Refactors ColumnTag code sort direction part, and fixes it so whenever a different column is clicked for sorting, it'll be sorted in ascending order first (previously it was just the opposite of the last sorting direction even though the clicked column is different from the last sorted one - basically switching the sort direction regardless of the change in the sorted column).