### PR TITLE
Display Message after deleting custom key

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/customkey/DeleteCustomKeyAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/customkey/DeleteCustomKeyAction.java
@@ -25,6 +25,8 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
+import org.apache.struts.action.ActionMessage;
+import org.apache.struts.action.ActionMessages;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -60,10 +62,19 @@ public class DeleteCustomKeyAction extends RhnAction {
         if (requestContext.isSubmitted()) {
             ServerFactory.removeCustomKey(key);
 
+            bindMessage(requestContext, "system.customkey.deletesuccess");
             return mapping.findForward("deleted");
         }
 
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
+    }
+
+    private void bindMessage(RequestContext requestContext, String error) {
+        ActionMessages msg = new ActionMessages();
+        String[] actionParams = {};
+        msg.add(ActionMessages.GLOBAL_MESSAGE,
+                new ActionMessage(error, actionParams));
+        getStrutsDelegate().saveMessages(requestContext.getRequest(), msg);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/customkey/DeleteCustomKeyAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/customkey/DeleteCustomKeyAction.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.frontend.action.systems.customkey;
 import com.redhat.rhn.domain.org.CustomDataKey;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
@@ -47,7 +46,6 @@ public class DeleteCustomKeyAction extends RhnAction {
             HttpServletResponse response) {
 
         RequestContext requestContext = new RequestContext(request);
-        User user =  requestContext.getCurrentUser();
         Long cikid = requestContext.getParamAsLong(CIKID_PARAM);
 
         CustomDataKey key = OrgFactory.lookupKeyById(cikid);

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7669,6 +7669,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="system.customkey.addsuccess">
         <source>Successfully added 1 custom key.</source>
       </trans-unit>
+      <trans-unit id="system.customkey.deletesuccess">
+        <source>Successfully deleted 1 custom key.</source>
+      </trans-unit>
       <trans-unit id="channel.java.package.deletesuccess">
         <source>Successfully deleted {0} packages.</source>
       </trans-unit>


### PR DESCRIPTION
This pull request displays a success message when a custom key has been deleted successfully.
Without these changes the key just disappears on the list.

It also gets rid of an initialized variable that is unused.