### PR TITLE
1342977 - Prevent ORA-01878 on repository sync.

### DIFF
--- a/backend/common/Makefile
+++ b/backend/common/Makefile
@@ -28,7 +28,9 @@ SPACEWALK_FILES	=   __init__ \
 	    rhn_mpm \
 	    rhn_pkg \
 	    rhn_rpm \
-	    stringutils
+	    stringutils \
+	    timezone_utils
+
 SCRIPTS = spacewalk-cfg-get
 
 # check if we can build man pages

--- a/backend/common/timezone_utils.py
+++ b/backend/common/timezone_utils.py
@@ -1,0 +1,35 @@
+"""
+Copyright (C) 2017 Oracle and/or its affiliates. All rights reserved.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, version 2
+
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+
+Utility to get system UTC offset and format as needed by DBs.
+"""
+import time
+
+
+def get_utc_offset():
+    """Return the UTC offset, allowing for DST."""
+    is_dst = time.daylight and time.localtime().tm_isdst > 0
+    utc_offset = - (time.altzone if is_dst else time.timezone)
+
+    mins = divmod(utc_offset, 60)[0]
+    hours, mins = divmod(mins, 60)
+    return '{0:+03d}:{1:02d}'.format(hours, mins)
+
+
+if __name__ == "__main__":
+    print "UTC offset (allowing for DST if in effect): %s" % get_utc_offset()

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -59,7 +59,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
             if f == 'build_time':
                 if val is not None and isinstance(val, IntType):
                     # A UNIX timestamp
-                    val = gmtime(val)
+                    val = localtime(val)
             elif val:
                 # Convert to strings
                 if isinstance(val, UnicodeType):

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -59,7 +59,7 @@ class rpmPackage(IncompletePackage):
             if f == 'build_time':
                 if type(val) in (IntType, LongType):
                     # A UNIX timestamp
-                    val = gmtime(val)
+                    val = localtime(val)
             if f == 'payload_size':
                 if val is None:
                     # use longarchivesize header field for rpms with archive > 4GB
@@ -351,7 +351,7 @@ class rpmFile(File, ChangeLog):
         tm = self['mtime']
         if type(tm) in (IntType, LongType):
             # A UNIX timestamp
-            self['mtime'] = gmtime(tm)
+            self['mtime'] = localtime(tm)
         if type(self['filedigest']) == StringType:
             self['checksum'] = self['filedigest']
             del(self['filedigest'])
@@ -487,7 +487,7 @@ class rpmChangeLog(ChangeLog):
         tm = self['time']
         if type(tm) in (IntType, LongType):
             # A UNIX timestamp
-            self['time'] = gmtime(tm)
+            self['time'] = localtime(tm)
         # In changelog, data is either in UTF-8, or in any other
         # undetermined encoding. Assume ISO-Latin-1 if not UTF-8.
         for i in ('text', 'name'):

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -651,6 +651,7 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/common/rhn_rpm.py*
 %{pythonrhnroot}/common/stringutils.py*
 %{pythonrhnroot}/common/rhnLib.py*
+%{pythonrhnroot}/common/timezone_utils.py*
 %{pythonrhnroot}/__init__.py*
 %{pythonrhnroot}/common/__init__.py*
 
@@ -796,6 +797,9 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{_mandir}/man8/cdn-sync.8*
 
 %changelog
+* Mon Mar 20 2017 Laurence Rochfort <laurence.rochfort@oracle.com> 2.7.57-1
+- Add timezone_utils.py to libs files for BZ 1342977
+
 * Mon Mar 20 2017 Gennadii Altukhov <galt@redhat.com> 2.7.57-1
 - 1418025 - fix package downloading for Kickstart addons. Add parsing repodata
   for addons repository and download all packages according to its location.


### PR DESCRIPTION
This prevents ORA-01878 on Oracle, and incorrect timezone insertion on
PostgreSQL when repo sync is triggered from the web UI. It also prevents
timestamps being off by one hour when spacewalk-repo-sync is run from
the cmdline.

See Bugzilla for details.