### PR TITLE
Do not import ignored errata

### DIFF
--- a/backend/server/importlib/errataImport.py
+++ b/backend/server/importlib/errataImport.py
@@ -45,7 +45,7 @@ class ErrataImport(GenericPackageImport):
             release = errata['advisory_rel']
             errata_hash[advisory + release] = errata
             if advisory in advisories:
-                if release < advisories[advisory]:
+                if long(release) < long(advisories[advisory]):
                     # Seen a newer one already
                     errata.ignored = 1
                     continue


### PR DESCRIPTION
@tkasparek 

See this PR as alternative for #581 

It is further modified, to not only fix the `ERROR: 'list' object has no attribute 'keys'`, I'm also able to import erratas for SLES11.3 (and older)

I don't think, that this patch should cause any trouble with "new" (current) repositories with very large (and mostly unique) `advisory_names`, but solves my problem in still syncing "SLES11.3", which is still supported. Beginning with SLES11.4, the `advisory_names` got longer and more unique.

I also have to note, that I have to wait for new patches in SLES11.3 to see, if this patch really works as designed.
