### PR TITLE
Remove useless self-link on login page

### DIFF
--- a/java/code/webapp/WEB-INF/nav/sitenav.xml
+++ b/java/code/webapp/WEB-INF/nav/sitenav.xml
@@ -2,11 +2,10 @@
 <rhn-navi-tree xmlns:xi="http://www.w3.org/2001/XInclude" label="sitenav_unauth" title-depth="0">
   <rhn-tab name="Create First User" url="/rhn/newlogin/CreateFirstUser.do" acl="need_first_user()">
   </rhn-tab>
-  <rhn-tab name="Sign In" url="/rhn/Login.do" active-image="tab-sign_in-selected.gif" inactive-image="tab-sign_in.gif">
-  </rhn-tab>
 
   <rhn-tab name="About Spacewalk" url="/rhn/help/about.do" active-image="tab-about_rhn-selected.gif" inactive-image="tab-about_rhn.gif" >
     <rhn-tab name="About Spacewalk" url="/rhn/help/about.do" />
+    <rhn-tab name="Sign In" url="/rhn/Login.do" acl="not user_authenticated()" />
     <rhn-tab name="Help Desk" url="/rhn/help/index.do" />
     <rhn-tab name="Lookup Login/Password" url="/rhn/help/ForgotCredentials.do" />
     <rhn-tab name="Release Notes" url="/rhn/help/dispatcher/release_notes">
@@ -40,6 +39,5 @@
     <rhn-tab name="Search" url="/rhn/help/Search.do" />
     <rhn-tab name="Chat" url="/rhn/help/Chat.do" />
 </rhn-tab>
-
 
 </rhn-navi-tree>


### PR DESCRIPTION
The login page has a Sign In link that points to itself, this patch removes it.

![login](https://cloud.githubusercontent.com/assets/250541/20527871/491b0f06-b0ca-11e6-9102-c206b474255d.png)
