### PR TITLE
Duplicate Systems: correct language not to mention 'profiles'

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -5283,10 +5283,10 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/DuplicateIPList.do pages</context>
         </context-group>
         <trans-unit id="duplicates.jsp.header">
-          <source>Duplicate System Profiles</source>
+          <source>Duplicate Systems</source>
         </trans-unit>
         <trans-unit id="duplicate.jsp.message">
-          <source>Inactive system profiles are highlighted below.</source>
+          <source>Inactive systems are listed below.</source>
         </trans-unit>
         <trans-unit id="Delete Selected">
           <source>Delete Selected</source>
@@ -20429,7 +20429,7 @@ given channel.</source>
         <source>6 Month</source>
       </trans-unit>
       <trans-unit id="duplicate-ip.jsp.inactive.header">
-        <source>A system profile is inactive if its system has not checked in for:</source>
+        <source>A system is inactive if its system has not checked in for:</source>
       </trans-unit>
       <trans-unit id="schedule.header">
         <source>Select a schedule:</source>


### PR DESCRIPTION
We feel it's clearer to just use "systems" in this page, rather than mixing "systems" (in the table) and "system profiles" (in title and description).