### PR TITLE
1493143 - keep errata in the original channel for channel.software.mergeErrata

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2074,8 +2074,8 @@ public class ChannelSoftwareHandler extends BaseHandler {
             throw new PermissionCheckFailureException();
         }
 
-        Set<Errata> mergedErrata = mergeErrataToChannel(loggedInUser, mergeFrom
-                .getErratas(), mergeTo, mergeFrom);
+        Set<Errata> mergedErrata = mergeErrataToChannel(loggedInUser, new HashSet(mergeFrom
+                .getErratas()), mergeTo, mergeFrom);
 
         return mergedErrata.toArray();
     }


### PR DESCRIPTION

in case they're present in the target channel already