### PR TITLE
reposync dependency resolution fix

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -382,10 +382,19 @@ class ContentSource(object):
 
     def _get_package_dependencies(self, sack, packages):
         self.yumbase.pkgSack = sack
+        known_deps = set()
         resolved_deps = self.yumbase.findDeps(packages)
-        for (_pkg, deps) in resolved_deps.items():
-            for (_dep, dep_packages) in deps.items():
-                packages.extend(dep_packages)
+        while resolved_deps:
+            next_level_deps = []
+            for deps in resolved_deps.values():
+                for _dep, dep_packages in deps.items():
+                    if _dep not in known_deps:
+                        next_level_deps.extend(dep_packages)
+                        packages.extend(dep_packages)
+                        known_deps.add(_dep)
+
+            resolved_deps = self.yumbase.findDeps(next_level_deps)
+
         return yum.misc.unique(packages)
 
     def get_package(self, package, metadata_only=False):


### PR DESCRIPTION
When some package filter is active, reposync tries to resolve dependencies but it seems to resolve only direct dependencies, not whole available dependency tree.

Example - sync glibc from Fedora repo (attached to fedora channel):

`# spacewalk-repo-sync -c fedora -i "glibc"`

Repoclosure on fedora channel repodata will report missing dependencies.