### PR TITLE
fix bz1422518 - request failed: error reading the headers 

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+++ b/client/rhel/dnf-plugin-spacewalk/spacewalk.py
@@ -250,7 +250,7 @@ class  SpacewalkRepo(dnf.repo.Repo):
                 # This doesn't work due to bug in librepo (or even deeper in libcurl)
                 # the workaround bellow can be removed once BZ#1211662 is fixed
                 #http_headers.append("%s;" % header)
-                http_headers.append("%s: \nX-libcurl-Empty-Header-Workaround: *" % header)
+                http_headers.append("%s: \r\nX-libcurl-Empty-Header-Workaround: *" % header)
             else:
                 http_headers.append("%s: %s" % (header, self.login_info[header]))
         if not self.force_http:

--- a/client/rhel/yum-rhn-plugin/rhnplugin.py
+++ b/client/rhel/yum-rhn-plugin/rhnplugin.py
@@ -425,7 +425,7 @@ class RhnRepo(YumRepository):
             # but we have to send and empty X-RHN-Auth-User-Id ...
             AuthUserH = 'X-RHN-Auth-User-Id'
             if (AuthUserH in self.http_headers and not self.http_headers[AuthUserH]):
-                self.http_headers[AuthUserH] = "\nX-libcurl-Empty-Header-Workaround: *"
+                self.http_headers[AuthUserH] = "\r\nX-libcurl-Empty-Header-Workaround: *"
 
         # Turn our dict into a list of 2-tuples
         headers = YumRepository._YumRepository__headersListFromDict(self)   # pylint: disable-msg=E1101


### PR DESCRIPTION
Clients don't download metadata from Satellite due to new httpd security patch:
Bug 1412974 - CVE-2016-8743 httpd: Apache HTTP Request Parsing Whitespace Defects [rhel-6.9] 