### PR TITLE
Overview page small fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -9823,7 +9823,7 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
         </context-group>
       </trans-unit>
       <trans-unit id="yourrhn.jsp.recentlyregistered">
-        <source>&lt;strong&gt;Recently Registered Systems&lt;/strong&gt;</source>
+        <source>Recently Registered Systems</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/YourRhn.do</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/systemGroups.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/systemGroups.jsp
@@ -9,7 +9,7 @@
                 <rl:list dataset="systemGroupList"
                  width="100%"
                  name="systemsGroupList"
-                 title="${rhn:localize('yourrhn.jsp.systemgroups')}"
+                 title="${rhn:localize('yourrhn.jsp.systemgroups.header')}"
                  styleclass="list list-doubleheader"
                  hidepagenums="true"
                  emptykey="yourrhn.jsp.systemgroups.none">


### PR DESCRIPTION
## What does this PR do?

This patch fixes two small issues on the overview / landing page that you go to immediately after login.

## GUI diff

Screenshots were taken from SUSE Manager.

Before:
![overview-page-before](https://user-images.githubusercontent.com/729454/31618450-419f7044-b292-11e7-9b05-9addc997bba9.png)

After:
![overview-page-after](https://user-images.githubusercontent.com/729454/31618454-471d276e-b292-11e7-90f8-8232607f4ee8.png)

## Previous Behavior

1. Wrong string was referenced for system groups: It was showing "System Group Name" instead of "System Groups". "System Group Name" is supposed to be just the title of the second column in that table.
2. The title of "Recently Registered Systems" was in `<strong>` tags which makes it look odd and different from the other section titles.

## New Behavior

1. Correct string is now used for the title of system groups: "System Groups".
2. The `<strong>` tags were removed so the title appears equally formatted as other section titles.
