### PR TITLE
Differentiate writable/non-writable fields

### DIFF
--- a/branding/css/spacewalk-fixes.less
+++ b/branding/css/spacewalk-fixes.less
@@ -16,3 +16,7 @@
 input[type="file"].form-control {
     height: 100%;
 }
+
+div.form-control {
+    &:extend(.form-control[readonly]);
+}


### PR DESCRIPTION
Give to `<div>` tag for non-writable fields the same aspect as `<input>` tag for `readonly` fields.

Before:
![before-readonly](https://cloud.githubusercontent.com/assets/7080830/20703305/89571cda-b61b-11e6-8c70-21d7ec0698ce.png)

After:
![after-readonly](https://cloud.githubusercontent.com/assets/7080830/20703308/8d6c2248-b61b-11e6-9c1b-aca2acd4b657.png)
