### PR TITLE
Use ErrorStatusFilter in case of error and clean up UI messages

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/ErrorStatusFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/ErrorStatusFilter.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.frontend.servlets;
 
+import org.apache.struts.Globals;
+
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -43,6 +45,10 @@ public class ErrorStatusFilter implements Filter {
         }
         else if (httpRequest.getRequestURI().endsWith("/500.jsp")) {
             httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+            // Drop all messages from the request and session
+            httpRequest.removeAttribute(Globals.MESSAGE_KEY);
+            httpRequest.getSession().removeAttribute(Globals.MESSAGE_KEY);
         }
 
         chain.doFilter(request, response);

--- a/java/code/src/com/redhat/rhn/frontend/servlets/SessionFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SessionFilter.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.servlets;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.HibernateRuntimeException;
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.common.LoggingFactory;
 
 import org.apache.log4j.Logger;
@@ -73,6 +74,8 @@ private static final String ROLLBACK_MSG = "Error during transaction. Rolling ba
         }
         catch (RuntimeException e) {
             LOG.error(ROLLBACK_MSG, e);
+            request.setAttribute("exception", LocalizationService.getInstance()
+                    .getMessage("errors.unexpected"));
             throw e;
         }
         catch (AssertionError e) {

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -298,6 +298,12 @@
           <context context-type="paramnotes">Count must be a double.</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="errors.unexpected">
+        <source>An unexpected error has occurred during the request.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Any page where an unexpected error occurred.</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="toolbar.jsp.helpicon.alt">
         <source>Help Icon</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/MessagesTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/MessagesTag.java
@@ -64,7 +64,7 @@ public class MessagesTag extends TagSupport {
         try {
             out = pageContext.getOut();
             out.print(baseTag.renderCloseTag());
-            removeMessagesFromSession(out);
+            removeMessagesFromSession();
             return (EVAL_PAGE);
         }
         catch (Exception e) {
@@ -72,7 +72,7 @@ public class MessagesTag extends TagSupport {
         }
     }
 
-    private void removeMessagesFromSession(JspWriter out) {
+    private void removeMessagesFromSession() {
         HttpServletRequest request = (HttpServletRequest)pageContext.getRequest();
         HttpSession session = request.getSession();
         session.removeAttribute(Globals.MESSAGE_KEY);

--- a/java/code/webapp/WEB-INF/decorators/layout_c.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_c.jsp
@@ -41,6 +41,11 @@
           <html:messages id="message" message="true">
             <rhn:messages><c:out escapeXml="false" value="${message}" /></rhn:messages>
           </html:messages>
+          <c:if test="${ not empty exception }">
+            <div class="alert alert-danger">
+              <c:out value="${exception}"/>
+            </div>
+          </c:if>
           <decorator:body />
         </section>
       </div>

--- a/java/code/webapp/WEB-INF/web.xml
+++ b/java/code/webapp/WEB-INF/web.xml
@@ -150,6 +150,8 @@
   <filter-mapping>
     <filter-name>ErrorStatusFilter</filter-name>
     <url-pattern>/errors/*</url-pattern>
+    <dispatcher>request</dispatcher>
+    <dispatcher>error</dispatcher>
   </filter-mapping>
 
   <!--


### PR DESCRIPTION
It can happen that after the `client request` is completed with success, something else in the back-end fails: this leads to an inconsistent page with some *success message* about the `request` and **at the same time** an `ISE` page content.

Inconsistent UI:
![screenshot from 2017-06-22 09-48-16](https://user-images.githubusercontent.com/7080830/27906831-71c6767a-6245-11e7-800c-047c7eb5e828.png)


This can be caused, for instance, in `/rhn/systems/customdata/CreateCustomKey.do` page using a too long sized string as a value for the `input` or `textarea`. Nothing will fail for the `client request` since adding a very long `String` in an `Hibernate Object` is not a problem. The `error` will be raised up as soon as [Hibernate commit a transaction](https://github.com/spacewalkproject/spacewalk/blob/master/java/code/src/com/redhat/rhn/frontend/servlets/SessionFilter.java#L58), the Database will fail `throwing` an `Exception` after the `response` is already completed, containing *success messages*.

The purpose of this PR is to
 - [activate the ErrorStatusFilter.java](https://github.com/ncounter/spacewalk/commit/8bf1aeb0daeea628918c85bdb808161b1fdf745f#diff-12d666402bb5c2b88d32e3d57ac18db6R154)
- [clean up success messages to prevent showing them in the UI](https://github.com/ncounter/spacewalk/commit/f49dda7fa7501e6c681e4dc73a8ee70b14f81dda#diff-8e5e591f11c105ac2bbf0466e1ba4d92R50)
- [add a custom generic message about the occurred exception](https://github.com/ncounter/spacewalk/commit/b10345cfeab524fdc5a31faef2ea0d3b9652621a#diff-bc8cde1cf0e011dde44e0965b7abf054R77)


UI after this patch:
![screenshot from 2017-07-04 13-38-24](https://user-images.githubusercontent.com/7080830/27906900-b3db82da-6245-11e7-92a8-72bf810321e9.png)

