### PR TITLE
Use different symbols for collapsible sidebar items

### DIFF
--- a/branding/css/spacewalk-theme.less
+++ b/branding/css/spacewalk-theme.less
@@ -267,8 +267,18 @@ aside .nav > li > a {
                 color: @spacewalk-aside-second-submenu-hyperlink-hover;
                 .glow-text;
         }
-	a:before {
+	li a:before {
+		content: "◦";
+		font-family: 'FontAwesome';
+		margin-right: .5em
+	}
+	li.parent a:before {
 		content: "\f105 ";
+		font-family: 'FontAwesome';
+		margin-right: .5em
+	}
+	li.parent.active a:before {
+		content: "\f107 ";
 		font-family: 'FontAwesome';
 		margin-right: .5em
 	}
@@ -847,4 +857,3 @@ code {
   color: #cfcfcf;
   clear: both;
 }
-

--- a/java/code/src/com/redhat/rhn/frontend/nav/SidenavRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/SidenavRenderer.java
@@ -18,6 +18,13 @@ package com.redhat.rhn.frontend.nav;
 import com.redhat.rhn.frontend.html.HtmlTag;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Stream.concat;
+import static java.util.stream.Stream.empty;
+import static java.util.stream.Stream.of;
 
 /**
  * SidenavRenderer renders an unordered list which is decorated
@@ -69,7 +76,7 @@ public class SidenavRenderer extends Renderable {
             return;
         }
 
-        renderNode(sb, node, "active");
+        renderNode(sb, node, Stream.of("active"));
     }
 
     /** {@inheritDoc} */
@@ -82,14 +89,16 @@ public class SidenavRenderer extends Renderable {
             return;
         }
 
-        this.renderNode(sb, node, null);
+        this.renderNode(sb, node, Stream.empty());
     }
 
-    private void renderNode(StringBuffer sb, NavNode node, String cssClass) {
+    private void renderNode(StringBuffer sb, NavNode node, Stream<String> baseClasses) {
         HtmlTag li = new HtmlTag("li");
-        if (cssClass != null) {
-            li.setAttribute("class", cssClass);
-        }
+
+        Stream<String> additionalClasses =
+                node.getNodes().isEmpty() ? empty() : of("parent");
+        String classString = concat(baseClasses, additionalClasses).collect(joining(" "));
+        li.setAttribute("class", classString);
 
         li.addBody(aHref(node.getPrimaryURL(), node.getName(), node.getTarget()));
         sb.append(li.render());

--- a/java/code/src/com/redhat/rhn/frontend/nav/SidenavRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/SidenavRenderer.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
  * SidenavRenderer renders an unordered list which is decorated
@@ -98,7 +99,10 @@ public class SidenavRenderer extends Renderable {
         Stream<String> additionalClasses =
                 node.getNodes().isEmpty() ? empty() : of("parent");
         String classString = concat(baseClasses, additionalClasses).collect(joining(" "));
-        li.setAttribute("class", classString);
+
+        if (isNotEmpty(classString)) {
+            li.setAttribute("class", classString);
+        }
 
         li.addBody(aHref(node.getPrimaryURL(), node.getName(), node.getTarget()));
         sb.append(li.render());


### PR DESCRIPTION
This makes it easier to distinguish menu items visually:
 - use a small circle for items that have no child items
 - use a rightward pointing arrow for items that are collapsed
 - use a downward pointing arrow for items that are uncollapsed

Before:
![before](https://cloud.githubusercontent.com/assets/250541/20525749/2a7c7bba-b0c1-11e6-8ca1-97a65bb4111b.png)

After:
![after](https://cloud.githubusercontent.com/assets/250541/20525748/2a7a8058-b0c1-11e6-968b-8a6967c30a49.png)

