### PR TITLE
Use consistent naming for SSM pages

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -14727,7 +14727,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <context context-type="sourcefile">/rhn/ssm/ViewLogDetails.do</context>
         </context-group>
         <trans-unit id="ssm.operations.viewlog.header">
-          <source>Tasks Log</source>
+          <source>Task Log</source>
         </trans-unit>
         <trans-unit id="ssm.operations.viewlog.description">
           <source>Description</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -16505,7 +16505,13 @@ The Tree Path, Kickstart RPM, Base Channel, and Installer Generation should alwa
         </context-group>
       </trans-unit>
       <trans-unit id="ssm.jsp.header">
-        <source>System Set Manager</source>
+        <source>System Set Manager Overview</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">System Set Manager header</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="view-log.jsp.header">
+        <source>System Set Manager Task Log</source>
         <context-group name="ctx">
           <context context-type="sourcefile">System Set Manager header</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml
@@ -201,7 +201,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="ssm.nav.status">
-        <source>Status</source>
+        <source>Task Log</source>
         <context-group name="ctx">
           <context context-type="sourcefile">System Set Manager Navigation Menu</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/nav/ssm_status.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm_status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <rhn-navi-tree label="ssm-status" invisible="1" title-depth="1">
-   <rhn-tab name="ssm.nav.status.all" url="/rhn/ssm/ViewAllLog.do"/>
-   <rhn-tab name="ssm.nav.status.inprogress" url="/rhn/ssm/ViewLog.do"/>
-   <rhn-tab name="ssm.nav.status.completed" url="/rhn/ssm/ViewCompletedLog.do"/>
+    <rhn-tab name="ssm.nav.status.all" url="/rhn/ssm/ViewAllLog.do" />
+    <rhn-tab name="ssm.nav.status.inprogress" url="/rhn/ssm/ViewLog.do" />
+    <rhn-tab name="ssm.nav.status.completed" url="/rhn/ssm/ViewCompletedLog.do" />
 </rhn-navi-tree>

--- a/java/code/webapp/WEB-INF/nav/ssm_status.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm_status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <rhn-navi-tree label="ssm-status" invisible="1" title-depth="1">
+   <rhn-tab name="ssm.nav.status.all" url="/rhn/ssm/ViewAllLog.do"/>
    <rhn-tab name="ssm.nav.status.inprogress" url="/rhn/ssm/ViewLog.do"/>
    <rhn-tab name="ssm.nav.status.completed" url="/rhn/ssm/ViewCompletedLog.do"/>
-   <rhn-tab name="ssm.nav.status.all" url="/rhn/ssm/ViewAllLog.do"/>
 </rhn-navi-tree>

--- a/java/code/webapp/WEB-INF/pages/ssm/view-log.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/view-log.jsp
@@ -11,7 +11,7 @@
     icon="header-system-groups"
         imgAlt="ssm.jsp.imgAlt"
         helpUrl="">
-        <bean:message key="ssm.jsp.header" />
+        <bean:message key="view-log.jsp.header" />
 </rhn:toolbar>
 
 <rhn:dialogmenu mindepth="0" maxdepth="1" definition="/WEB-INF/nav/ssm_status.xml" renderer="com.redhat.rhn.frontend.nav.DialognavRenderer" />


### PR DESCRIPTION
This does the following:
 - change the SSM "main" pages title into "System Set Manager Overview". This is consistent with main pages of other features, eg. "Autoinstallation" -> "Autoinstallation Overview"
 - renames, both in the navigation menu and in the title, the "Status" page to "System Set Manager Task Log". This better reflects the content and is consistent with detail pages of other features, eg "Autoinstallation > Profiles" -> "Autoinstallation Profiles"
 - changes the ordering of tabs in the Task Log page, so that the tab opened by default ("All") is the first. This is also consistent with many other tabbed pages in the Web UI

Overview page example:
![overview](https://cloud.githubusercontent.com/assets/250541/20530410/8c20f668-b0d3-11e6-969c-b66e9d87871c.png)

Task Log page example:
![tasklog](https://cloud.githubusercontent.com/assets/250541/20530411/8d895c70-b0d3-11e6-89be-6543c65b671d.png)
