### PR TITLE
Fix spacewalk-data-fsck removing SRPMs associated with RPMs

### DIFF
--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -56,6 +56,12 @@ def db_init():
     rhnSQL.initDB()
 
 
+def src_package_query():
+    query = """select p.id
+                 from rhnPackage p
+                where p.path like :filename"""
+    return query
+
 def package_query(options, bind_path=False):
     query = """select %s
                  from %s
@@ -271,8 +277,9 @@ def check_disk_vs_db(disk_content=None, db_content=None):
             row = h.fetchone_dict()
 
             if not row:
-                report['dbexists'] += 1
-                not_in_db(abs_path, options)
+                if is_orphaned_srpm(abs_path, f):
+                    report['dbexists'] += 1
+                    not_in_db(abs_path, options)
                 continue
 
             if options.size and options.fs_only:
@@ -291,6 +298,18 @@ def check_disk_vs_db(disk_content=None, db_content=None):
                 error_found = 1
     return error_found
 
+def is_orphaned_srpm(path, file):
+    if file.find("src.rpm") != -1:
+        query = src_package_query()
+        h = rhnSQL.prepare(query)
+        wildcard_filename = "%/" + file.replace('src','%')
+        h.execute(filename=wildcard_filename)
+        row = h.fetchone_dict()
+        if not row:
+            log(0, "SRPM without matching RPM: %s" % (path))
+            return True
+
+    return False
 
 def not_in_db(path, options):
     if options.remove:

--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -985,7 +985,7 @@ def load_config_section(self, section):
 
     try:
         if (self.config.has_key('username')
-            and self.config['username'] != self.config_parser.get(section, 'username')):
+                and self.config['username'] != self.config_parser.get(section, 'username')):
             del self.config['password']
     except NoOptionError:
         pass

--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -983,6 +983,13 @@ def load_config_section(self, section):
             except NoOptionError:
                 pass
 
+    try:
+        if (self.config.has_key('username')
+            and self.config['username'] != self.config_parser.get(section, 'username')):
+            del self.config['password']
+    except NoOptionError:
+        pass
+
     # handle the nossl boolean
     if self.config.has_key('nossl') and isinstance(self.config['nossl'], str):
         self.config['nossl'] = re.match('^1|y|true$', self.config['nossl'], re.I)


### PR DESCRIPTION
spacewalk-data-fsck incorrectly identifies for removal SRPMs that are associated with RPMs in a channel. If used with the -r option spacewalk-data-fsck will remove the SRPMS. 