### PR TITLE
Added password option for .rhncfgrc

### DIFF
--- a/client/tools/rhncfg/config_common/handler_base.py
+++ b/client/tools/rhncfg/config_common/handler_base.py
@@ -62,13 +62,19 @@ class HandlerBase:
             if not username :
                 username=local_config.get('username')
             if not password :
-               (username, password) = self.get_auth_info(username)
+                password=local_config.get('password')
 
             try:
                 self.repository.login(username=username, password=password)
             except cfg_exceptions.InvalidSession:
-                e = sys.exc_info()[1]
-                rhn_log.die(1, "Session error: %s\n" % e)
+                if not password :
+                    (username, password) = self.get_auth_info(username)
+
+                try:
+                     self.repository.login(username=username, password=password)
+                except cfg_exceptions.InvalidSession:
+                     e = sys.exc_info()[1]
+                     rhn_log.die(1, "Session error: %s\n" % e)
 
     def get_auth_info(self, username=None):
         if username is None:


### PR DESCRIPTION
According to https://access.redhat.com/solutions/489553 this feature was being tracked by an internal RFE for Satellite 5.6 back to 2013, but has never seemed to hit the codebase.

This change allows users to add a `password` option to either `/etc/sysconfig/rhn/rhncfg-manager.conf` or `~/.rhncfgrc` under the `[rhncfg-manager]` section, as requested.

Signed-off-by: Avi Miller <avi.miller@oracle.com>