### PR TITLE
Add a command-line switch to satellite-sync to ignore proxy settings

### DIFF
--- a/backend/satellite_tools/satellite-sync.sgml
+++ b/backend/satellite_tools/satellite-sync.sgml
@@ -90,6 +90,9 @@ Incrementally synchronize an Red Hat Satellite's DB data and RPM repository with
         <arg>--server=<replaceable>HOSTNAME</replaceable></arg>
     </cmdsynopsis>
     <cmdsynopsis>
+        <arg>--ignore-proxy</arg>
+    </cmdsynopsis>
+    <cmdsynopsis>
         <arg>--http-proxy=<replaceable>HOSTNAME:PORT</replaceable></arg>
     </cmdsynopsis>
     <cmdsynopsis>
@@ -420,6 +423,12 @@ Incrementally synchronize an Red Hat Satellite's DB data and RPM repository with
                 </listitem>
                 </varlistentry>
             </variablelist>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>--ignore-proxy</term>
+        <listitem>
+            <para>Do not use an http proxy under any circumstances</para>
         </listitem>
     </varlistentry>
     <varlistentry>

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -2093,6 +2093,10 @@ def processCommandline():
                help=_('e-mail a report of what was synced/imported')),
         Option('--force-all-errata',    action='store_true',
                help=_('forcibly process all (not a diff of) errata metadata')),
+        Option('--force-all-packages',  action='store_true',
+               help=_('forcibly process all (not a diff of) package metadata')),
+        Option('--ignore-proxy',          action='store_true',
+               help=_('Do not use an http proxy under any circumstances.')),
         Option('--http-proxy',          action='store',
                help=_('alternative http proxy (hostname:port)')),
         Option('--http-proxy-username', action='store',
@@ -2174,10 +2178,11 @@ def processCommandline():
         CFG.set("ISS_CA_CHAIN", OPTIONS.ca_cert or getDbCaChain(CFG.RHN_PARENT)
                 or CFG.CA_CHAIN)
 
-    CFG.set("HTTP_PROXY", idn_ascii_to_puny(OPTIONS.http_proxy or CFG.HTTP_PROXY))
-    CFG.set("HTTP_PROXY_USERNAME", OPTIONS.http_proxy_username or CFG.HTTP_PROXY_USERNAME)
-    CFG.set("HTTP_PROXY_PASSWORD", OPTIONS.http_proxy_password or CFG.HTTP_PROXY_PASSWORD)
-    CFG.set("CA_CHAIN", OPTIONS.ca_cert or CFG.CA_CHAIN)
+    if not OPTIONS.ignore_proxy:
+        CFG.set("HTTP_PROXY", idn_ascii_to_puny(OPTIONS.http_proxy or CFG.HTTP_PROXY))
+        CFG.set("HTTP_PROXY_USERNAME", OPTIONS.http_proxy_username or CFG.HTTP_PROXY_USERNAME)
+        CFG.set("HTTP_PROXY_PASSWORD", OPTIONS.http_proxy_password or CFG.HTTP_PROXY_PASSWORD)
+        CFG.set("CA_CHAIN", OPTIONS.ca_cert or CFG.CA_CHAIN)
 
     CFG.set("SYNC_TO_TEMP", OPTIONS.sync_to_temp or CFG.SYNC_TO_TEMP)
 


### PR DESCRIPTION
This patch adds a command-line switch to allow satellite-sync to perform ISS against an internal Spacewalk server when an HTTP proxy server has been configured in the environment or config file.