### PR TITLE
dnf-plugin-spacewalk updated to dnf 2.0

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk-revert-to-1.0.patch
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk-revert-to-1.0.patch
@@ -1,0 +1,39 @@
+diff --git a/client/rhel/dnf-plugin-spacewalk/spacewalk.py b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+index ee8e08e..269f94f 100644
+--- a/client/rhel/dnf-plugin-spacewalk/spacewalk.py
++++ b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+@@ -39,6 +39,7 @@ from rhn.i18n import ustr
+ from up2date_client import up2dateErrors
+ 
+ STORED_CHANNELS_NAME = '_spacewalk.json'
++PLUGIN_CONF = 'spacewalk'
+ 
+ RHN_DISABLED    = _("Spacewalk based repositories will be disabled.")
+ CHANNELS_DISABLED = _("Spacewalk channel support will be disabled.")
+@@ -65,7 +66,7 @@ class Spacewalk(dnf.Plugin):
+         self.connected_to_spacewalk = False
+         self.up2date_cfg = {}
+         self.conf = copy(self.base.conf)
+-        self.parser = self.read_config(self.conf)
++        self.parser = self.read_config(self.conf, PLUGIN_CONF)
+         if "main" in self.parser.sections():
+             options = self.parser.items("main")
+             for (key, value) in options:
+@@ -143,7 +144,7 @@ class Spacewalk(dnf.Plugin):
+                 for (key, value) in options:
+                     setattr(conf, key, value)
+             repo = SpacewalkRepo(channel_dict, {
+-                                    'conf'      : self.base.conf,
++                                    'cachedir'  : self.base.conf.cachedir,
+                                     'proxy'     : proxy_url,
+                                     'timeout'   : conf.timeout,
+                                     'sslcacert' : sslcacert,
+@@ -211,7 +212,7 @@ class  SpacewalkRepo(dnf.repo.Repo):
+ 
+     def __init__(self, channel, opts):
+         super(SpacewalkRepo, self).__init__(ustr(channel['label']),
+-                                            opts.get('conf'))
++                                            opts.get('cachedir'))
+         # dnf stuff
+         self.name = ustr(channel['name'])
+         self.baseurl = [ url + '/GET-REQ/' + self.id for url in channel['url']]

--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
@@ -13,7 +13,7 @@ BuildRequires: python3-devel
 %else
 BuildRequires: python-devel
 %endif
-Requires: dnf >= 0.5.3
+Requires: dnf >= 2.0.0
 Requires: dnf-plugins-core
 Requires: librepo >= 1.7.15
 Requires: rhn-client-tools >= 2.5.5

--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
@@ -13,7 +13,11 @@ BuildRequires: python3-devel
 %else
 BuildRequires: python-devel
 %endif
+%if 0%{?fedora} <= 25
+Requires: dnf >= 0.5.3
+%else
 Requires: dnf >= 2.0.0
+%endif
 Requires: dnf-plugins-core
 Requires: librepo >= 1.7.15
 Requires: rhn-client-tools >= 2.5.5
@@ -28,7 +32,9 @@ This DNF plugin provides access to a Spacewalk server for software updates.
 %setup -q
 
 %build
-
+%if 0%{?fedora} <= 25
+patch -p4 < dnf-plugin-spacewalk-revert-to-1.0.patch
+%endif
 
 %install
 install -d %{buildroot}%{_sysconfdir}/dnf/plugins/

--- a/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+++ b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
@@ -39,7 +39,6 @@ from rhn.i18n import ustr
 from up2date_client import up2dateErrors
 
 STORED_CHANNELS_NAME = '_spacewalk.json'
-PLUGIN_CONF = 'spacewalk'
 
 RHN_DISABLED    = _("Spacewalk based repositories will be disabled.")
 CHANNELS_DISABLED = _("Spacewalk channel support will be disabled.")
@@ -66,7 +65,7 @@ class Spacewalk(dnf.Plugin):
         self.connected_to_spacewalk = False
         self.up2date_cfg = {}
         self.conf = copy(self.base.conf)
-        self.parser = self.read_config(self.conf, PLUGIN_CONF)
+        self.parser = self.read_config(self.conf)
         if "main" in self.parser.sections():
             options = self.parser.items("main")
             for (key, value) in options:
@@ -80,7 +79,7 @@ class Spacewalk(dnf.Plugin):
             return
         self.cli.demands.root_user = True
 
-        self.activate_channels(self.cli.demands.sack_activation)
+        self.activate_channels()
 
     def activate_channels(self, networking=True):
         enabled_channels = {}
@@ -144,7 +143,7 @@ class Spacewalk(dnf.Plugin):
                 for (key, value) in options:
                     setattr(conf, key, value)
             repo = SpacewalkRepo(channel_dict, {
-                                    'cachedir'  : self.base.conf.cachedir,
+                                    'conf'      : self.base.conf,
                                     'proxy'     : proxy_url,
                                     'timeout'   : conf.timeout,
                                     'sslcacert' : sslcacert,
@@ -212,7 +211,7 @@ class  SpacewalkRepo(dnf.repo.Repo):
 
     def __init__(self, channel, opts):
         super(SpacewalkRepo, self).__init__(ustr(channel['label']),
-                                            opts.get('cachedir'))
+                                            opts.get('conf'))
         # dnf stuff
         self.name = ustr(channel['name'])
         self.baseurl = [ url + '/GET-REQ/' + self.id for url in channel['url']]

--- a/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+++ b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
@@ -74,12 +74,12 @@ class Spacewalk(dnf.Plugin):
             return
         logger.debug('initialized Spacewalk plugin')
 
+        self.activate_channels()
+
     def config(self):
         if not self.conf.enabled:
             return
         self.cli.demands.root_user = True
-
-        self.activate_channels()
 
     def activate_channels(self, networking=True):
         enabled_channels = {}


### PR DESCRIPTION
this is an update for dnf-plugin-spacewalk to work with dnf-2.0
dnf-2.0 is currently only in rawhide (will be Fedora 26) and the current Fedoras (24 and 25) still use dnf-1.0