### PR TITLE
1436634 - Fix KS Default Download Location appending URL verbatim.

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
@@ -523,19 +523,29 @@ public class KickstartFormatter {
         log.debug("isRhnTree: " + this.ksdata.getTree().isRhnTree());
         log.debug("Actual URL: " + urlLocation);
 
-        if (urlLocation.startsWith("/")) {
+        StringBuilder url = new StringBuilder();
+        url.append("--url ");
+
+        if (urlLocation.equals(this.ksdata.getTree().getAbsolutePath())) {
             log.debug("URL is not customized.");
             log.debug("Formatting for view use.");
             // /kickstart/dist/ks-rhel-i386-as-4-u2
-            StringBuilder url = new StringBuilder();
-            url.append("--url ");
             url.append(urlHelper.getCobblerMediaUrl());
+            log.debug("constructed: " + url);
+            argVal = url.toString();
+        }
+        else if (urlLocation.startsWith("/")) {
+            log.debug("URL is customized.");
+            log.debug("Appending provided subpath to cobbler host.");
+            url.append(urlHelper.getCobblerMediaUrlBase());
+            url.append(urlLocation);
             log.debug("constructed: " + url);
             argVal = url.toString();
         }
         else {
             log.debug("Just return the arg value.");
         }
+
         log.debug("returning url: " + argVal);
         return argVal;
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -257,7 +257,21 @@ public class KickstartUrlHelper {
      */
     public String getCobblerMediaUrl() {
         StringBuilder url = new StringBuilder();
-        url.append(protocol + host + "$" + COBBLER_MEDIA_VARIABLE);
+        url.append(getCobblerMediaUrlBase() + "$" + COBBLER_MEDIA_VARIABLE);
+        log.debug("returning: " + url);
+        return url.toString();
+    }
+
+    /**
+     * Get the cobbler style --url base:
+     *
+     * http://$http_server/
+     *
+     * @return String base url , cobbler style: http://$http_server/
+     */
+    public String getCobblerMediaUrlBase() {
+        StringBuilder url = new StringBuilder();
+        url.append(protocol + host);
         log.debug("returning: " + url);
         return url.toString();
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -257,7 +257,7 @@ public class KickstartUrlHelper {
      */
     public String getCobblerMediaUrl() {
         StringBuilder url = new StringBuilder();
-        url.append(getCobblerMediaUrlBase() + "$" + COBBLER_MEDIA_VARIABLE);
+	 url.append(getCobblerMediaUrlBase()).append("$").append(COBBLER_MEDIA_VARIABLE);
         log.debug("returning: " + url);
         return url.toString();
     }
@@ -271,7 +271,7 @@ public class KickstartUrlHelper {
      */
     public String getCobblerMediaUrlBase() {
         StringBuilder url = new StringBuilder();
-        url.append(protocol + host);
+	 url.append(protocol).append(host);
         log.debug("returning: " + url);
         return url.toString();
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCommand.java
@@ -106,9 +106,6 @@ public abstract class CobblerProfileCommand extends CobblerCommand {
 
         Map meta = profile.getKsMeta();
         meta.put("org", this.ksData.getOrg().getId());
-        if (this.ksData.getUrl().startsWith("/")) {
-            meta.put("media_path", this.ksData.getUrl());
-        }
         profile.setKsMeta(meta);
 
         // Check for para_host

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartUrlHelperTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartUrlHelperTest.java
@@ -107,6 +107,14 @@ public class KickstartUrlHelperTest extends BaseKickstartCommandTestCase {
         assertEquals(expected, helper.getCobblerMediaUrl());
     }
 
+    public void testGetCobblerMediaUrlBase() throws Exception {
+        helper = new KickstartUrlHelper(ksdata);
+        String expected = "http://" +
+            KickstartUrlHelper.COBBLER_SERVER_VARIABLE;
+
+        assertEquals(expected, helper.getCobblerMediaUrl());
+    }
+
     public void testGetKickstartMediaSessionUrl() throws Exception {
         // /ks/dist/session/35x45fed383beaeb31a184166b4c1040633/ks-f9-x86_64
         KickstartSession session =


### PR DESCRIPTION
Fix a bug introduced as described in the BZ, whereby a Kickstart distro-tree path is appended verbatim to the SW/proxy host in the "url" field of the Kickstart file.

This fix also incorporates the functionality that was intended to be introduced by the BZ that introduced the bug. Specifically, if a path starting wiht a "/", that is not the distro-tree path, is entered it should be appended to the automatically derived SW/proxy host in the "url" field of the Kickstart file.

Paths starting with http or ftp are just inserted verbatim.