### PR TITLE
Do not fail import on ignored errata

### DIFF
--- a/backend/server/importlib/errataImport.py
+++ b/backend/server/importlib/errataImport.py
@@ -132,6 +132,9 @@ class ErrataImport(GenericPackageImport):
 
         self.backend.lookupPackages(list(self.packages.values()), self.checksums, self.ignoreMissing)
         for erratum in self.batch:
+            if erratum.ignored:
+                # Skip it
+                continue
             self._fix_erratum_packages(erratum)
             self._fix_erratum_file_channels(erratum)
 


### PR DESCRIPTION
When a errata is ignored, because a newer errata has already
been found, this breaks the import with error

ERROR: 'list' object has no attribute 'keys'

in '_fix_erratum_packages' because 'packages' of an ignored errata
has not been 'transferred' to a dict() by '_fix_erratum_packages_lookup'