### PR TITLE
Add incomplete_package_import option to speed reposync up

### DIFF
--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -98,6 +98,8 @@ class Backend:
             capabilityHash[(name, version)] = row['id']
 
     def processChangeLog(self, changelogHash):
+        if CFG.has_key('package_import_skip_changelog') and CFG.package_import_skip_changelog:
+            return
         sql = "select id from rhnPackageChangeLogData where name = :name and time = :time and text = :text"
         h = self.dbmodule.prepare(sql)
         toinsert = [[], [], [], []]
@@ -737,6 +739,9 @@ class Backend:
             'rhnPackageFile':       'package_id',
             'rhnPackageChangeLogRec':  'package_id',
         }
+
+        if CFG.has_key('package_import_skip_changelog') and CFG.package_import_skip_changelog:
+            del childTables['rhnPackageChangeLogRec']
 
         for package in packages:
             if not isinstance(package, Package):

--- a/spacewalk/config/usr/share/man/man5/rhn.conf.5
+++ b/spacewalk/config/usr/share/man/man5/rhn.conf.5
@@ -221,6 +221,12 @@ The maximum amount of memory (MB) that Taskomatic can use. If you find that Task
 .B Default:
 1024
 
+.TP
+.B "package_import_skip_changelog" (boolean)
+When importing packages, skip non-essential data that can make the import faster (changelogs). Not recommended in production.
+.IP
+.B Default:
+0
 
 .SS Database Options
 .TP


### PR DESCRIPTION
Considerable time is taken by `spacewalk-repo-sync` and inter-server sync due to database insertions in tables with a high number of rows.

Three of these (`rhnPackageFile`, `rhnPackageChangeLogRec` and `rhnPackageChangeLogData`) only contain informational data that can be skipped in order to get faster repo-sync times, at the expense of not finding this data in the Web UI.

This patch adds an `rhn.conf` flag (`incomplete_package_import = 1`) that will result in `spacewalk-repo-sync` and inter-server sync skipping those tables with noticeable performance gains.

This is particularly useful in tests and demos, and is not recommended in production.