### PR TITLE
Improve messaging for "Compare Packages"

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -18915,7 +18915,7 @@ given channel.</source>
         <source>Compare Packages</source>
       </trans-unit>
       <trans-unit id="channel.jsp.package.comparemessage">
-        <source>You can compare the packages in this channel with another channel. Select the channel which you would like to compare from the list below, and click 'View Packages'.</source>
+        <source>Compare packages in the current channel with packages from another channel. Only the latest version of packages will be compared. Choose a channel from the list below then select 'View Packages'.</source>
       </trans-unit>
       <trans-unit id="channel.jsp.package.compareto">
         <source>Compare to</source>


### PR DESCRIPTION
## What does this PR do?

The description for the "Compare Packages" web UI is improved to avoid misunderstandings. In particular it should be made clear that only the **newest version** of each package will be considered for a comparison, while not every potentially missing older version of a package will be listed, like it would be the case with a diff.

## GUI diff

The following screenshots were taken from SUSE Manager.

Before:
![compare-packages-before](https://user-images.githubusercontent.com/729454/32599050-a40193a0-c53b-11e7-9bee-639540bea3f5.png)

After:
![compare-packages-fixed](https://user-images.githubusercontent.com/729454/32949771-49568536-cba4-11e7-86bd-c1318bd11da1.png)

## Tests written? 

No tests written as this patch is supposed to improve only the page description.

## Documentation

The documentation would need to be updated as well.
