### PR TITLE
correct name of module 'actions.configfiles'

### DIFF
--- a/client/tools/rhncfg/actions/script.py
+++ b/client/tools/rhncfg/actions/script.py
@@ -30,7 +30,7 @@ except:
 
 
 # this is ugly, hopefully it will be natively supported in up2date
-from actions.configfiles import _local_permission_check, _perm_error
+from rhn.actions.configfiles import _local_permission_check, _perm_error
 from config_common import local_config
 from config_common.rhn_log import set_logfile, log_to_file
 


### PR DESCRIPTION
Remote script doesn't work with following traceback:
```
(Pdb) import rhn.actions.script
*** ImportError: No module named actions.configfiles
```