### PR TITLE
fix missing import in rhncfg

### DIFF
--- a/client/tools/rhncfg/config_client/rpc_cli_repository.py
+++ b/client/tools/rhncfg/config_client/rpc_cli_repository.py
@@ -24,6 +24,7 @@ except ImportError: # python3
 from config_common import local_config, cfg_exceptions, file_utils, \
     repository
 from config_common.rhn_log import log_debug
+from spacewalk.common.usix import raise_with_tb
 
 import traceback
 


### PR DESCRIPTION
I received traceback about missing import when system is not registered to spacewalk.

```
rhncfg-client diff
Using server name xmlrpc.rhn.redhat.com
Traceback (most recent call last):
  File "/usr/bin/rhncfg-client", line 38, in <module>
    sys.exit(Main().main() or 0)
  File "/usr/share/rhn/config_common/rhn_main.py", line 218, in main
    handler.run()
  File "/usr/share/rhn/config_client/handler_base.py", line 56, in run
    for file in self.get_valid_files():
  File "/usr/share/rhn/config_client/handler_base.py", line 30, in get_valid_files
    for file in self.repository.list_files():
  File "/usr/share/rhn/config_client/rpc_cli_repository.py", line 73, in list_files
    return self.rpc_call('config.client.list_files', self.system_id)
  File "/usr/share/rhn/config_client/rpc_cli_repository.py", line 60, in rpc_call
    raise_with_tb(cfg_exceptions.AuthenticationError(
NameError: global name 'raise_with_tb' is not defined
```
