### PR TITLE
Add proper debian version handling to spacewalk

### DIFF
--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -179,7 +179,7 @@ def parseRPMName(pkgName):
     return str(n), e, str(v), str(r)
 
 def parseDEBName(pkgName):
-    """ IN:  Package string in, n-n-n-v.v.v-r.r_r, format.
+    """ IN:  Package string in, n-n-n_v.v.v-v.v-r.r.r, format.
         OUT: Four strings (in a tuple): name, epoch, version, release.
     """
     if pkgName.find('_') == -1:

--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -178,13 +178,14 @@ def parseRPMName(pkgName):
         r = r[0:ind]
     return str(n), e, str(v), str(r)
 
+
 def parseDEBName(pkgName):
-    """ IN:  Package string in, n-n-n_v.v.v-v.v-r.r.r, format.
+    """ IN:  Package string in, n-n_v.v-v.v-r.r, format.
         OUT: Four strings (in a tuple): name, epoch, version, release.
     """
     if pkgName.find('_') == -1:
         return None, None, None, None
-    e = ''
+    e = None
     n, version = pkgName.split('_')
     if version.find(':') != -1:
         e, version = version.split(':')
@@ -192,6 +193,7 @@ def parseDEBName(pkgName):
     v = '-'.join(version_tmpArr[:-1])
     r = version_tmpArr[-1]
     return str(n), e, str(v), str(r)
+
 
 def isSUSE():
     """Return true if this is a SUSE system, otherwise false"""

--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -178,7 +178,7 @@ def parseRPMName(pkgName):
         r = r[0:ind]
     return str(n), e, str(v), str(r)
 
-def parseDEPName(pkgName):
+def parseDEBName(pkgName):
     """ IN:  Package string in, n-n-n-v.v.v-r.r_r, format.
         OUT: Four strings (in a tuple): name, epoch, version, release.
     """

--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -159,7 +159,7 @@ def hash_object_id(object_id, factor):
     return num_id.rjust(factor, '0')
 
 
-# reg exp for splitting package names.
+# reg exp for splitting rpm package names.
 re_rpmName = re.compile("^(.*)-([^-]*)-([^-]*)$")
 
 
@@ -176,6 +176,21 @@ def parseRPMName(pkgName):
     if ind >= 0:  # epoch found
         e = r[ind + 1:]
         r = r[0:ind]
+    return str(n), e, str(v), str(r)
+
+def parseDEPName(pkgName):
+    """ IN:  Package string in, n-n-n-v.v.v-r.r_r, format.
+        OUT: Four strings (in a tuple): name, epoch, version, release.
+    """
+    if pkgName.find('_') == -1:
+        return None, None, None, None
+    e = ''
+    n, version = pkgName.split('_')
+    if version.find(':') != -1:
+        e, version = version.split(':')
+    version_tmpArr = version.split('-')
+    v = '-'.join(version_tmpArr[:-1])
+    r = version_tmpArr[-1]
     return str(n), e, str(v), str(r)
 
 def isSUSE():

--- a/backend/common/rhn_deb.py
+++ b/backend/common/rhn_deb.py
@@ -78,13 +78,16 @@ class deb_Header:
                     self.hdr[k] = debcontrol.get_as_string(k)
 
             version = debcontrol.get_as_string('Version')
-            version_tmpArr = version.split('-', 1)
-            if len(version_tmpArr) == 1:
+            if version.find(':') != -1:
+                self.hdr['epoch'], version = version.split(':')
                 self.hdr['version'] = version
-                self.hdr['release'] = "X"
+            if version.find('-') != -1:
+                version_tmpArr = version.split('-')
+                self.hdr['version'] = '-'.join(version_tmpArr[:-1])
+                self.hdr['release'] = version_tmpArr[-1]
             else:
-                self.hdr['version'] = version_tmpArr[0]
-                self.hdr['release'] = version_tmpArr[1]
+                self.hdr['version'] = version
+                self.hdr['release'] = 'X'
         except Exception:
             e = sys.exc_info()[1]
             raise_with_tb(InvalidPackageError(e), sys.exc_info()[2])

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -94,13 +94,17 @@ class DebRepo(object):
                 elif pair[0] == "Architecture:":
                     package['arch'] = pair[1] + '-deb'
                 elif pair[0] == "Version:":
-                    version = pair[1].split('-', 1)
-                    if len(version) == 1:
-                        package['version'] = version[0]
-                        package['release'] = 'X'
+                    package['epoch'] = ''
+                    version = pair[1]
+                    if version.find(':') != -1:
+                        package['epoch'], version = version.split(':')
+                    if version.find('-') != -1:
+                        tmp = version.split('-')
+                        package['version'] = '-'.join(tmp[:-1])
+                        package['release'] = tmp[-1]
                     else:
