### PR TITLE
Adding filters feature to deb_src.py

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -17,6 +17,7 @@ import os.path
 from shutil import rmtree
 import time
 import requests
+import re
 from spacewalk.common import fileutils
 from spacewalk.satellite_tools.repo_plugins import ContentPackage
 from spacewalk.common.rhnConfig import CFG, initCFG
@@ -171,8 +172,8 @@ class ContentSource(object):
                 filters.append(('-', [p]))
 
         if filters:
-            # TODO
-            pass
+            pkglist = self._filter_packages(pkglist, filters)
+            self.num_excluded = self.num_packages - len(pkglist)
 
         to_return = []
         for pack in pkglist:
@@ -194,6 +195,57 @@ class ContentSource(object):
             return 0
         else:
             return -1
+    @staticmethod
+    def _filter_packages(packages, filters):
+        """ implement include / exclude logic
+            filters are: [ ('+', includelist1), ('-', excludelist1),
+                           ('+', includelist2), ... ]
+        """
+        if filters is None:
+            return
+
+        selected = []
+        excluded = []
+        allmatched_include = []
+        allmatched_exclude = []
+        if filters[0][0] == '-':
+            # first filter is exclude, start with full package list
+            # and then exclude from it
+            selected = packages
+        else:
+            excluded = packages
+
+        for filter_item in filters:
+            sense, pkg_list = filter_item
+            if sense == '+':
+                    # include
+                    for index in range(len(excluded)):
+                      regex = fnmatch.translate(pkg_list[0])
+                      reobj = re.compile(regex)
+                      if (reobj.match(excluded[index]['name'])):
+                        print("It's an include match for " + excluded[index]['name'])
+                        allmatched_include.insert(0,excluded[index])
+                        selected.insert(0,excluded[index])
+                    for pkg in allmatched_include:
+                        if pkg in excluded:
+                            excluded.remove(pkg)
+            elif sense == '-':
+                # exclude
+                for index in range(len(selected)):
+                  regex = fnmatch.translate(pkg_list[0])
+                  reobj = re.compile(regex)
+                  if (reobj.match(selected[index]['name'])):
+                    print("It's an exclude match for " + selected[index]['name'])
+                    allmatched_exclude.insert(0,selected[index])
+                    excluded.insert(0,selected[index])
+
+                for pkg in allmatched_exclude:
+                    if pkg in selected:
+                        selected.remove(pkg)
+                excluded = (excluded + allmatched_exclude)
+            else:
+                raise UpdateNoticeException
+        return selected
 
     def get_package(self, package, metadata_only=False):
         """ get package """

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -220,32 +220,32 @@ class ContentSource(object):
             sense, pkg_list = filter_item
             if sense == '+':
                     # include
-                    for index in range(len(excluded)):
-                      regex = fnmatch.translate(pkg_list[0])
-                      reobj = re.compile(regex)
-                      if (reobj.match(excluded[index]['name'])):
+                for index in range(len(excluded)):
+                    regex = fnmatch.translate(pkg_list[0])
+                    reobj = re.compile(regex)
+                    if (reobj.match(excluded[index]['name'])):
                         print("It's an include match for " + excluded[index]['name'])
                         allmatched_include.insert(0,excluded[index])
                         selected.insert(0,excluded[index])
-                    for pkg in allmatched_include:
-                        if pkg in excluded:
-                            excluded.remove(pkg)
+                for pkg in allmatched_include:
+                    if pkg in excluded:
+                        excluded.remove(pkg)
             elif sense == '-':
                 # exclude
                 for index in range(len(selected)):
-                  regex = fnmatch.translate(pkg_list[0])
-                  reobj = re.compile(regex)
-                  if (reobj.match(selected[index]['name'])):
-                    print("It's an exclude match for " + selected[index]['name'])
-                    allmatched_exclude.insert(0,selected[index])
-                    excluded.insert(0,selected[index])
+                    regex = fnmatch.translate(pkg_list[0])
+                    reobj = re.compile(regex)
+                    if (reobj.match(selected[index]['name'])):
+                        print("It's an exclude match for " + selected[index]['name'])
+                        allmatched_exclude.insert(0,selected[index])
+                        excluded.insert(0,selected[index])
 
                 for pkg in allmatched_exclude:
                     if pkg in selected:
                         selected.remove(pkg)
                 excluded = (excluded + allmatched_exclude)
             else:
-                raise UpdateNoticeException
+                raise IOError("Filters are malformed")
         return selected
 
     def get_package(self, package, metadata_only=False):

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -218,27 +218,23 @@ class ContentSource(object):
 
         for filter_item in filters:
             sense, pkg_list = filter_item
+            regex = fnmatch.translate(pkg_list[0])
+            reobj = re.compile(regex)
             if sense == '+':
-                    # include
-                for index in range(len(excluded)):
-                    regex = fnmatch.translate(pkg_list[0])
-                    reobj = re.compile(regex)
-                    if (reobj.match(excluded[index]['name'])):
-                        print("It's an include match for " + excluded[index]['name'])
-                        allmatched_include.insert(0,excluded[index])
-                        selected.insert(0,excluded[index])
+                # include
+                for index, excluded_pkg in enumerate(excluded):
+                    if (reobj.match(excluded_pkg['name'])):
+                        allmatched_include.insert(0,excluded_pkg)
+                        selected.insert(0,excluded_pkg)
                 for pkg in allmatched_include:
                     if pkg in excluded:
                         excluded.remove(pkg)
             elif sense == '-':
                 # exclude
-                for index in range(len(selected)):
-                    regex = fnmatch.translate(pkg_list[0])
-                    reobj = re.compile(regex)
-                    if (reobj.match(selected[index]['name'])):
-                        print("It's an exclude match for " + selected[index]['name'])
-                        allmatched_exclude.insert(0,selected[index])
-                        excluded.insert(0,selected[index])
+                for index, selected_pkg in enumerate(selected):
+                    if (reobj.match(selected_pkg['name'])):
+                        allmatched_exclude.insert(0,selected_pkg)
+                        excluded.insert(0,selected_pkg)
 
                 for pkg in allmatched_exclude:
                     if pkg in selected:

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -16,8 +16,9 @@
 import os.path
 from shutil import rmtree
 import time
-import requests
 import re
+import fnmatch
+import requests
 from spacewalk.common import fileutils
 from spacewalk.satellite_tools.repo_plugins import ContentPackage
 from spacewalk.common.rhnConfig import CFG, initCFG

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -222,7 +222,7 @@ class ContentSource(object):
             reobj = re.compile(regex)
             if sense == '+':
                 # include
-                for index, excluded_pkg in enumerate(excluded):
+                for excluded_pkg in enumerate(excluded):
                     if (reobj.match(excluded_pkg['name'])):
                         allmatched_include.insert(0,excluded_pkg)
                         selected.insert(0,excluded_pkg)
@@ -231,7 +231,7 @@ class ContentSource(object):
                         excluded.remove(pkg)
             elif sense == '-':
                 # exclude
-                for index, selected_pkg in enumerate(selected):
+                for selected_pkg in enumerate(selected):
                     if (reobj.match(selected_pkg['name'])):
                         allmatched_exclude.insert(0,selected_pkg)
                         excluded.insert(0,selected_pkg)


### PR DESCRIPTION
Inspired by yum_src.py, I added the filters feature to enable the ability to use spacewalk-repo-sync with the following options when syncing a Debian repository :

-   -i FILTERS, --include=FILTERS
-   -e FILTERS, --exclude=FILTERS