### PR TITLE
Fix typo introduced in 79b0ed8e2f

### DIFF
--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -859,7 +859,7 @@ def base_eus_channel_for_ver_rel_arch(version, release, server_arch,
         else:
             parts = 2
 
-        server_rel = '.'.join(release..split('-')[0].split('.')[:parts])
+        server_rel = '.'.join(release.split('-')[0].split('.')[:parts])
         channel_rel = '.'.join(db_release.split('.')[:parts])
 
         # XXX we're no longer using the is_default column from the db


### PR DESCRIPTION
Just fix a simple typo introduced in 79b0ed8e2fa but it breaks package creation and travis tests.