### PR TITLE
Persistence of the current set

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesAction.java
@@ -63,13 +63,6 @@ public abstract class BaseSystemPackagesAction extends RhnAction {
 
         Set<String> sessionSet = SessionSetHelper.lookupAndBind(request, getDecl(sid));
 
-        //if its not submitted
-        // ==> this is the first visit to this page
-        // clear the 'dirty set'
-        if (!requestContext.isSubmitted()) {
-            sessionSet.clear();
-        }
-
         SessionSetHelper helper = new SessionSetHelper(request);
 
         if (request.getParameter("dispatch") != null) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
@@ -81,7 +81,7 @@ public class ErrataSetupAction extends RhnAction implements Listable {
         help.setListName(LIST_NAME);
         String parentURL = request.getRequestURI() + "?sid=" + sid;
         help.setParentUrl(parentURL);
-
+        help.setWillClearSet(false);
         help.execute();
 
         if (help.isDispatched()) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
@@ -67,20 +67,15 @@ public class ErrataSetupAction extends RhnAction implements Listable {
 
     public static final String SELECTOR = "type";
 
-
-
     /** {@inheritDoc} */
-    public ActionForward execute(ActionMapping mapping,
-                                 ActionForm formIn,
-                                 HttpServletRequest request,
-                                 HttpServletResponse response) {
+    @Override
+    public ActionForward execute(ActionMapping mapping, ActionForm formIn,
+            HttpServletRequest request, HttpServletResponse response) {
 
         RequestContext requestContext = new RequestContext(request);
         User user = requestContext.getCurrentUser();
         Long sid = requestContext.getRequiredParam("sid");
         RhnSet set = getSetDecl(sid).get(user);
-
-
 
         ListRhnSetHelper help = new ListRhnSetHelper(this, request, getSetDecl(sid));
         help.setListName(LIST_NAME);
@@ -95,17 +90,11 @@ public class ErrataSetupAction extends RhnAction implements Listable {
             }
         }
 
-
         String showButton = "true";
         // Show the "Apply Errata" button only when unapplied errata exist:
         if (!SystemManager.hasUnscheduledErrata(user, sid)) {
            showButton = "false";
         }
-
-
-
-
-
 
         Map params =  new HashMap();
         Set keys = request.getParameterMap().keySet();
@@ -133,36 +122,31 @@ public class ErrataSetupAction extends RhnAction implements Listable {
      * @return the map for the combo
      */
     protected List<Map<String, Object>> getComboList(HttpServletRequest request) {
-
         String selected = request.getParameter(SELECTOR);
-
-        List<Map<String, Object>> combo = new ArrayList<Map<String, Object>>();
-
+        List<Map<String, Object>> combo = new ArrayList<>();
         LocalizationService ls = LocalizationService.getInstance();
 
-
-        Map<String, Object> tmp = new HashMap<String, Object>();
+        Map<String, Object> tmp = new HashMap<>();
         tmp.put("name", ALL);
         tmp.put("id", ALL);
         tmp.put("default", ls.getMessage(ALL).equals(selected));
 
-        Map<String, Object> tmp1 = new HashMap<String, Object>();
+        Map<String, Object> tmp1 = new HashMap<>();
         tmp1.put("name", NON_CRITICAL);
         tmp1.put("id", NON_CRITICAL);
         tmp1.put("default",  ls.getMessage(NON_CRITICAL).equals(selected));
 
-
-        Map<String, Object> tmp2 = new HashMap<String, Object>();
+        Map<String, Object> tmp2 = new HashMap<>();
         tmp2.put("name", BUGFIX);
         tmp2.put("id", BUGFIX);
         tmp2.put("default",  ls.getMessage(BUGFIX).equals(selected));
 
-        Map<String, Object> tmp3 = new HashMap<String, Object>();
+        Map<String, Object> tmp3 = new HashMap<>();
         tmp3.put("name", ENHANCE);
         tmp3.put("id", ENHANCE);
         tmp3.put("default",  ls.getMessage(ENHANCE).equals(selected));
 
-        Map<String, Object> tmp4 = new HashMap<String, Object>();
+        Map<String, Object> tmp4 = new HashMap<>();
         tmp4.put("name", SECUR);
         tmp4.put("id", SECUR);
         tmp4.put("default",  ls.getMessage(SECUR).equals(selected));
@@ -173,7 +157,6 @@ public class ErrataSetupAction extends RhnAction implements Listable {
         combo.add(tmp3);
         combo.add(tmp4);
         return combo;
-
     }
 
 
@@ -185,18 +168,14 @@ public class ErrataSetupAction extends RhnAction implements Listable {
      * @param response ServletResponse
      * @return The ActionForward to go to next.
      */
-    public ActionForward applyErrata(ActionMapping mapping,
-                                     ActionForm formIn,
-                                     HttpServletRequest request,
-                                     HttpServletResponse response) {
+    public ActionForward applyErrata(ActionMapping mapping, ActionForm formIn,
+            HttpServletRequest request, HttpServletResponse response) {
 
-        Map<String, Object> params = new HashMap<String, Object>();
-
+        Map<String, Object> params = new HashMap<>();
         RequestContext requestContext = new RequestContext(request);
         StrutsDelegate strutsDelegate = getStrutsDelegate();
         //if they chose errata, send them to the confirmation page
         Long sid = requestContext.getParamAsLong("sid");
-
         User user = requestContext.getCurrentUser();
         RhnSet set = getSetDecl(sid).get(user);
 
@@ -234,7 +213,6 @@ public class ErrataSetupAction extends RhnAction implements Listable {
      * TODO: was private
      */
     protected Map makeParamMap(ActionForm form, HttpServletRequest request) {
-
         RequestContext rctx = new RequestContext(request);
         Map params = rctx.makeParamMapWithPagination();
         Long sid = new RequestContext(request).getParamAsLong("sid");
@@ -250,7 +228,7 @@ public class ErrataSetupAction extends RhnAction implements Listable {
      * @return a list of types to get
      */
     protected List<String> getTypes(String type) {
-        List<String> typeList = new ArrayList<String>();
+        List<String> typeList = new ArrayList<>();
         LocalizationService ls = LocalizationService.getInstance();
 
         if (ls.getMessage(BUGFIX).equals(type)) {
@@ -279,6 +257,7 @@ public class ErrataSetupAction extends RhnAction implements Listable {
      *
      * {@inheritDoc}
      */
+    @Override
     public List getResult(RequestContext context) {
          User user = context.getCurrentUser();
          Long sid = context.getRequiredParam("sid");
@@ -318,5 +297,4 @@ public class ErrataSetupAction extends RhnAction implements Listable {
         List<String> typeList = getTypes(type);
         return SystemManager.relevantErrata(user, sid, typeList);
     }
-
 }

--- a/java/code/webapp/WEB-INF/pages/systems/errata.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/errata.jsp
@@ -14,137 +14,113 @@
 <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
 
 <h2>
-  <rhn:icon type="header-errata" title="errata.common.errataAlt" />
-  <bean:message key="errata.jsp.header"/>
+    <rhn:icon type="header-errata" title="errata.common.errataAlt" />
+    <bean:message key="errata.jsp.header"/>
 </h2>
 
-  <div class="page-summary">
-    <p>
-    <bean:message key="errata.jsp.summary"/>
-    </p>
-  </div>
+<div class="page-summary">
+    <p><bean:message key="errata.jsp.summary"/></p>
+</div>
 
 <c:set var="pageList" value="${requestScope.pageList}" />
 
 <rl:listset name="errataListSet" legend="errata">
-<rhn:csrf />
-<rhn:submitted />
-
-        <br/>
-        <select name="type">
-                <c:forEach items="${combo}" var="item">
-                        <option id="${item.id}"
-                                <c:if test="${item['default']}"> selected</c:if>
-                                >  <bean:message key="${item.name}"/>
-                        </option>
-                </c:forEach>
-        </select>
-        <html:submit styleClass="btn btn-default" property="show">
-                <bean:message key="system.errata.show"/>
-        </html:submit>
-        <br/>
-
-
-        <rl:list
-         width="100%"
-         name="errataList"
-         styleclass="list"
-         emptykey="erratalist.jsp.norelevanterrata"
-         alphabarcolumn="advisorySynopsis">
-
+    <rhn:csrf />
+    <rhn:submitted />
+    <br/>
+    <select name="type">
+        <c:forEach items="${combo}" var="item">
+            <option id="${item.id}" <c:if test="${item['default']}"> selected</c:if>>
+                <bean:message key="${item.name}"/>
+            </option>
+        </c:forEach>
+    </select>
+    <html:submit styleClass="btn btn-default" property="show">
+        <bean:message key="system.errata.show"/>
+    </html:submit>
+    <br/>
+    <rl:list
+            width="100%"
+            name="errataList"
+            styleclass="list"
+            emptykey="erratalist.jsp.norelevanterrata"
+            alphabarcolumn="advisorySynopsis">
         <rl:decorator name="ElaborationDecorator"/>
-                <rl:decorator name="PageSizeDecorator"/>
-
-                <c:if test="${requestScope.showApplyErrata == 'false'}">
-                        <rl:column headerkey="emptyspace.jsp"  styleclass="text-align: center;">
-                        <rhn:icon type="action-pending" />
+        <rl:decorator name="PageSizeDecorator"/>
+        <c:if test="${requestScope.showApplyErrata == 'false'}">
+            <rl:column headerkey="emptyspace.jsp"  styleclass="text-align: center;">
+                <rhn:icon type="action-pending" />
             </rl:column>
-                </c:if>
-
-                <c:if test="${requestScope.showApplyErrata == 'true'}">
-                        <rl:decorator name="SelectableDecorator"/>
-                        <rl:selectablecolumn value="${current.id}"
-                                selected="${current.selected}"
-                                disabled="${not current.selectable}"/>
-                </c:if>
-
-                  <rl:column headerkey="erratalist.jsp.type" styleclass="text-align: center;"
-                        bound="false">
-                      <c:if test="${current.securityAdvisory}">
-                        <rhn:icon type="errata-security" />
-                      </c:if>
-                      <c:if test="${current.bugFix}">
-                        <rhn:icon type="errata-bugfix" />
-                      </c:if>
-                      <c:if test="${current.productEnhancement}">
-                        <rhn:icon type="errata-enhance" />
-                      </c:if>
-                  </rl:column>
-
-                  <rl:column headerkey="erratalist.jsp.advisory" bound="false"
-                        sortattr="advisoryName"
-                        sortable="true">
-                      <a href="/rhn/errata/details/Details.do?eid=${current.id}">
-                        ${current.advisoryName}</a>
-                  </rl:column>
-
-                  <rl:column headerkey="erratalist.jsp.synopsis" bound="false"
-                        sortattr="advisorySynopsis"
-                        sortable="true"
-                        filterattr="advisorySynopsis">
-                      ${current.advisorySynopsis}
-                  </rl:column>
-
-                  <rl:column headerkey="errata.jsp.status" bound="false"
-                        sortattr="currentStatusAndActionId[0]"
-                        sortable="true">
-                      <c:if test="${not empty current.status}">
-                         <c:if test="${current.currentStatusAndActionId[0] == 'Queued'}">
-                            <a href="/rhn/schedule/ActionDetails.do?aid=${current.currentStatusAndActionId[1]}">
-                              <bean:message key="affectedsystems.jsp.pending"/></a>
-                         </c:if>
-                         <c:if test="${current.currentStatusAndActionId[0] == 'Failed'}">
-                            <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&aid=${current.currentStatusAndActionId[1]}">
-                              <bean:message key="actions.jsp.failed"/></a>
-                         </c:if>
-                         <c:if test="${current.currentStatusAndActionId[0] == 'Picked Up'}">
-                            <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&aid=${current.currentStatusAndActionId[1]}">
-                              <bean:message key="actions.jsp.pickedup"/></a>
-                         </c:if>
-                      </c:if>
-                      <c:if test="${empty current.status}">
-                            <bean:message key="affectedsystems.jsp.none"/>
-                      </c:if>
-                  </rl:column>
-
-                  <rl:column headerkey="erratalist.jsp.updated" bound="false"
-                        sortattr="updateDateObj"
-                        sortable="true"
-                        defaultsort="desc">
-                      ${current.updateDate}
-                  </rl:column>
-
-        </rl:list>
-
-        <c:if test="${requestScope.showApplyErrata == 'true'}">
-                <div class="text-right">
-                <hr />
-                <html:submit styleClass="btn btn-success" property="dispatch">
-                        <bean:message key="errata.jsp.apply"/>
-                </html:submit>
-                </div>
         </c:if>
-
-
         <c:if test="${requestScope.showApplyErrata == 'true'}">
-                <rl:csv
-                        name="errataList"
-                        exportColumns="associatedSystem,errataAdvisoryType,advisoryName,advisorySynopsis,errataStatus,updateDate"
-                        header="${system.name}"/>
+            <rl:decorator name="SelectableDecorator"/>
+            <rl:selectablecolumn value="${current.id}"
+                    selected="${current.selected}"
+                    disabled="${not current.selectable}"/>
         </c:if>
-        <rhn:submitted/>
+        <rl:column headerkey="erratalist.jsp.type"
+                styleclass="text-align: center;" bound="false">
+            <c:if test="${current.securityAdvisory}">
+                <rhn:icon type="errata-security" />
+            </c:if>
+            <c:if test="${current.bugFix}">
+                <rhn:icon type="errata-bugfix" />
+            </c:if>
+            <c:if test="${current.productEnhancement}">
+                <rhn:icon type="errata-enhance" />
+            </c:if>
+        </rl:column>
+        <rl:column headerkey="erratalist.jsp.advisory" bound="false"
+                sortattr="advisoryName" sortable="true">
+            <a href="/rhn/errata/details/Details.do?eid=${current.id}">
+                ${current.advisoryName}
+            </a>
+        </rl:column>
+        <rl:column headerkey="erratalist.jsp.synopsis" bound="false"
+                sortattr="advisorySynopsis" sortable="true"
+                filterattr="advisorySynopsis">
+            ${current.advisorySynopsis}
+        </rl:column>
+        <rl:column headerkey="errata.jsp.status" bound="false"
+                sortattr="currentStatusAndActionId[0]" sortable="true">
+            <c:if test="${not empty current.status}">
+                <c:if test="${current.currentStatusAndActionId[0] == 'Queued'}">
+                    <a href="/rhn/schedule/ActionDetails.do?aid=${current.currentStatusAndActionId[1]}">
+                        <bean:message key="affectedsystems.jsp.pending"/>
+                    </a>
+                </c:if>
+                <c:if test="${current.currentStatusAndActionId[0] == 'Failed'}">
+                    <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&aid=${current.currentStatusAndActionId[1]}">
+                        <bean:message key="actions.jsp.failed"/>
+                    </a>
+                </c:if>
+                <c:if test="${current.currentStatusAndActionId[0] == 'Picked Up'}">
+                    <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&aid=${current.currentStatusAndActionId[1]}">
+                        <bean:message key="actions.jsp.pickedup"/>
+                    </a>
+                </c:if>
+            </c:if>
+            <c:if test="${empty current.status}">
+                <bean:message key="affectedsystems.jsp.none"/>
+            </c:if>
+        </rl:column>
+        <rl:column headerkey="erratalist.jsp.updated" bound="false"
+                sortattr="updateDateObj" sortable="true" defaultsort="desc">
+            ${current.updateDate}
+        </rl:column>
+    </rl:list>
+    <c:if test="${requestScope.showApplyErrata == 'true'}">
+        <div class="text-right">
+            <hr />
+            <html:submit styleClass="btn btn-success" property="dispatch">
+                <bean:message key="errata.jsp.apply"/>
+            </html:submit>
+        </div>
+        <rl:csv name="errataList"
+                exportColumns="associatedSystem,errataAdvisoryType,advisoryName,advisorySynopsis,errataStatus,updateDate"
+                header="${system.name}"/>
+    </c:if>
+    <rhn:submitted/>
 </rl:listset>
-
-
 </body>
 </html>


### PR DESCRIPTION
Problem: when selecting an errata or a package for a system from the list, reloading the page or going away from it will delete the selection. This is not compliant with the `rhnSet` behavior for *errata_list* (for instance *system_list* is always persistent), but also for *package*s that the user selects and store in the session: the expected behavior should be to have that selection persistent.

Fixes of this patch:
- do not clear `rhnSet` table for `errata` but keep selection persistent loading the list page e502d76fd5eb3310594a49955629ab7491118f95
- do not clear `session set` for `packages` but keep selection persistent loading the list pages b2958b81ef1a86523a784f1a32e9b1bd1871dc82

Pages affected:
- [ ] `/rhn/systems/details/ErrataList.do`
- [x] `/rhn/systems/details/packages/PackageList.do`
- [x] `/rhn/systems/details/packages/UpgradableList.do`
- [x] `/rhn/systems/details/packages/InstallPackages.do`
- [x] `/rhn/systems/details/packages/VerifyPackages.do`
- [x] `/rhn/systems/details/packages/ExtraPackagesList.do`

@grinrag : can you please take a look? Do you have any clue why it was implemented like this lack of persistence with the *clear-on-refresh* mechanism? Thank you in advance.