### PR TITLE
1260527 - fix Python 2.4 syntax (RHEL5)

### DIFF
--- a/client/tools/rhncfg/actions/script.py
+++ b/client/tools/rhncfg/actions/script.py
@@ -49,7 +49,7 @@ ACTION_VERSION = 2
 # SystemExit exception error code
 SYSEXIT_CODE = 3
 
-class SignalHandler():
+class SignalHandler:
     def __init__(self):
         self.gotSigterm = False
     # Handle SIGTERM so that we can return status to Satellite


### PR DESCRIPTION
fixes
Traceback (most recent call last):
  File "/usr/sbin/rhn_check", line 381, in __run_action
    (status, message, data) = CheckCli.__do_call(method, params, kwargs)
  File "/usr/sbin/rhn_check", line 373, in __do_call
    method = getMethod.getMethod(method, "/usr/share/rhn/", "actions")
  File "/usr/share/rhn/up2date_client/getMethod.py", line 83, in getMethod
    actions = __import__(modulename)
exceptions.SyntaxError: invalid syntax (script.py, line 52)
        log.log_debug("do_call ", method, params, kwargs)

