### PR TITLE
make country, state/province and city searchable for system location

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
@@ -95,7 +95,10 @@ public class SystemSearchAction extends BaseSearchAction implements Listable {
                     { SystemSearchHelper.INSTALLED_PACKAGES,
                                     SystemSearchHelper.NEEDED_PACKAGES },
                     /* location */
-                    { SystemSearchHelper.LOC_ADDRESS, SystemSearchHelper.LOC_BUILDING,
+                    { SystemSearchHelper.LOC_COUNTRY, SystemSearchHelper.LOC_STATE,
+                                    SystemSearchHelper.LOC_CITY,
+                                    SystemSearchHelper.LOC_ADDRESS,
+                                    SystemSearchHelper.LOC_BUILDING,
                                     SystemSearchHelper.LOC_ROOM,
                                     SystemSearchHelper.LOC_RACK } };
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -83,6 +83,9 @@ public class SystemSearchHelper {
     public static final String INSTALLED_PACKAGES = "systemsearch_installed_packages";
     public static final String NEEDED_PACKAGES = "systemsearch_needed_packages";
     public static final String RUNNING_KERNEL = "systemsearch_running_kernel";
+    public static final String LOC_COUNTRY = "systemsearch_location_country";
+    public static final String LOC_STATE = "systemsearch_location_state";
+    public static final String LOC_CITY = "systemsearch_location_city";
     public static final String LOC_ADDRESS = "systemsearch_location_address";
     public static final String LOC_BUILDING = "systemsearch_location_building";
     public static final String LOC_ROOM = "systemsearch_location_room";
@@ -139,7 +142,10 @@ public class SystemSearchHelper {
                     { SystemSearchHelper.INSTALLED_PACKAGES,
                                     SystemSearchHelper.NEEDED_PACKAGES },
                     /* location */
-                    { SystemSearchHelper.LOC_ADDRESS, SystemSearchHelper.LOC_BUILDING,
+                    { SystemSearchHelper.LOC_COUNTRY, SystemSearchHelper.LOC_STATE,
+                                    SystemSearchHelper.LOC_CITY,
+                                    SystemSearchHelper.LOC_ADDRESS,
+                                    SystemSearchHelper.LOC_BUILDING,
                                     SystemSearchHelper.LOC_ROOM,
                                     SystemSearchHelper.LOC_RACK } };
 
@@ -408,6 +414,18 @@ public class SystemSearchHelper {
         }
         else if (RUNNING_KERNEL.equals(mode)) {
             query = "runningKernel:(" + terms + ")";
+            index = SERVER_INDEX;
+        }
+        else if (LOC_COUNTRY.equals(mode)) {
+            query = "country:(" + terms + ")";
+            index = SERVER_INDEX;
+        }
+        else if (LOC_STATE.equals(mode)) {
+            query = "state:(" + terms + ")";
+            index = SERVER_INDEX;
+        }
+        else if (LOC_CITY.equals(mode)) {
+            query = "city:(" + terms + ")";
             index = SERVER_INDEX;
         }
         else if (LOC_ADDRESS.equals(mode)) {

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -2811,6 +2811,24 @@ available for this kickstart profile to function properly.
           <context context-type="sourcefile">/systems/Search</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="systemsearch_location_country">
+        <source>Country</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/Search</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="systemsearch_location_state">
+        <source>State/Province</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/Search</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="systemsearch_location_city">
+        <source>City</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/Search</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemsearch_location_address">
         <source>Address</source>
         <context-group name="ctx">


### PR DESCRIPTION
System country, state and city could be set, but you cannot search for it.
This PR add these fields to search options. The index exists already.