### PR TITLE
Add spacewalk client and server repos for Fedora 25 and 26

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -585,6 +585,15 @@ gpgkey_id = %(_spacewalk_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
 yumrepo_url = http://yum.spacewalkproject.org/2.7/Fedora/25/%(arch)s/
 
+[spacewalk27-server-fedora26]
+name     = Spacewalk Server 2.7 for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = fedora26-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/2.7/Fedora/26/%(arch)s/
+
 [spacewalk27-server-oraclelinux6]
 name     = Spacewalk Server 2.7 for %(base_channel_name)s
 archs    = %(_x86_archs)s
@@ -648,6 +657,15 @@ gpgkey_id = %(_spacewalk_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
 yumrepo_url = http://yum.spacewalkproject.org/2.7-client/Fedora/25/%(arch)s/
 
+[spacewalk27-client-fedora26]
+name     = Spacewalk Client 2.7 for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = fedora26-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/2.7-client/Fedora/26/%(arch)s/
+
 [spacewalk27-client-oraclelinux6]
 name     = Spacewalk Client 2.7 for %(base_channel_name)s
 archs    = %(_x86_archs)s
@@ -665,6 +683,24 @@ gpgkey_url = %(_spacewalk_gpgkey_url)s
 gpgkey_id = %(_spacewalk_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
 yumrepo_url = http://yum.spacewalkproject.org/2.7-client/RHEL/7/%(arch)s/
+
+[spacewalk-nightly-server-fedora25]
+name     = Spacewalk Server nightly for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = fedora25-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/nightly/Fedora/25/%(arch)s/
+
+[spacewalk-nightly-server-fedora26]
+name     = Spacewalk Server nightly for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = fedora26-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/nightly/Fedora/26/%(arch)s/
 
 [spacewalk-nightly-server-centos6]
 name     = Spacewalk Server nightly for %(base_channel_name)s
@@ -710,6 +746,24 @@ gpgkey_url = %(_spacewalk_gpgkey_url)s
 gpgkey_id = %(_spacewalk_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
 yumrepo_url = http://yum.spacewalkproject.org/nightly/RHEL/7/%(arch)s/
+
+[spacewalk-nightly-client-fedora25]
+name     = Spacewalk Client nightly for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = fedora25-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/nightly-client/Fedora/25/%(arch)s/
+
+[spacewalk-nightly-client-fedora26]
+name     = Spacewalk Client nightly for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = fedora26-%(arch)s
+gpgkey_url = %(_spacewalk_gpgkey_url)s
+gpgkey_id = %(_spacewalk_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
+yumrepo_url = http://yum.spacewalkproject.org/nightly-client/Fedora/26/%(arch)s/
 
 [spacewalk-nightly-client-centos6]
 name     = Spacewalk Client nightly for %(base_channel_name)s


### PR DESCRIPTION
...omitting Fedora 26 as it is [EOL](https://fedoraproject.org/wiki/End_of_life) now.
In my opinion, this commit should be cherry-picked into SPACEWALK-2.7 branch.