### PR TITLE
do not fail with a traceback when media.1 is requested

### DIFF
--- a/backend/common/rhnRepository.py
+++ b/backend/common/rhnRepository.py
@@ -55,6 +55,7 @@ class Repository(RPC_Base):
             'getPackageHeader',
             'getPackageSource',
             'i18n',
+            'media_1'
         ]
 
     def set_compress_headers(self, val):
@@ -126,6 +127,16 @@ class Repository(RPC_Base):
             We do not support it so just return 404. But do not fail with
             traceback.
         """
+        raise rhnNotFound()
+
+    @staticmethod
+    def media_1(filePath):
+        """SUSE File
+
+        We do not support it so just return 404. But do not fail with
+        traceback.
+        """
+        log_debug(3, filePath)
         raise rhnNotFound()
 
     def getPackageSource(self, pkgFilename):

--- a/backend/server/apacheRequest.py
+++ b/backend/server/apacheRequest.py
@@ -562,8 +562,8 @@ class GetHandler(apacheRequest):
         repository = rhnRepository.Repository(self.channel, server_id,
                                               username)
         repository.set_qos()
-
-        f = repository.get_function(method)
+        meth = method.replace('.', '_')
+        f = repository.get_function(meth)
         if f is None:
             raise UnknownXML("function '%s' invalid; path_info is %s" % (
                 method, self.req.path_info))


### PR DESCRIPTION
New libzypp request media.1 directory which result in a traceback.
Just returning 404 Not Found is ok.