### PR TITLE
Avoid "stuck" tabs

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/security/AuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/AuthenticationService.java
@@ -46,6 +46,14 @@ public interface AuthenticationService {
         throws ServletException;
 
     /**
+     * Refresh any storage of session information (cookies, database rows).
+     *
+     * @param request the request
+     * @param response the response
+     */
+    void refresh(HttpServletRequest request, HttpServletResponse response);
+
+    /**
      * CSFR check might be skipped for particular POST requests f.e. all login
      * pages
      * @param request The current request

--- a/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
@@ -122,12 +122,22 @@ public class PxtAuthenticationService extends BaseAuthenticationService {
                 invalidate(request, response);
                 return false;
             }
-            // If URL requires auth and we are authenticated refresh the session.
-            // We don't refresh when the URL doesn't require auth because
-            // that may invalidate our old session
-            pxtDelegate.refreshPxtSession(request, response);
         }
         return true;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh(HttpServletRequest request, HttpServletResponse response) {
+        // If URL requires auth and we are authenticated refresh the session.
+        // We don't refresh when the URL doesn't require auth because
+        // that may invalidate our old session
+        if (requestURIRequiresAuthentication(request)) {
+            pxtDelegate.refreshPxtSession(request, response);
+        }
     }
 
     private boolean isAuthenticationRequired(HttpServletRequest request) {

--- a/java/code/src/com/redhat/rhn/frontend/security/test/PxtAuthenticationServiceTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/test/PxtAuthenticationServiceTest.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * PxtAuthenticationServiceTest
- * @version $Rev$
  */
 // TODO Review Test classes in package to factor out common code
 public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractTestCase {

--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
@@ -105,6 +105,8 @@ public class AuthFilter implements Filter {
                 LoggingFactory.setLogAuth(user.getId());
             }
             chain.doFilter(request, response);
+            authenticationService.refresh((HttpServletRequest) request,
+                    (HttpServletResponse) response);
         }
         else {
             authenticationService.redirectToLogin((HttpServletRequest)request,

--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
@@ -46,8 +46,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * AuthFilter - a servlet filter to ensure authenticated user info is put at
  * request scope properly
- *
- * @version $Rev$
  */
 public class AuthFilter implements Filter {
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/AuthFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/AuthFilterTest.java
@@ -31,7 +31,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * AuthFilterTest
- * @version $Rev$
  */
 public class AuthFilterTest extends MockObjectTestCase {
 


### PR DESCRIPTION
If a page renders slowly for whatever reason, users might open other tabs to visit other pages while it completes.

This is currently blocking - all tabs will not start rendering before the slow one has completed.

Note that this is different from having two distinct browsers - it only applies if the same cookie is used, which maps to the same session and ultimately to the same contended database row.