### PR TITLE
add new option skip-services-restart

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -169,10 +169,12 @@ if ($opts{'upgrade'}) {
     print Spacewalk::Setup::loc("for any remaining steps in the process.\n");
   }
 } else {
-  print Spacewalk::Setup::loc("* Restarting services.\n");
-  Spacewalk::Setup::system_or_exit(['/usr/sbin/spacewalk-service', 'restart'], 40,
-               'Could not restart spacewalk services.');
-  wait_for_tomcat($answers{hostname}) or exit 56;
+  if (!$opts{'skip-services-restart'}){
+      print Spacewalk::Setup::loc("* Restarting services.\n");
+      Spacewalk::Setup::system_or_exit(['/usr/sbin/spacewalk-service', 'restart'], 40,
+                   'Could not restart spacewalk services.');
+      wait_for_tomcat($answers{hostname}) or exit 56;
+  }
   print Spacewalk::Setup::loc("Installation complete.\n");
   print Spacewalk::Setup::loc("Visit https://%s to create the $product_name administrator account.\n", $answers{hostname});
 }

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -113,6 +113,7 @@ sub parse_options {
             "skip-ssl-cert-generation",
             "skip-ssl-vhost-setup",
             "skip-services-check",
+            "skip-services-restart",
             "skip-logfile-init",
             "clear-db",
             "re-register",
@@ -134,7 +135,7 @@ sub parse_options {
 
   my $usage = loc("usage: %s %s\n",
                   $0,
-                  "[ --help ] [ --answer-file=<filename> ] [ --non-interactive ] [ --skip-system-version-test ] [ --skip-selinux-test ] [ --skip-fqdn-test ] [ --skip-db-install ] [ --skip-db-diskspace-check ] [ --skip-db-population ] [ --skip-gpg-key-import ] [ --skip-ssl-cert-generation ] [--skip-ssl-vhost-setup] [ --skip-services-check ] [ --clear-db ] [ --re-register ] [ --upgrade ] [ --run-updater=<yes|no>] [--run-cobbler] [ --enable-tftp=<yes|no>] [ --external-oracle | --external-postgresql [ --external-postgresql-over-ssl ] ]" );
+                  "[ --help ] [ --answer-file=<filename> ] [ --non-interactive ] [ --skip-system-version-test ] [ --skip-selinux-test ] [ --skip-fqdn-test ] [ --skip-db-install ] [ --skip-db-diskspace-check ] [ --skip-db-population ] [ --skip-gpg-key-import ] [ --skip-ssl-cert-generation ] [--skip-ssl-vhost-setup] [ --skip-services-check ] [ --skip-services-restart ] [ --clear-db ] [ --re-register ] [ --upgrade ] [ --run-updater=<yes|no>] [--run-cobbler] [ --enable-tftp=<yes|no>] [ --external-oracle | --external-postgresql [ --external-postgresql-over-ssl ] ]" );
 
   # Terminate if any errors were encountered parsing the command line args:
   my %opts;
@@ -1947,6 +1948,10 @@ Only runs necessary steps for a Satellite upgrade.
 =item B<--skip-services-check>
 
 Proceed with upgrade if services are already stopped.
+
+=item B<--skip-services-restart>
+
+Do not restart services at the end of installation.
 
 =item B<--run-updater=<yes|no>>
 


### PR DESCRIPTION
In some special situation I don't want restart service at end  of installation and I prefer skip this step. For example when spacewalk is installed in Docker.