### PR TITLE
bz1490801 - [RFE] skip child channels with no repo during sync

### DIFF
--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -132,6 +132,7 @@ def main():
     l_ch_custom=reposync.getCustomChannels()
     d_parent_child=reposync.getParentsChilds()
     d_ch_repo_sync={}
+    l_no_ch_repo_sync=[]
 
     if options.list:
         log(0, "======================================")
@@ -186,7 +187,11 @@ def main():
         if ch not in l_ch_custom:
             systemExit(1, "Channel %s is not custom or does not exist." % ch)
         if not d_ch_repo_sync[ch] and not ch in d_chan_repo:
-            systemExit(1, "Channel %s Channel has no URL associated" % ch)
+            log(0, "Channel %s Channel has no URL associated, skipping sync" % ch)
+            l_no_ch_repo_sync.append(ch)
+
+    for ch in l_no_ch_repo_sync:
+        del d_ch_repo_sync[ch]
 
     if options.dry_run:
         log(0, "======================================")


### PR DESCRIPTION
Prevent `spacewalk-repo-sync` from aborting if any child channel doesn't
have a repository/URL associated, by removing them from the list of
channels to be synchronised.

Allows syncing using `-p` option when some channels don't have upstream
repositories (i.e. they contain packages uploaded via rhnpush or webui).

Fixes bz1490801