### PR TITLE
(bz#1491451) osad: set KillMode=process in systemd unit

### DIFF
--- a/client/tools/osad/osad.service
+++ b/client/tools/osad/osad.service
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=forking
+KillMode=process
 EnvironmentFile=-/etc/sysconfig/osad
 PIDFile=/var/run/osad.pid
 ExecStart=/usr/sbin/osad --pid-file /var/run/osad.pid


### PR DESCRIPTION
Systemd kills the complete control-group by default on
stop/restart. This also kills any running rhn_check process
started by osad.

This is a problem as soon as osad itself is updated by a osad
initiated rhn_check run. Without KillMode=process the rhn_check
process is killed and the running rpm updates aborted forcefully.
This leaves the system in a bad state like not created initramfs
when the update job also includes a kernel update and half-upgraded
packages which need to be solved manually.

Setting KillMode=process will tell systemd to only kill the primary
process and not the complete control-group. This way the rhn_check
process survives a osad restart.