### PR TITLE
localhost is not local - port versus socket

### DIFF
--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -149,7 +149,7 @@ class Database(sql_base.Database):
         if not (self.username and self.database):
             raise AttributeError("PostgreSQL requires at least a user and database name.")
 
-        if host is None or host == '' or host == 'localhost':
+        if host is None or host == '' or host == 'local':
             self.host = None
             self.port = None
         else:
@@ -200,7 +200,7 @@ class Database(sql_base.Database):
 
     def is_connected_to(self, backend, host, port, username, password,
                         database, sslmode, sslrootcert):
-        if host is None or host == '' or host == 'localhost':
+        if host is None or host == '' or host == 'local':
             host = None
             port = None
         if not port:


### PR DESCRIPTION
The local is term for unix socket, but localhost is used as port on IP 127.0.0.1

It causes problem when the postgresql runs in docker with forwarding port on localhost.

`docker run -p 5432:5432 postgres`

