### PR TITLE
Fix: hide non-org event details

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2011,7 +2011,7 @@ select event_id as id,
        all_events.history_type_name,
        all_events.history_status,
        case when action_details.org_id != :oid then 0
-         else 1 end as details_visible
+         else 1 end as history_visible
   from (select SH.id event_id,
                SH.summary summary,
                to_timestamp(NULL, NULL) as created,

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2001,15 +2001,17 @@ select s.id as id,
 
 <mode name="system_events_history"
   class="com.redhat.rhn.frontend.dto.SystemEventDto">
-  <query params="sid">
+  <query params="sid, oid">
 select event_id as id,
-       to_char(created, 'YYYY-MM-DD HH24:MI:SS') created,
-       to_char(picked_up, 'YYYY-MM-DD HH24:MI:SS') picked_up,
-       to_char(completed, 'YYYY-MM-DD HH24:MI:SS') completed,
-       summary,
-       history_type,
-       history_type_name,
-       history_status
+       to_char(all_events.created, 'YYYY-MM-DD HH24:MI:SS') created,
+       to_char(all_events.picked_up, 'YYYY-MM-DD HH24:MI:SS') picked_up,
+       to_char(all_events.completed, 'YYYY-MM-DD HH24:MI:SS') completed,
+       all_events.summary,
+       all_events.history_type,
+       all_events.history_type_name,
+       all_events.history_status,
+       case when action_details.org_id != :oid then 0
+         else 1 end as details_visible
   from (select SH.id event_id,
                SH.summary summary,
                to_timestamp(NULL, NULL) as created,
@@ -2040,8 +2042,10 @@ select event_id as id,
            and ATYPE.id = A.action_type
            and AStat.id = SA.status
            and AStat.id IN (1, 2, 3)
-       ) X
-order by completed desc, picked_up desc, created desc, event_id desc
+       ) all_events
+  left join rhnaction action_details on event_id = action_details.id
+order by completed desc, picked_up desc, all_events.created desc, event_id desc
+
   </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryAction.java
@@ -61,8 +61,10 @@ public class SystemHistoryAction extends RhnAction implements Listable<SystemEve
     }
 
     /** {@inheritDoc} */
