### PR TITLE
bz1497216 - [RFE] Add softwarechannel_setsyncschedule --latest

### DIFF
--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -2232,6 +2232,8 @@ def help_softwarechannel_setsyncschedule(self):
     print 'Sets the repo sync schedule for a software channel'
     print
     print 'usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>'
+    print 'Options:'
+    print '    -l/--latest : Only download latest package versions when repo syncs'
     print
     print 'The schedule is specified in Quartz CronTrigger format without enclosing quotes.'
     print 'For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ?'
@@ -2243,7 +2245,13 @@ def complete_softwarechannel_setsyncschedule(self, text, line, beg, end):
 
 
 def do_softwarechannel_setsyncschedule(self, args):
-    (args, _options) = parse_arguments(args, glob=False)
+    options = [Option('-l', '--latest', action='store_true')]
+
+    (args, options) = parse_arguments(args, options, glob=False)
+
+    params = {}
+    if (options.latest):
+        params["latest"] = "true"
 
     if not len(args) == 7:
         self.help_softwarechannel_setsyncschedule()
@@ -2252,7 +2260,7 @@ def do_softwarechannel_setsyncschedule(self, args):
     channel = args[0]
     schedule = ' '.join(args[1:])
 
-    self.client.channel.software.syncRepo(self.session, channel, schedule)
+    self.client.channel.software.syncRepo(self.session, channel, schedule, params)
 
 ####################
 


### PR DESCRIPTION
Add support for the `--latest` option on the
`softwarechannel_setsyncshedule` command so that tasko sync tasks
only download the most recent versions rather than the full repository
content.

This brings the spacecmd command closer into line with the features
available via the webinterface and allows use of the latest option when
setting sync schedules programmatically.

Fixes [#1497216](https://bugzilla.redhat.com/show_bug.cgi?id=1497216)