### PR TITLE
Make spacecmd prompt for password when overriding config file user

### DIFF
--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -985,7 +985,7 @@ def load_config_section(self, section):
 
     try:
         if (self.config.has_key('username')
-            and self.config['username'] != self.config_parser.get(section, 'username')):
+                and self.config['username'] != self.config_parser.get(section, 'username')):
             del self.config['password']
     except NoOptionError:
         pass

--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -983,6 +983,13 @@ def load_config_section(self, section):
             except NoOptionError:
                 pass
 
+    try:
+        if (self.config.has_key('username')
+            and self.config['username'] != self.config_parser.get(section, 'username')):
+            del self.config['password']
+    except NoOptionError:
+        pass
+
     # handle the nossl boolean
     if self.config.has_key('nossl') and isinstance(self.config['nossl'], str):
         self.config['nossl'] = re.match('^1|y|true$', self.config['nossl'], re.I)


### PR DESCRIPTION
If user credentials are set via spacecmd config file and the spacecmd user is overridden with the -u option, the spacecmd still tries to use the password stored for the user in the config file.

This change makes spacecmd either prompt for a password, or accept one via the -p option.