+    @Override
     public List<SystemEventDto> getResult(RequestContext context) {
         Long sid = context.getRequiredParam("sid");
-        return SystemManager.systemEventHistory(sid, null);
+        Long oid = context.getCurrentUser().getOrg().getId();
+        return SystemManager.systemEventHistory(sid, oid, null);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemEventDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemEventDto.java
@@ -42,6 +42,7 @@ public class SystemEventDto extends BaseDto implements Serializable {
     protected String historyTypeName;
     private String historyStatus;
     protected static final Map<String, String> ACTIONTYPES;
+    private boolean historyVisible;
 
     static {
         ACTIONTYPES = new HashMap<String, String>();
@@ -217,6 +218,20 @@ public class SystemEventDto extends BaseDto implements Serializable {
      */
     public void setHistoryStatus(String historyStatusIn) {
         this.historyStatus = historyStatusIn;
+    }
+
+    /**
+     * @return if details of this event will be visible
+     */
+    public boolean isHistoryVisible() {
+        return historyVisible;
+    }
+
+    /**
+     * @param historyVisibleIn to set if details of this event will be visible
+     */
+    public void setHistoryVisible(boolean historyVisibleIn) {
+        this.historyVisible = historyVisibleIn;
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -11038,6 +11038,9 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
         <trans-unit id="system.event.history.headerPending">
           <source>Please note that this system has &lt;a href="{0}"&gt;{1} pending event(s)&lt;/a&gt;.</source>
         </trans-unit>
+        <trans-unit id="system.event.history.actionsWithoutDetails">
+          <source>Events marked with a star (*) happened within a different organization: migrate the system back to the original organization to access event details.</source>
+        </trans-unit>
         <trans-unit id="system.event.history.noevent">
           <source>No event history for this system.</source>
         </trans-unit>

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2893,13 +2893,17 @@ public class SystemManager extends BaseManager {
 
     /**
      * @param sid server id
+     * @param oid organization id
      * @param pc pageContext
      * @return Returns history events for a system
      */
-    public static DataResult<SystemEventDto> systemEventHistory(Long sid, PageControl pc) {
+    public static DataResult<SystemEventDto> systemEventHistory(Long sid, Long oid,
+            PageControl pc) {
         SelectMode m = ModeFactory.getMode("System_queries", "system_events_history");
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("sid", sid);
+        params.put("oid", oid);
+
         Map<String, Object> elabParams = new HashMap<String, Object>();
         return makeDataResult(params, elabParams, pc, m, SystemEventDto.class);
     }

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/history.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/history.jsp
@@ -7,77 +7,84 @@
 
 <html>
 
-<body>
+    <body>
 
-<%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
+        <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
 
-<rhn:toolbar base="h2" icon="header-event-history">
-  <bean:message key="system.event.history.header" />
-</rhn:toolbar>
+        <rhn:toolbar base="h2" icon="header-event-history">
+            <bean:message key="system.event.history.header" />
+        </rhn:toolbar>
 
-<div class="page-summary">
-  <bean:message key="system.event.history.headerSummary" />
-  <br/>
-  <c:choose>
-    <c:when test="${param.pendingActions != 0}">
-      <bean:message key="system.event.history.headerPending" arg0="/rhn/systems/details/history/Pending.do?sid=${fn:escapeXml(param.sid)}" arg1="${fn:escapeXml(param.pendingActions)}" />
-      <c:if test="${param.isLocked == true}">
-        <br/>
-        <bean:message key="system.event.history.locked" arg0="/rhn/systems/details/Overview.do?sid=${fn:escapeXml(param.sid)}" />
-      </c:if>
-    </c:when>
-    <c:otherwise>
-      <bean:message key="system.event.history.headerNoPending" />
-    </c:otherwise>
-  </c:choose>
-</div>
+        <div class="page-summary">
+            <bean:message key="system.event.history.headerSummary" />
+            <br/>
+            <c:choose>
+                <c:when test="${param.pendingActions != 0}">
+                    <bean:message key="system.event.history.headerPending" arg0="/rhn/systems/details/history/Pending.do?sid=${fn:escapeXml(param.sid)}" arg1="${fn:escapeXml(param.pendingActions)}" />
+                    <c:if test="${param.isLocked == true}">
+                        <br/>
+                        <bean:message key="system.event.history.locked" arg0="/rhn/systems/details/Overview.do?sid=${fn:escapeXml(param.sid)}" />
+                    </c:if>
+                </c:when>
+                <c:otherwise>
+                    <bean:message key="system.event.history.headerNoPending" />
+                </c:otherwise>
+            </c:choose>
+            <bean:message key="system.event.history.actionsWithoutDetails" />
+        </div>
 
-<rl:listset name="eventSet" legend="system-history">
-  <rhn:csrf />
-  <rhn:hidden name="sid" value="${param.sid}" />
-  <rl:list emptykey="system.event.history.noevent">
-    <rl:decorator name="PageSizeDecorator" />
-    <rl:decorator name="ElaborationDecorator" />
-    <rl:column headerkey="system.event.history.type">
-      <c:choose>
-        <c:when test="${current.historyType == 'event-type-package'}">
-          <rhn:icon type="event-type-package" />
-        </c:when>
-        <c:when test="${current.historyType == 'event-type-preferences'}">
-          <rhn:icon type="event-type-errata" />
-        </c:when>
-        <c:when test="${current.historyType == 'event-type-errata'}">
-          <rhn:icon type="event-type-errata" />
-        </c:when>
-        <c:otherwise>
-          <rhn:icon type="event-type-system" />
-        </c:otherwise>
-      </c:choose>
-    </rl:column>
-    <rl:column headerkey="system.event.history.status">
-      <c:choose>
-        <c:when test="${current.historyStatus == 'Completed'}">
-          <rhn:icon type="action-ok" />
-        </c:when>
-        <c:when test="${current.historyStatus == 'Failed'}">
-          <rhn:icon type="action-failed" />
-        </c:when>
-        <c:when test="${current.historyStatus == 'Picked Up'}">
-          <rhn:icon type="action-running" />
-        </c:when>
-        <c:otherwise>
-          ${current.historyStatus}
-        </c:otherwise>
-      </c:choose>
-    </rl:column>
-    <rl:column headerkey="system.event.history.summary">
-      <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&amp;aid=${current.id}">${current.summary}</a>
-    </rl:column>
-    <rl:column headerkey="system.event.history.time">
-      ${current.completed}
-    </rl:column>
-  </rl:list>
-</rl:listset>
-
-</body>
+        <rl:listset name="eventSet" legend="system-history">
+            <rhn:csrf />
+            <rhn:hidden name="sid" value="${param.sid}" />
+            <rl:list emptykey="system.event.history.noevent">
+                <rl:decorator name="PageSizeDecorator" />
+                <rl:decorator name="ElaborationDecorator" />
+                <rl:column headerkey="system.event.history.type">
+                    <c:choose>
+                        <c:when test="${current.historyType == 'event-type-package'}">
+                            <rhn:icon type="event-type-package" />
+                        </c:when>
+                        <c:when test="${current.historyType == 'event-type-preferences'}">
+                            <rhn:icon type="event-type-errata" />
+                        </c:when>
+                        <c:when test="${current.historyType == 'event-type-errata'}">
+                            <rhn:icon type="event-type-errata" />
+                        </c:when>
+                        <c:otherwise>
+                            <rhn:icon type="event-type-system" />
+                        </c:otherwise>
+                    </c:choose>
+                </rl:column>
+                <rl:column headerkey="system.event.history.status">
+                    <c:choose>
+                        <c:when test="${current.historyStatus == 'Completed'}">
+                            <rhn:icon type="action-ok" />
+                        </c:when>
+                        <c:when test="${current.historyStatus == 'Failed'}">
+                            <rhn:icon type="action-failed" />
+                        </c:when>
+                        <c:when test="${current.historyStatus == 'Picked Up'}">
+                            <rhn:icon type="action-running" />
+                        </c:when>
+                        <c:otherwise>
+                            ${current.historyStatus}
+                        </c:otherwise>
+                    </c:choose>
+                </rl:column>
+                <rl:column headerkey="system.event.history.summary">
+                    <c:choose>
+                        <c:when test="${current.detailsVisible}">
+                            <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&amp;aid=${current.id}">${current.summary}</a>
+                        </c:when>
+                        <c:otherwise>
+                            ${current.summary} *
+                        </c:otherwise>
+                    </c:choose>
+                </rl:column>
+                <rl:column headerkey="system.event.history.time">
+                    ${current.completed}
+                </rl:column>
+            </rl:list>
+        </rl:listset>
+    </body>
 </html>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/history.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/history.jsp
@@ -73,7 +73,7 @@
                 </rl:column>
                 <rl:column headerkey="system.event.history.summary">
                     <c:choose>
-                        <c:when test="${current.detailsVisible}">
+                        <c:when test="${current.historyVisible}">
                             <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&amp;aid=${current.id}">${current.summary}</a>
                         </c:when>
                         <c:otherwise>


### PR DESCRIPTION
When a server is migrated from an organization to another organization,
its associated actions are tied to the original org.
If user tries to show event details for "migrated" events, will get an
ISE, as:

https://github.com/spacewalkproject/spacewalk/blob/f4c8ad60fdd9dc7b8f40861287be4ab6933a70eb/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java#L62

will return null.

This patch fixes the problem by not displaying a link to show event
details for all the events that does not belong to the organization
linked to the user who is visiting the page.

Signed-off-by: Michele Bologna <michele.bologna@gmail.com>