### PR TITLE
rhnlib: enable py3 build for Tumbleweed

### DIFF
--- a/client/rhel/rhnlib/rhnlib.spec
+++ b/client/rhel/rhnlib/rhnlib.spec
@@ -1,3 +1,7 @@
+%if 0%{?fedora} || 0%{?suse_version} > 1320
+%global build_py3   1
+%endif
+
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Summary: Python libraries for the Spacewalk project
@@ -31,7 +35,7 @@ Conflicts: spacewalk-proxy < 1.3.6
 rhnlib is a collection of python modules used by the Spacewalk (http://spacewalk.redhat.com) software.
 
 
-%if 0%{?fedora}
+%if 0%{?build_py3}
 %package -n python3-rhnlib
 Summary: Python libraries for the Spacewalk project
 Group: Development/Libraries
@@ -68,7 +72,7 @@ make -f Makefile.rhnlib
 %install
 rm -rf $RPM_BUILD_ROOT
 %{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT --prefix=%{_prefix}
-%if 0%{?fedora}
+%if 0%{?build_py3}
 %{__python3} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT --prefix=%{_prefix}
 %endif
 
@@ -81,7 +85,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc ChangeLog COPYING README TODO
 %{python_sitelib}/*
 
-%if 0%{?fedora}
+%if 0%{?build_py3}
 %files -n python3-rhnlib
 %doc ChangeLog COPYING README TODO
 %{python3_sitelib}/*


### PR DESCRIPTION
Build python 3 also on Tumbleweed