### PR TITLE
Enhanced spacewalk-debug performance

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -248,6 +248,7 @@ if [ -f /rhnsat/admin/rhnsat/bdump/alert_rhnsat.log ] ; then
 fi
 
 PGSQL_ROOT=""
+MAX_PGSQL_LOGS_SIZE="6291456" #6 GB
 rpm -q postgresql92-postgresql > /dev/null
 if [ $? == 0 ]; then
 	PGSQL_ROOT="/opt/rh/postgresql92/root"
@@ -262,8 +263,21 @@ if [ -f /var/lib/pgsql/initlog ] ; then
        echo "    * copying initlog"
        cp -fa /var/lib/pgsql/initlog $DIR/database
 fi
+ls $PGSQL_ROOT/var/lib/pgsql/data/*.conf 2>/dev/null | xargs -I file cp -fa file $DIR/database
 
-ls $PGSQL_ROOT/var/lib/pgsql/data/*.conf $PGSQL_ROOT/var/lib/pgsql/data/pg_log/* 2>/dev/null | xargs -I file cp -fa file $DIR/database
+# compress postgres logs
+if [ -d $PGSQL_ROOT/var/lib/pgsql/data/pg_log ]; then
+
+    PGSQL_LOGS_SIZE=$(du -s $PGSQL_ROOT/var/lib/pgsql/data/pg_log | cut -d'/' -f1)
+    if [ $PGSQL_LOGS_SIZE -gt $MAX_PGSQL_LOGS_SIZE ]; then
+        echo "    * $PGSQL_ROOT/var/lib/pgsql/data/pg_log exceeded the maximum size allowed. Please copy it separately."
+        echo "PostgreSQL logs exceeded the maximum size of $MAX_PGSQL_LOGS_SIZE bytes" >> $DIR/database/warning
+    else
+        for pg_log in $(ls $PGSQL_ROOT/var/lib/pgsql/data/pg_log/* 2>/dev/null); do
+            cat $pg_log | gzip > $DIR/database/$(basename $pg_log).gz
+        done
+    fi
+fi
 
 if [ -d /var/log/spacewalk/schema-upgrade ] ; then
 	echo "    * copying schema upgrade logs"

--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -88,7 +88,7 @@ mkdir -p $DIR/conf/rhn/sysconfig
 mkdir -p $DIR/httpd-logs
 mkdir -p $DIR/tomcat-logs
 mkdir -p $DIR/cobbler-logs
-mkdir -p $DIR/rhn-logs
+mkdir -p $DIR/rhn-logs/rhn
 mkdir -p $DIR/config-defaults
 mkdir -p $DIR/kickstarts
 mkdir -p $DIR/database
@@ -114,7 +114,27 @@ if [ -d /var/log/httpd ]; then
 elif [ -d /var/log/apache2 ]; then
     cp -fapRd /var/log/apache2 $DIR/httpd-logs
 fi
-cp -fapRd /var/log/rhn* $DIR/rhn-logs
+
+# copy rhn logs
+if [ -d /var/log/rhn ]; then
+    cp -fapd  /var/log/rhn/{*log*,*.gz} $DIR/rhn-logs/rhn
+
+    # check for oracle dir
+    if [ -d /var/log/rhn/oracle ]; then
+        cp -fapRd /var/log/rhn/oracle $DIR/rhn-logs/rhn
+    fi
+
+    # check for reposync dir
+    if [ -d /var/log/rhn/reposync ]; then
+        cp -fapRd /var/log/rhn/reposync $DIR/rhn-logs/rhn
+    fi
+
+    # check for search dir
+    if [ -d /var/log/rhn/search ]; then
+        cp -fapRd /var/log/rhn/search $DIR/rhn-logs/rhn
+    fi
+fi
+
 DB_INSTALL_LOG=/var/log/rhn/rhn-database-installation.log
 if [ -f "$DB_INSTALL_LOG" ] ; then
     mkdir -p $DIR/tmp
@@ -288,4 +308,3 @@ rm -Rf $(echo $DIR | sed -e 's/\/[^\/]*$//g')
 
 echo
 echo "Debug dump created, stored in $TARBALL"
-


### PR DESCRIPTION
When running sosreport on a Satellite server, the spacewalk plugin is enabled by default. 
For Satellite servers on large environments, the spacewalk-debug may take more than 300 seconds to be finished.
```bash
# du -sch /opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/ /var/log/rhn
5.4G	/opt/rh/postgresql92/root/var/lib/pgsql/data/pg_log/
215M	/var/log/rhn
5.6G	total
```
In such environments, the sosreport will not get generated and will fail with the error below:
```bash
[root@orbital ~]# time sosreport

sosreport (version 3.2)

[..SNIP..]

 Setting up archive ...
 Setting up plugins ...
dbname must be supplied to dump a database.
 Running plugins. Please wait ...

  Running 10/92: boot...

[..SNIP..]

  Running 70/92: satellite...        [plugin:satellite] command 'spacewalk-debug --dir /tmp/sos.PKdPAS/sosreport-rhn-support-jfoots-20170405132739/sos_commands/satellite/spacewalk-debug' timed out after 300s

[..SNIP..]

Creating compressed archive...
Traceback (most recent call last):
  File "/usr/sbin/sosreport", line 25, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1520, in main
    sos.execute()
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1499, in execute
    return self.final_work()
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1411, in final_work
    checksum = self._create_checksum(archive, hash_name)
  File "/usr/lib/python2.6/site-packages/sos/sosreport.py", line 1349, in _create_checksum
    archive_fp = open(archive, 'rb')
IOError: [Errno 2] No such file or directory: '/tmp/sos.PKdPAS/sosreport-rhn-support-jfoots-20170405132739.tar.xz'

real    60m6.624s
user    12m25.001s
sys     10m39.263s
```

To address this issue, there are 2 possible situations:
    1) increase the timeout value (> 300 seconds) however it may not fix the problem on cases where data is huge (see PR#989 -> https://github.com/sosreport/sos/pull/989)
    2) modify the spacewalk-debug code to enhance its performance (this PR).

  Just executing spacewalk-debug by itself on the same box we can see considerable changes:
        
   * without patch
```bash
[root@orbital ~]# time /usr/bin/spacewalk-debug 
Collecting and packaging relevant diagnostic information.
Warning: this may take some time...
    * copying configuration information
[...SNIP...]

-- +31 minutes (still going) to generate the tarball
 PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND                                            
19142 root      20   0 13512 7912  468 R 100.0  0.0  31:21.31 bzip2   
````
* with this patch
```bash
[root@orbital ~]# time ~/spacewalk-debug 
Collecting and packaging relevant diagnostic information.
 Warning: this may take some time...
    * copying configuration information
    * copying logs
Debug dump created, stored in /tmp/spacewalk-debug.tar.bz2

real	7m25.887s
user	5m22.079s
sys	0m23.699s
```

Basically, this patch makes sure to gzip the PostgreSQL logs which increase dramatically the speed when generating the tarball. 