### PR TITLE
python 3 requires print with parentheses

### DIFF
--- a/client/tools/spacewalk-remote-utils/spacewalk-create-channel/spacewalk-create-channel
+++ b/client/tools/spacewalk-remote-utils/spacewalk-create-channel/spacewalk-create-channel
@@ -440,7 +440,7 @@ def gather(clear):
                         #do supplementary
                         suppl = extras[1]
                         fullDir = GATHER_DIR + "Supp-RHEL-%s/%s.%s/%s/%s/os/Packages/" % (version, version, update_num, release, arch)
-                        print fullDir
+                        print(fullDir)
                         saveRpmList(fullDir + "/", DATA_DIR + getFileName(version, update,release, arch, suppl))
 
                         #do optional


### PR DESCRIPTION
fixing sytax error introduced in 8af97691a1

    File /usr/bin/spacewalk-create-channel, line 443
       print fullDir
                   ^
     SyntaxError: Missing parentheses in call to 'print'