### PR TITLE
Enhanced documentation for Taskomatic memory variables in rhn.conf 

### DIFF
--- a/spacewalk/config/usr/share/man/man5/rhn.conf.5
+++ b/spacewalk/config/usr/share/man/man5/rhn.conf.5
@@ -215,11 +215,18 @@ then the job will be queued.
 2
 
 .TP
-.B "taskomatic.maxmemory" (integer)
+.B "taskomatic.java.maxmemory" (integer)
 The maximum amount of memory (MB) that Taskomatic can use. If you find that Taskomatic is running out of memory, consider increasing this.
 .IP
 .B Default:
 1024
+
+.TP
+.B "taskomatic.java.initmemory" (integer)
+The initial amount of memory (MB) that Taskomatic is allocated on start-up.
+.IP
+.B Default:
+256
 
 .TP
 .B "package_import_skip_changelog" (boolean)


### PR DESCRIPTION
Corrected variables for Taskomatic memory in rhn.conf  and added documentation for taskomatic.java.initmemory. It is important for users to use the correct variables in rhn.conf when changing these settings, as these values will persist through upgrades, whereas changes made in the config-default files will not persist through upgrades.