### PR TITLE
pylint - fix intendation

### DIFF
--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -645,9 +645,9 @@ def do_softwarechannel_listarches(self, args):
 
     for arch in sorted(arches):
         if (options.verbose):
-                print("%s (%s)" % (arch["label"], arch["name"]))
+            print("%s (%s)" % (arch["label"], arch["name"]))
         else:
-                print("%s" % arch["label"])
+            print("%s" % arch["label"])
 
 ####################
 


### PR DESCRIPTION
************* Module spacecmd.softwarechannel
W:648, 0: Bad indentation. Found 16 spaces, expected 12 (bad-indentation)
W:650, 0: Bad indentation. Found 16 spaces, expected 12 (bad-indentation)