### PR TITLE
Fix notification order

### DIFF
--- a/java/code/src/com/redhat/rhn/common/validator/SchemaParser.java
+++ b/java/code/src/com/redhat/rhn/common/validator/SchemaParser.java
@@ -23,8 +23,8 @@ import org.jdom.input.SAXBuilder;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ public class SchemaParser {
     private URL schemaURL;
 
     /** The constraints from the schema */
-    private Map constraints;
+    private Map<String, Constraint> constraints;
 
     /** XML Schema Namespace */
     private Namespace schemaNamespace;
@@ -63,7 +63,7 @@ public class SchemaParser {
      */
     public SchemaParser(URL schemaURLIn) throws IOException {
         this.schemaURL = schemaURLIn;
-        constraints = new HashMap();
+        constraints = new LinkedHashMap<String, Constraint>();
         schemaNamespace =
             Namespace.getNamespace(SCHEMA_NAMESPACE_URI);
 
@@ -78,7 +78,7 @@ public class SchemaParser {
      *
      * @return <code>Map</code> - the schema-defined constraints.
      */
-    public Map getConstraints() {
+    public Map<String, Constraint> getConstraints() {
         return constraints;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/validation/orgCreateForm.xsd
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/validation/orgCreateForm.xsd
@@ -2,13 +2,6 @@
 
 <schema targetNamespace="http://rhn.redhat.com"
 	xmlns="http://www.w3.org/1999/XMLSchema" xmlns:rhn="http://rhn.redhat.com">
-	<attribute name="email">
-		<simpleType baseType="string">
-		<matchesExpression value="(.+)@(.+)(\..+)*" />
-		<minLength value="1" />
-		<maxLength value="128" />
-		</simpleType>
-	</attribute>
 	<attribute name="orgName">
 		<simpleType baseType="string">
 		<minLength value="3" />
@@ -27,6 +20,13 @@
             <maxLength value="48" />
         </simpleType>
     </attribute>
+  <attribute name="email">
+    <simpleType baseType="string">
+    <matchesExpression value="(.+)@(.+)(\..+)*" />
+    <minLength value="1" />
+    <maxLength value="128" />
+    </simpleType>
+  </attribute>
        <attribute name="firstNames">
                 <simpleType baseType="string">
                         <minLength value="1" />

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/validation/orgCreateForm.xsd
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/validation/orgCreateForm.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 
-<schema targetNamespace="http://rhn.redhat.com"
-	xmlns="http://www.w3.org/1999/XMLSchema" xmlns:rhn="http://rhn.redhat.com">
-	<attribute name="orgName">
-		<simpleType baseType="string">
-		<minLength value="3" />
-		<maxLength value="128" />
-		</simpleType>
-	</attribute>
+<schema targetNamespace="http://rhn.redhat.com" xmlns="http://www.w3.org/1999/XMLSchema"
+    xmlns:rhn="http://rhn.redhat.com">
+    <attribute name="orgName">
+        <simpleType baseType="string">
+            <minLength value="3" />
+            <maxLength value="128" />
+        </simpleType>
+    </attribute>
     <attribute name="desiredpassword">
         <simpleType baseType="string">
             <minLength value="1" />
@@ -20,24 +20,23 @@
             <maxLength value="48" />
         </simpleType>
     </attribute>
-  <attribute name="email">
-    <simpleType baseType="string">
-    <matchesExpression value="(.+)@(.+)(\..+)*" />
-    <minLength value="1" />
-    <maxLength value="128" />
-    </simpleType>
-  </attribute>
-       <attribute name="firstNames">
-                <simpleType baseType="string">
-                        <minLength value="1" />
-                        <maxLength value="128" />
-                </simpleType>
-        </attribute>
-    <attribute name="lastName">
+    <attribute name="email">
         <simpleType baseType="string">
-            <minLength value="1"/>
-            <maxLength value="128"/>
+            <matchesExpression value="(.+)@(.+)(\..+)*" />
+            <minLength value="1" />
+            <maxLength value="128" />
         </simpleType>
     </attribute>
-
+    <attribute name="firstNames">
+        <simpleType baseType="string">
+            <minLength value="1" />
+            <maxLength value="128" />
+        </simpleType>
+    </attribute>
+    <attribute name="lastName">
+        <simpleType baseType="string">
+            <minLength value="1" />
+            <maxLength value="128" />
+        </simpleType>
+    </attribute>
 </schema>


### PR DESCRIPTION
Order of notifications in case of errors did not reflect the form field ordering.

After this patch is applied order is respected:
![after](https://cloud.githubusercontent.com/assets/250541/20528510/ca5bdc7e-b0cc-11e6-947b-98be108b82fc.png)