### PR TITLE
1404841 - spacewalk-remove-channel accepts removing channels by pattern matching

### DIFF
--- a/backend/satellite_tools/spacewalk-remove-channel
+++ b/backend/satellite_tools/spacewalk-remove-channel
@@ -19,6 +19,7 @@
 
 import sys
 import os
+import fnmatch
 from optparse import Option, OptionParser
 
 # quick check to see if you are a super-user.
@@ -117,11 +118,13 @@ def main():
         channels[channel] = None
 
     for parent in options.channel_with_children:
-        if parent in dict_parents:
-            channels[parent] = None
-            for ch in dict_parents[parent]:
-                channels[ch] = None
-        else:
+        matchs = fnmatch.filter(dict_parents, parent)
+        for parent in matchs:
+            if parent in dict_parents:
+                channels[parent] = None
+                for ch in dict_parents[parent]:
+                    channels[ch] = None
+        if not matchs:
             print "Unknown parent channel %s" % parent
             sys.exit(-1)
 


### PR DESCRIPTION
Accept this commands to removing channel:
```
spacewalk-remove-channel -a fedora1*
spacewalk-remove-channel -a fedora1?
```
https://docs.python.org/2/library/fnmatch.html