### PR TITLE
Add password config option to rhncfg-manager.

### DIFF
--- a/client/tools/rhncfg/config_common/handler_base.py
+++ b/client/tools/rhncfg/config_common/handler_base.py
@@ -62,8 +62,10 @@ class HandlerBase:
             if not username :
                 username=local_config.get('username')
             if not password :
-               (username, password) = self.get_auth_info(username)
+                password=local_config.get('password')
 
+            if not password :
+                (username, password) = self.get_auth_info(username)
             try:
                 self.repository.login(username=username, password=password)
             except cfg_exceptions.InvalidSession:

--- a/client/tools/rhncfg/config_management/rhncfg-manager.sgml
+++ b/client/tools/rhncfg/config_management/rhncfg-manager.sgml
@@ -45,7 +45,7 @@
 <para>
     This tool is intended for use by the Config Administrator and therefore
     requires an &RHN; username and password that has the appropriate permission
-    set. (The username may be specified in
+    set. (The username and password may be specified in
     <filename>/etc/sysconfig/rhn/rhncfg-manager.conf</filename> or in the [rhncfg-manager] section
     of <filename>~/.rhncfgrc</filename>).
 </para>
@@ -270,6 +270,7 @@
     <member>Mihai Ibanescu <email>misa@redhat.com</email></member>
     <member>Bret McMillan <email>bretm@redhat.com</email></member>
     <member>Todd Warner <email>taw@redhat.com</email> (man page only)</member>
+    <member>Laurence Rochfort <email>laurence.rochfort@oracle.com</email></member>
 </simplelist>
 </RefSect1>
 </RefEntry>


### PR DESCRIPTION
According to https://access.redhat.com/solutions/489553 this feature was being tracked by an internal RFE for Satellite 5.6 back to 2013, but has never seemed to hit the codebase.

This change allows users to add a password option to either /etc/sysconfig/rhn/rhncfg-manager.conf or ~/.rhncfgrc under the [rhncfg-manager] section, as requested.

Signed-off-by: Laurence Rochfort <laurence.rochfort@oracle.com>