### PR TITLE
Fix to promote a child channel as child channel

### DIFF
--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -544,9 +544,16 @@ if parent_dest in all_channel_labels:
     merge_channels(parent_source, parent_dest)
 else:
     # channel doesn't exist, clone it from the original
+    # let's check if there's a parent for the original channel and if so, clone it in the right place
+    new_parent_source = client.channel.software.getDetails(session,parent_source)['parent_channel_label']
+    new_parent_dest = ""
+    if new_parent_source:
+        (new_parent_source, new_parent_dest) = build_channel_labels(new_parent_source)
+    
     details = {'label': parent_dest,
                'name': parent_dest,
-               'summary': parent_dest}
+               'summary': parent_dest,
+               'parent_label': new_parent_dest}
 
     clone_channel(parent_source, details)
 


### PR DESCRIPTION
Consider the command "spacewalk-manage-channel-lifecycle -c mychannel --promote" and the scenario stated as below:

- mychannel exists as a child of another channel, say base-mychannel
- nextphase-base-mychannel already exists
- nextphase-mychannel does NOT exists

The original code creates nextphase-mychannel as a base channel itself, ignoring nextphase-base-mychannel. The modification aims to fix it, creating nextphase-mychannel correctly as a child of nextphase-base-mychannel.

Please check if there's any side effects (I didn't find any).

Thanks.