-                        package['version'] = version[0]
-                        package['release'] = version[1]
+                        package['version'] = version
+                        package['release'] = 'X'
                 elif pair[0] == "Filename:":
                     package['path'] = pair[1]
                 elif pair[0] == "SHA256:":

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -20,7 +20,7 @@ import string
 import base64
 import posixpath
 
-from spacewalk.common.rhnLib import parseRPMName
+from spacewalk.common.rhnLib import parseRPMName, parseDEBName
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 
@@ -60,8 +60,10 @@ def parseRPMFilename(pkgFilename):
     # that crap off.
     pkg = string.split(pkgFilename, '.')
 
+    dist = string.lower(pkg[-1])
+
     # 'rpm' at end?
-    if string.lower(pkg[-1]) not in ['rpm', 'deb']:
+    if dist not in ['rpm', 'deb']:
         raise rhnFault(21, 'neither an rpm nor a deb package name: %s' % pkgFilename)
 
     # Valid architecture next?
@@ -72,7 +74,12 @@ def parseRPMFilename(pkgFilename):
 
     # Nuke that arch.rpm.
     pkg = string.join(pkg[:-2], '.')
-    ret = list(parseRPMName(pkg))
+
+    if dist == "deb":
+        ret = list(parseDEBName(pkg))
+    else:
+        ret = list(parseRPMName(pkg))
+
     if ret:
         ret.append(_arch)
     return ret

--- a/client/rhel/rhn-client-tools/src/up2date_client/debUtils.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/debUtils.py
@@ -28,7 +28,7 @@ def verifyPackages(packages):
 
 def parseVRE(version):
     epoch = ''
-    release = '0'
+    release = 'X'
     if version.find(':') != -1:
         epoch, version = version.split(':')
     if version.find('-') != -1:

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -78,6 +78,10 @@ public class DebPackageWriter {
             out.newLine();
 
             out.write("Version: ");
+            String epoch = pkgDto.getEpoch();
+            if (!epoch.isEmpty()) {
+                out.write(epoch + ":");
+            }
             out.write(pkgDto.getVersion());
             String release = pkgDto.getRelease();
             if (!release.equalsIgnoreCase("X")) {
@@ -134,9 +138,13 @@ public class DebPackageWriter {
                     TaskConstants.TASK_QUERY_REPOMD_GENERATOR_CAPABILITY_BREAKS,
                     pkgDto.getId(), "Breaks");
 
-            out.write("Filename: XMLRPC/GET-REQ/" + channelLabel + "/getPackage/" +
-                    pkgDto.getName() + "-" + pkgDto.getVersion() + "-" +
-                    pkgDto.getRelease() + "." + pkgDto.getArchLabel() + ".deb");
+            out.write("Filename: XMLRPC/GET-REQ/" + channelLabel + "/getPackage/");
+            out.write(pkgDto.getName() + "_");
+            if (!epoch.isEmpty()) {
+                out.write(epoch + ":");
+            }
+            out.write(pkgDto.getVersion() + "-" + out.write(pkgDto.getRelease());
+            out.write("." + pkgDto.getArchLabel() + ".deb");
             out.newLine();
 
             // size of package, is checked by apt

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -143,7 +143,7 @@ public class DebPackageWriter {
             if (!epoch.equalsIgnoreCase("")) {
                 out.write(epoch + ":");
             }
-            out.write(pkgDto.getVersion() + "-" + out.write(pkgDto.getRelease());
+            out.write(pkgDto.getVersion() + "-" + pkgDto.getRelease());
             out.write("." + pkgDto.getArchLabel() + ".deb");
             out.newLine();
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -79,7 +79,7 @@ public class DebPackageWriter {
 
             out.write("Version: ");
             String epoch = pkgDto.getEpoch();
-            if (!epoch.isEmpty()) {
+            if (!epoch.equalsIgnoreCase("")) {
                 out.write(epoch + ":");
             }
             out.write(pkgDto.getVersion());
@@ -140,7 +140,7 @@ public class DebPackageWriter {
 
             out.write("Filename: XMLRPC/GET-REQ/" + channelLabel + "/getPackage/");
             out.write(pkgDto.getName() + "_");
-            if (!epoch.isEmpty()) {
+            if (!epoch.equalsIgnoreCase("")) {
                 out.write(epoch + ":");
             }
             out.write(pkgDto.getVersion() + "-" + out.write(pkgDto.getRelease());


### PR DESCRIPTION
This fixes a few failures to match debian package versions in spacewalk channels with ones reported as installed from clients.

It changes the parsing to handle the debian package version components according to definitions from here: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
It uses logic that is already inside of client/rhel/rhn-client-tools/src/up2date_client/debUtils.py in all relevant places.

It also fixes a failure to fetch packages with name containing hyphens.
It uses parts of #444 from @hlawatschek for this.

User-Notes:
After the update the channels must be cleaned and synced again to import the right versions.
The client needs to be fixed also to report an X instead of a 0 as release if it is empty.
(Which is wrong as some debian packages like **pyca** and **python-manila-ui** use a release value of 0)