### PR TITLE
Initialize prefix property in build.xml for install-tomcat target

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -850,6 +850,10 @@ delete from rhnChannel where label like 'ChannelLabel%';
 
   <target name="install-tomcat">
        <property name="webapp-dir" value="/var/lib/tomcat/webapps/" />
+    <!--
+     - initializing prefix otherwise webapp is not copied to tomcat directory
+     -->
+       <property name="prefix" value="" />
        <echo message="${prefix}" />
        <echo message="${webapp-dir}" />
        <antcall target="install" />


### PR DESCRIPTION
Initializing prefix property for install-tomcat target so that compiled webapp gets copied into tomcat directory. This fix is for Poor Man's Dev Workstation compilation (Webapplication).

Signed-off-by: bhavesh_bharadiya <bhavesh_bharadiya@dell.com>