### PR TITLE
1434037 - Make spacecmd prompt for password when overriding config

### DIFF
--- a/spacecmd/src/lib/misc.py
+++ b/spacecmd/src/lib/misc.py
@@ -991,6 +991,13 @@ def load_config_section(self, section):
             except NoOptionError:
                 pass
 
+    try:
+        if (self.config.has_key('username')
+                and self.config['username'] != self.config_parser.get(section, 'username')):
+            del self.config['password']
+    except NoOptionError:
+        pass
+
     # handle the nossl boolean
     if self.config.has_key('nossl') and isinstance(self.config['nossl'], str):
         self.config['nossl'] = re.match('^1|y|true$', self.config['nossl'], re.I)


### PR DESCRIPTION
If user credentials are set via spacecmd config file and the spacecmd user is overridden with the -u option, the spacecmd still tries to use the password stored for the user in the config file.

This PR makes spacecmd prompt for a password when overriding config user.