### PR TITLE
abrt python2/3 fix

### DIFF
--- a/client/tools/spacewalk-abrt/src/spacewalk_abrt/abrt.py
+++ b/client/tools/spacewalk-abrt/src/spacewalk_abrt/abrt.py
@@ -123,7 +123,7 @@ def report(problem_dir):
         if server.abrt.is_crashfile_upload_enabled(systemid) and filesize <= server.abrt.get_crashfile_uploadlimit(systemid):
             f = open(path, 'r')
             try:
-                crash_file_data['filecontent'] = base64.encodestring(f.read())
+                crash_file_data['filecontent'] = base64.encodestring(bstr(f.read()))
             finally:
                 f.close()
 


### PR DESCRIPTION
fixing spacewalk-abrt --sync on Fedora 24:
  File "/usr/share/rhn/spacewalk_abrt/abrt.py", line 126, in report
    crash_file_data['filecontent'] = base64.encodestring(f.read())
  File "/usr/lib64/python3.5/base64.py", line 547, in encodestring
    return encodebytes(s)
  File "/usr/lib64/python3.5/base64.py", line 535, in encodebytes
    _input_type_check(s)
  File "/usr/lib64/python3.5/base64.py", line 521, in _input_type_check
    raise TypeError(msg) from err
<class 'TypeError'>: expected bytes-like object, not str