### PR TITLE
align number to right in output

### DIFF
--- a/backend/cdn_tools/cdnsync.py
+++ b/backend/cdn_tools/cdnsync.py
@@ -513,11 +513,12 @@ class CdnSync(object):
             except Exception:
                 packages_size = '?B'
 
+            packages_size = "(%s)" % packages_size
             space = " "
             offset = longest_label - len(channel)
             space += " " * offset
 
-            log(0, "    %s %s%s%s packages (%s)" % (status, channel, space, packages_number, packages_size))
+            log(0, "    %s %s%s%6s packages %9s" % (status, channel, space, packages_number, packages_size))
             sources = self.cdn_repository_manager.get_content_sources(channel)
             if repos:
                 if sources:
@@ -550,11 +551,12 @@ class CdnSync(object):
                     except Exception:
                         packages_size = '?B'
 
+                    packages_size = "(%s)" % packages_size
                     space = " "
                     offset = longest_label - len(child)
                     space += " " * offset
 
-                    log(0, "    %s %s%s%s packages (%s)" % (status, child, space, packages_number, packages_size))
+                    log(0, "    %s %s%s%6s packages %9s" % (status, child, space, packages_number, packages_size))
                     if repos:
                         sources = self.cdn_repository_manager.get_content_sources(child)
                         if sources:


### PR DESCRIPTION
Output list of channels is not clearly.

Current state:
```
17:47:14     . rhel-x86_64-workstation-supplementary-7                   164 packages (4.0G)
17:47:14     . rhel-x86_64-workstation-supplementary-7-beta              ? packages (?B)
17:47:14     . rhel-x86_64-workstation-supplementary-7-beta-debuginfo    0 packages (0.0B)
17:47:14     . rhel-x86_64-workstation-supplementary-7-debuginfo         0 packages (0.0B)
17:47:14     . rhn-tools-rhel-x86_64-workstation-7                       103 packages (21.8M)
17:47:14     . rhn-tools-rhel-x86_64-workstation-7-debuginfo             2 packages (194.2K)
17:47:14 rhel-x86_64-workstation-7-htb:
17:47:14     . rhel-x86_64-workstation-7-htb-debuginfo                   0 packages (0.0B)
17:47:14     . rhel-x86_64-workstation-optional-7-htb                    3996 packages (2.5G)
17:47:14     . rhel-x86_64-workstation-optional-7-htb-debuginfo          190 packages (1.3G)
17:47:14 rhel-x86_64-ws-4:
17:47:14     . rhel-x86_64-ws-4-beta                                     0 packages (0.0B)
``` 

After my fix (I suppose that count of packages never be more then 999999)
```
18:28:43     . rhel-x86_64-workstation-supplementary-7-beta                   ? packages     (?B)
18:28:43     . rhel-x86_64-workstation-supplementary-7-beta-debuginfo         0 packages   (0.0B)
18:28:43     . rhel-x86_64-workstation-supplementary-7-debuginfo              0 packages   (0.0B)
18:28:43     . rhn-tools-rhel-x86_64-workstation-7                          103 packages  (21.8M)
18:28:43     . rhn-tools-rhel-x86_64-workstation-7-debuginfo                  2 packages (194.2K)
18:28:43 rhel-x86_64-workstation-7-htb:
18:28:43     . rhel-x86_64-workstation-7-htb-debuginfo                        0 packages   (0.0B)
18:28:43     . rhel-x86_64-workstation-optional-7-htb                      3996 packages   (2.5G)
18:28:43     . rhel-x86_64-workstation-optional-7-htb-debuginfo             190 packages   (1.3G)
18:28:43 rhel-x86_64-ws-4:
18:28:43     . rhel-x86_64-ws-4-beta                                          0 packages   (0.0B)
```

Maybe string "packages" is used many times in output..