### PR TITLE
urlsplit back compatibility with python 2.4

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/rpcServer.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/rpcServer.py
@@ -72,9 +72,9 @@ class RetryServer(rpclib.Server):
 
                 # use the next serverURL
                 parse_res = urlparse.urlsplit(self.serverList.server())
-                typ = parse_res.scheme
-                self._host = parse_res.netloc
-                self._handler = parse_res.path
+                typ = parse_res[0] # scheme
+                self._host = parse_res[1] # netloc
+                self._handler = parse_res[2] # path
                 typ = typ.lower()
                 if typ not in ("http", "https"):
                     raise_with_tb(rpclib.InvalidRedirectionError(


### PR DESCRIPTION
fixing bug introduced in dc7ee6d

      File "/usr/share/rhn/up2date_client/rpcServer.py", line 75, in _request1
        typ = parse_res.scheme
    exceptions.AttributeError: 'tuple' object has no attribute 'scheme'