### PR TITLE
Allow passing multiple GPG keys to rhn-bootstrap

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -173,11 +173,9 @@ def getHeader(productName, activation_keys, org_gpg_key,
               overrides, hostname, orgCACert, isRpmYN,
               using_ssl, using_gpg,
               allow_config_actions, allow_remote_commands, up2dateYN, pubname):
-    #2/14/06 wregglej 181407 If the org_gpg_key option has the path to the file
-    #in it, remove it. It will cause the $FETCH to fail.
-    path_list = os.path.split(org_gpg_key)
-    if path_list[0] and path_list[0] != '':
-        org_gpg_key = path_list[1]
+    # 11/22/16 options.gpg_key is now a comma-separated list of path.
+    # Removing paths from options.gpg_key
+    org_gpg_key = ",".join([os.path.basename(gpg_key) for gpg_key in options.gpg_key.split(",")])
 
     if not activation_keys:
         exit_call = "exit 1"


### PR DESCRIPTION
This PR modifies `rhn-bootstrap` to receive multiple GPG keys using the `--gpg-key` option.

Before this PR, the generated `bootstrap.sh` handles multiple comma-separated GPG keys defined as `ORG_GPG_KEY`, but the user is not able to set multiple GPG keys when calling `rhn-bootstrap` to create the script.

After this PR, the user is able to set multiple GPG keys when calling `rhn-bootstrap`:
```
# rhn-bootstrap --gpg-key=/path1/my-key1.key,/path2/my-key2.key
```