### PR TITLE
Find nearby version of eus channel to subscribe

### DIFF
--- a/client/rhel/rhn-client-tools/src/bin/rhnreg_ks.py
+++ b/client/rhel/rhn-client-tools/src/bin/rhnreg_ks.py
@@ -133,6 +133,18 @@ class RegisterKsCli(rhncli.RhnCli):
                                                    self.options.password)
             other['channel'] = channels['default_channel']
 
+            # Find close version of channel
+            if not channels['default_channel']:
+                tmp_version = None
+                for channel in channels['channels']:
+                    chennel_version = channel.split(".")[1]
+                    if tmp_version == None:
+                        tmp_version = chennel_version
+                        other['channel'] = channel
+                    elif tmp_version > chennel_version:
+                        tmp_version = chennel_version
+                        other['channel'] = channel
+
         try:
             systemId = rhnreg.registerSystem(self.options.username,
                 self.options.password, profilename, self.options.activationkey, other)


### PR DESCRIPTION
For example: 
release: redhat-release-server-7.0-1.el7.x86_64

channels:
rhel-x86_64-server-7.1.eus
rhel-x86_64-server-7.2.eus
rhel-x86_64-server-7.3.eus
rhel-x86_64-server-7.4.eus

The system will be registered to "rhel-x86_64-server-7.1.eus".