### PR TITLE
fix isSUSE: command not found

### DIFF
--- a/spacewalk/spacewalk-setup-postgresql/bin/spacewalk-setup-postgresql
+++ b/spacewalk/spacewalk-setup-postgresql/bin/spacewalk-setup-postgresql
@@ -34,6 +34,17 @@ ask() {
     fi
 }
 
+isSUSE() {
+    if [ ! -e '/etc/os-release' ]; then
+        return 1
+    fi
+    source /etc/os-release
+    if echo $CPE_NAME | grep -E 'cpe:/o:(open)*suse:' >/dev/null ; then
+        return 0
+    fi
+    return 1
+}
+
 ask_check() {
     while true; do
         ask "$1" "$2" $3 || echo
@@ -277,17 +288,6 @@ check() {
         fi
     fi
     exit $RET
-}
-
-isSUSE() {
-    if [ ! -e '/etc/os-release' ]; then
-        return 1
-    fi
-    source /etc/os-release
-    if echo $CPE_NAME | grep -E 'cpe:/o:(open)*suse:' >/dev/null ; then
-        return 0
-    fi
-    return 1
 }
 
 exists_db() {


### PR DESCRIPTION
Declaration function have to be before its call.

```
# spacewalk-setup 
* Setting up SELinux..
** Database: Setting up database connection for PostgreSQL backend.
/usr/bin/spacewalk-setup-postgresql: line 87: isSUSE: command not found
/usr/bin/spacewalk-setup-postgresql: line 100: isSUSE: command not found
Database "rhnschema" does not exist
** Database: Installing the database:
```