### PR TITLE
Unquote possibly quoted url

### DIFF
--- a/spec-tree/cobbler20/cobbler-unquote-possibly-quoted-url.patch
+++ b/spec-tree/cobbler20/cobbler-unquote-possibly-quoted-url.patch
@@ -1,0 +1,18 @@
+diff -Naur cobbler-2.0.11.orig/scripts/services.wsgi cobbler-2.0.11/scripts/services.wsgi
+--- cobbler-2.0.11.orig/scripts/services.wsgi	2017-09-01 10:34:10.372509105 +0200
++++ cobbler-2.0.11/scripts/services.wsgi	2017-09-01 10:40:57.217564364 +0200
+@@ -22,12 +22,13 @@
+ import yaml
+ import os
+ import xmlrpclib
++import urllib
+ 
+ from cobbler.services import CobblerSvc
+ 
+ def application(environ, start_response):
+ 
+-    my_uri = environ['REQUEST_URI']
++    my_uri = urllib.unquote(environ['REQUEST_URI'])
+     
+     form = {}
+ 

--- a/spec-tree/cobbler20/cobbler20.spec
+++ b/spec-tree/cobbler20/cobbler20.spec
@@ -34,6 +34,7 @@ Patch20: buildiso-no-local-hdd.patch
 Patch21: cobbler-s390-kernel-options.patch
 Patch22: cobbler-ipv6.patch
 #Patch23: kickstart-autoinstall-rename.patch
+Patch24: cobbler-unquote-possibly-quoted-url.patch
 Group: Applications/System
 Requires: python >= 2.3
 
@@ -145,6 +146,7 @@ a XMLRPC API for integration with other applications.
 %patch21 -p1
 %patch22 -p1
 #%patch23 -p1
+%patch24 -p1
 
 %build
 %{__python} setup.py build 


### PR DESCRIPTION
Trying to install a SLES system via Spacewalk (using PXE),
the url for the configuration file gets quoted by 'autoyast'.
This results in 404 errors because a file name like

'SLES12-SP2-Standard-LVM%3a1%3aCOMP' is not found on disk instead of
'SLES12-SP1-Standard-LVM:1:COMP'.

I did not test to build this package. But my testing SW server (2.7 nightly) is using this fix
within ```services.wsgi``` without any problems right now.