### PR TITLE
bz1412600 - error during syncing duplicated channel's labels

### DIFF
--- a/backend/cdn_tools/cdn-sync
+++ b/backend/cdn_tools/cdn-sync
@@ -74,6 +74,9 @@ def process_commandline():
         if not os.path.isdir(cmd_args.mount_point):
             system_exit(1, "Invalid mount point: %s" % cmd_args.mount_point)
 
+    if cmd_args.channel:
+        cmd_args.channel = set(cmd_args.channel)
+
     return cmd_args
 
 


### PR DESCRIPTION
```
>> cdn-sync -c  ...
Exception: SYNC ERROR: attempting to display as much information as possible
 (54, 'ORA-00001: unique constraint (RHNSAT.RHN_CHANNEL_LABEL_UQ) violated\n', 
'\n     Package Upload Failed due to uniqueness constraint violation.\n 
    Make sure the package does not have any duplicate dependencies or\n     
does not already exists on the server\n     ')
```