### PR TITLE
Display constraint messages more user friendly

### DIFF
--- a/java/code/src/com/redhat/rhn/common/validator/DoubleConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/DoubleConstraint.java
@@ -25,10 +25,10 @@ import org.apache.log4j.Logger;
  * </p>
  * @version $Rev$
  */
-public class NumericConstraint extends RequiredIfConstraint {
+public class DoubleConstraint extends RequiredIfConstraint {
 
     /** Logger instance */
-    private static Logger log = Logger.getLogger(NumericConstraint.class);
+    private static Logger log = Logger.getLogger(DoubleConstraint.class);
 
     /** Minimum inclusive value allowed */
     private Double minInclusive;
@@ -44,8 +44,10 @@ public class NumericConstraint extends RequiredIfConstraint {
      *
      * @param identifierIn <code>String</code> identifier for <code>Constraint</code>.
      */
-    public NumericConstraint(String identifierIn) {
+    public DoubleConstraint(String identifierIn) {
         super(identifierIn);
+        this.minInclusive = Double.MIN_VALUE;
+        this.maxInclusive = Double.MAX_VALUE;
     }
 
 
@@ -71,23 +73,19 @@ public class NumericConstraint extends RequiredIfConstraint {
                 return new ValidatorError("errors.decimalvalue", args);
             }
 
-            if (hasMinInclusive()) {
-                if (doubleValue < getMinInclusive().doubleValue()) {
-                    log.debug("Under min size ...");
-                    Object[] args = new Object[2];
-                    args[0] = localizedIdentifier;
-                    args[1] = getMinInclusive();
-                    return new ValidatorError("errors.minsize", args);
-                }
+            if (doubleValue < getMinInclusive().doubleValue()) {
+                log.debug("Decimal too small ...");
+                Object[] args = new Object[2];
+                args[0] = localizedIdentifier;
+                args[1] = getMinInclusive();
+                return new ValidatorError("errors.minsize", args);
             }
-            if (hasMaxInclusive()) {
-                if (doubleValue > getMaxInclusive().doubleValue()) {
-                    log.debug("Over max size 2 ...");
-                    Object[] args = new Object[2];
-                    args[0] = localizedIdentifier;
-                    args[1] = getMaxInclusive();
-                    return new ValidatorError("errors.maxsize", args);
-                }
+            if (doubleValue > getMaxInclusive().doubleValue()) {
+                log.debug("Decimal too big ...");
+                Object[] args = new Object[2];
+                args[0] = localizedIdentifier;
+                args[1] = getMaxInclusive();
+                return new ValidatorError("errors.maxsize", args);
             }
         }
         catch (NumberFormatException e) {
@@ -125,19 +123,6 @@ public class NumericConstraint extends RequiredIfConstraint {
         return minInclusive;
     }
 
-    /**
-     * <p>
-     *  This will return <code>true</code> if a minimum value (inclusive) constraint
-     *    exists.
-     * </p>
-     *
-     * @return <code>boolean</code> - whether there is a constraint for the
-     *         minimum value (inclusive)
-     */
-    public boolean hasMinInclusive() {
-        return minInclusive != null;
-    }
-
 
     /**
      * <p>
@@ -159,19 +144,6 @@ public class NumericConstraint extends RequiredIfConstraint {
      */
     public Double getMaxInclusive() {
         return maxInclusive;
-    }
-
-    /**
-     * <p>
-     *  This will return <code>true</code> if a maximum value (inclusive) constraint
-     *    exists.
-     * </p>
-     *
-     * @return <code>boolean</code> - whether there is a constraint for the
-     *         maximum value (inclusive)
-     */
-    public boolean hasMaxInclusive() {
-        return maxInclusive != null;
     }
 
 }

--- a/java/code/src/com/redhat/rhn/common/validator/LongConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/LongConstraint.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.common.validator;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+
+import org.apache.log4j.Logger;
+
+/**
+ *  The <code>LongConstraint</code> class represents a constraint of type Long,
+ *    including the required ranges.
+ */
+public class LongConstraint extends RequiredIfConstraint {
+
+    /** Logger instance */
+    private static Logger log = Logger.getLogger(LongConstraint.class);
+
+    /** Minimum inclusive value allowed */
+    private Long minInclusive;
+
+    /** Maximum inclusive value allowed */
+    private Long maxInclusive;
+
+    /**
+     *  This will create a new <code>Constraints</code> with the specified
+     *    identifier as the "name".
+     *
+     * @param identifierIn <code>String</code> identifier for <code>Constraint</code>.
+     */
+    public LongConstraint(String identifierIn) {
+        super(identifierIn);
+        this.minInclusive = Long.MIN_VALUE;
+        this.maxInclusive = Long.MAX_VALUE;
+    }
+
+    /** {@inheritDoc} */
+    public ValidatorError checkConstraint(Object value) {
+
+        ValidatorError requiredCheck = super.checkConstraint(value);
+        if (requiredCheck != null) {
+            return requiredCheck;
+        }
+
+        String localizedIdentifier =
+            LocalizationService.getInstance().getMessage(getIdentifier());
+
+        // Validate against range specifications
+        try {
+            long longValue = new Long(value.toString()).longValue();
+            // Now we know its a valid number
+            if (longValue < getMinInclusive().longValue()) {
+                log.debug("Number too small ...");
+                Object[] args = new Object[2];
+                args[0] = localizedIdentifier;
+                args[1] = getMinInclusive();
+                return new ValidatorError("errors.minsize", args);
+            }
+            if (longValue > getMaxInclusive().longValue()) {
+                log.debug("Number too big ...");
+                Object[] args = new Object[2];
+                args[0] = localizedIdentifier;
+                args[1] = getMaxInclusive();
+                return new ValidatorError("errors.maxsize", args);
+            }
+        }
+        catch (NumberFormatException e) {
+            log.debug("NumberFormatException .. ");
+            Object[] args = new Object[1];
+            args[0] = localizedIdentifier;
+            return new ValidatorError("errors.notanumber", args);
+        }
+
+        return null;
+    }
+
+    /**
+     *  This will set the minimum allowed value for this data type (inclusive).
+     *
+     * @param minInclusiveIn minimum allowed value (inclusive)
+     */
+    public void setMinInclusive(Long minInclusiveIn) {
+        this.minInclusive = minInclusiveIn;
+    }
+
+    /**
+     *  This will return the minimum allowed value for this data type (inclusive).
+     *
+     * @return <code>Double</code> - minimum value allowed (inclusive)
+     */
+    public Long getMinInclusive() {
+        return minInclusive;
+    }
+
+    /**
+     *  This will set the maximum allowed value for this data type (inclusive).
+     *
+     * @param maxInclusiveIn maximum allowed value (inclusive)
+     */
+    public void setMaxInclusive(Long maxInclusiveIn) {
+        this.maxInclusive = maxInclusiveIn;
+    }
+
+    /**
+     *  This will return the maximum allowed value for this data type (inclusive).
+     *
+     * @return <code>Double</code> - maximum value allowed (inclusive)
+     */
+    public Long getMaxInclusive() {
+        return maxInclusive;
+    }
+}

--- a/java/code/src/com/redhat/rhn/common/validator/RequiredIfConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/RequiredIfConstraint.java
@@ -64,7 +64,6 @@ public class RequiredIfConstraint extends ParsedConstraint {
     */
     public boolean isRequired(Object value, Object objectToCheck) {
 
-        String strValue = (String) value;
         Iterator i = fieldValueList.iterator();
         // Default to true, the
         boolean required = true;

--- a/java/code/src/com/redhat/rhn/common/validator/SchemaParser.java
+++ b/java/code/src/com/redhat/rhn/common/validator/SchemaParser.java
@@ -172,22 +172,54 @@ public class SchemaParser {
         Element child;
 
         if (schemaType.equals("long") || schemaType.equals("int")) {
-            NumericConstraint nc = new NumericConstraint(name);
-            nc.setOptional(parseOptional(simpleType));
+            LongConstraint lc = new LongConstraint(name);
+            lc.setOptional(parseOptional(simpleType));
 
-            processRequiredIfConstraint(simpleType, nc);
+            processRequiredIfConstraint(simpleType, lc);
+            // Handle ranges
+            child = simpleType.getChild("minInclusive", schemaNamespace);
+            if (child != null) {
+                Long value = new Long(child.getAttributeValue("value"));
+                lc.setMinInclusive(value);
+            }
+            else if (schemaType.equals("int")) {
+                    lc.setMinInclusive((long) Integer.MIN_VALUE);
+            }
+            child = simpleType.getChild("maxInclusive", schemaNamespace);
+            if (child != null) {
+                Long value = new Long(child.getAttributeValue("value"));
+                lc.setMaxInclusive(value);
+            }
+            else if (schemaType.equals("int")) {
+                    lc.setMaxInclusive((long) Integer.MAX_VALUE);
+            }
+            constraint = lc;
+        }
+        else if (schemaType.equals("double") || schemaType.equals("float")) {
+            DoubleConstraint dc = new DoubleConstraint(name);
+            dc.setOptional(parseOptional(simpleType));
+
+            processRequiredIfConstraint(simpleType, dc);
             // Handle ranges
             child = simpleType.getChild("minInclusive", schemaNamespace);
             if (child != null) {
                 Double value = new Double(child.getAttributeValue("value"));
-                nc.setMinInclusive(value);
+                dc.setMinInclusive(value);
+            }
+            else if (schemaType.equals("float")) {
+                Double value = new Double(Float.MIN_VALUE);
+                dc.setMinInclusive(value);
             }
             child = simpleType.getChild("maxInclusive", schemaNamespace);
             if (child != null) {
                 Double value = new Double(child.getAttributeValue("value"));
-                nc.setMaxInclusive(value);
+                dc.setMaxInclusive(value);
             }
-            constraint = nc;
+            else if (schemaType.equals("float")) {
+                Double value = new Double(Float.MAX_VALUE);
+                dc.setMaxInclusive(value);
+            }
+            constraint = dc;
         }
         else if (schemaType.equals("string")) {
             StringConstraint lc = new StringConstraint(name);

--- a/java/code/src/com/redhat/rhn/common/validator/Validator.java
+++ b/java/code/src/com/redhat/rhn/common/validator/Validator.java
@@ -208,15 +208,35 @@ public class Validator {
                 Integer.parseInt(data);
             }
             catch (NumberFormatException e) {
-                validationMessage = new ValidatorError("errors.integer", identifier);
+                if (constraint instanceof LongConstraint) {
+                    LongConstraint longConstraint = (LongConstraint) constraint;
+                    Long minInclusive = longConstraint.getMinInclusive();
+                    Long maxInclusive = longConstraint.getMaxInclusive();
+                    validationMessage = new ValidatorError("errors.integer.minmax",
+                            identifier, minInclusive, maxInclusive);
+                }
+                else {
+                    validationMessage =
+                            new ValidatorError("errors.integer", identifier);
+                }
             }
         }
-        else if ((dataType.equals("long")) || (dataType.equals("java.lang.Long"))) {
+        else if (dataType.equals("long") || dataType.equals("java.lang.Long")) {
             try {
                 Long.parseLong(data);
             }
             catch (NumberFormatException e) {
-                validationMessage = new ValidatorError("errors.long", identifier);
+                if (constraint instanceof LongConstraint) {
+                    LongConstraint longConstraint = (LongConstraint) constraint;
+                    Long minInclusive = longConstraint.getMinInclusive();
+                    Long maxInclusive = longConstraint.getMaxInclusive();
+                    validationMessage = new ValidatorError("errors.integer.minmax",
+                            identifier, minInclusive, maxInclusive);
+                }
+                else {
+                    validationMessage =
+                            new ValidatorError("errors.integer", identifier);
+                }
             }
         }
         else if ((dataType.equals("float")) || (dataType.equals("java.lang.Float"))) {
@@ -224,7 +244,16 @@ public class Validator {
                 Float.parseFloat(data);
             }
             catch (NumberFormatException e) {
-                validationMessage = new ValidatorError("errors.float", identifier);
+                if (constraint instanceof DoubleConstraint) {
+                    DoubleConstraint doubleConstraint = (DoubleConstraint) constraint;
+                    Double minInclusive = doubleConstraint.getMinInclusive();
+                    Double maxInclusive = doubleConstraint.getMaxInclusive();
+                    validationMessage = new ValidatorError("errors.float.minmax",
+                            identifier, minInclusive, maxInclusive);
+                }
+                else {
+                    validationMessage = new ValidatorError("errors.float", identifier);
+                }
             }
         }
         else if ((dataType.equals("double")) || (dataType.equals("java.lang.Double"))) {
@@ -232,7 +261,17 @@ public class Validator {
                 Double.parseDouble(data);
             }
             catch (NumberFormatException e) {
-                validationMessage = new ValidatorError("errors.double", identifier);
+                if (constraint instanceof DoubleConstraint) {
+                    DoubleConstraint doubleConstraint = (DoubleConstraint) constraint;
+                    Double minInclusive = doubleConstraint.getMinInclusive();
+                    Double maxInclusive = doubleConstraint.getMaxInclusive();
+                    validationMessage = new ValidatorError("errors.float.minmax",
+                            identifier, minInclusive, maxInclusive);
+                }
+                else {
+                    validationMessage =
+                            new ValidatorError("errors.float", identifier);
+                }
             }
         }
 

--- a/java/code/src/com/redhat/rhn/common/validator/Validator.java
+++ b/java/code/src/com/redhat/rhn/common/validator/Validator.java
@@ -108,9 +108,8 @@ public class Validator {
      * data against.
      * @param objToValidate <code>String</code> data to validate.
      * @return ValidatorError whether the data is valid or not.
-     * TODO: rename this method to something other than isValid()
      */
-    public ValidatorError isValid(String constraintName, Object objToValidate) {
+    public ValidatorError validate(String constraintName, Object objToValidate) {
         // Validate against the correct constraint
         Object o = constraints.get(constraintName);
 

--- a/java/code/src/com/redhat/rhn/common/validator/ValidatorService.java
+++ b/java/code/src/com/redhat/rhn/common/validator/ValidatorService.java
@@ -107,7 +107,7 @@ public class ValidatorService {
                     continue;
                 }
             }
-            ValidatorError error = validatorIn.isValid(c.getIdentifier(), validateIn);
+            ValidatorError error = validatorIn.validate(c.getIdentifier(), validateIn);
             if (error != null) {
                 result.addError(error);
             }

--- a/java/code/src/com/redhat/rhn/common/validator/test/TestObject.java
+++ b/java/code/src/com/redhat/rhn/common/validator/test/TestObject.java
@@ -26,6 +26,7 @@ public class TestObject {
 
     private String stringField;
     private Long longField;
+    private Long thirdLongField;
     private Date dateField;
     private String compoundField;
     private String secondStringField;
@@ -74,6 +75,14 @@ public class TestObject {
 
     public Long getLongField() {
         return longField;
+    }
+
+    public void setThirdLongField(Long lin) {
+        thirdLongField = lin;
+    }
+
+    public Long getThirdLongField() {
+        return thirdLongField;
     }
 
 

--- a/java/code/src/com/redhat/rhn/common/validator/test/TestObject.xsd
+++ b/java/code/src/com/redhat/rhn/common/validator/test/TestObject.xsd
@@ -7,6 +7,9 @@
       <maxInclusive value="20"/>
     </simpleType>
   </attribute>
+  <attribute name="thirdLongField">
+    <simpleType baseType="long"/>
+  </attribute>
 
   <attribute name="stringField">
     <simpleType baseType="string">

--- a/java/code/src/com/redhat/rhn/common/validator/test/ValidatorServiceTest.java
+++ b/java/code/src/com/redhat/rhn/common/validator/test/ValidatorServiceTest.java
@@ -39,6 +39,7 @@ public class ValidatorServiceTest extends RhnBaseTestCase {
         to.setStringField("somevalue");
         to.setDateField(new Date());
         to.setLongField(new Long(10));
+        to.setThirdLongField(new Long(65168651651435L));
         to.setSecondStringField("someothervalue");
         to.setNumberString("1");
         to.setAsciiString("asciivalue");
@@ -60,6 +61,7 @@ public class ValidatorServiceTest extends RhnBaseTestCase {
         to.setStringField("somevalue");
         to.setDateField(new Date());
         to.setLongField(new Long(10));
+        to.setThirdLongField(new Long(65168651651435L));
         to.setSecondStringField("someothervalue");
         to.setNumberString("1");
         to.setAsciiString("asciivalue");

--- a/java/code/src/com/redhat/rhn/common/validator/test/ValidatorTest.java
+++ b/java/code/src/com/redhat/rhn/common/validator/test/ValidatorTest.java
@@ -66,29 +66,29 @@ public class ValidatorTest extends TestCase {
 
     public void testNullValue() throws Exception {
         TestObject to = new TestObject();
-        assertNotNull(validator.isValid("stringField", to));
+        assertNotNull(validator.validate("stringField", to));
     }
 
     public void testStringLength() throws Exception {
         TestObject to = new TestObject();
         to.setStringField("short");
-        assertNull(validator.isValid("stringField", to));
+        assertNull(validator.validate("stringField", to));
         to.setStringField("somethingthatistoolongandshouldfail");
-        assertNotNull(validator.isValid("stringField", to));
+        assertNotNull(validator.validate("stringField", to));
         to.setStringField("");
-        assertNotNull(validator.isValid("stringField", to));
+        assertNotNull(validator.validate("stringField", to));
         to.setStringField("    ");
-        assertNotNull(validator.isValid("stringField", to));
+        assertNotNull(validator.validate("stringField", to));
         to.setTwoCharField("it");
-        assertNull(validator.isValid("twoCharField", to));
+        assertNull(validator.validate("twoCharField", to));
     }
 
     public void testASCIIString() throws Exception {
         TestObject to = new TestObject();
         to.setAsciiString("shughes_login");
-        assertNull(validator.isValid("asciiString", to));
+        assertNull(validator.validate("asciiString", to));
         to.setAsciiString("機能拡張を");
-        assertNotNull(validator.isValid("asciiString", to));
+        assertNotNull(validator.validate("asciiString", to));
     }
 
     public void testUserNameString() throws Exception {
@@ -96,49 +96,49 @@ public class ValidatorTest extends TestCase {
 
         // bad user names
         to.setUsernameString("foo&user");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("joe+page");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("joe user");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("10%users");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("joe'suser");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("`eval`");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("joe=page");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("foo#user");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("joe\"user");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("機能拡張を");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("shughes login");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString("shughes%login");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
         to.setUsernameString(" shughes");
-        assertNotNull(validator.isValid("usernameString", to));
+        assertNotNull(validator.validate("usernameString", to));
 
         // good user names
         to.setUsernameString("john.cusack@foobar.com");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("a$user");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("!@$^*()-_{}[]|\\:;?");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("/usr/bin");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("shughes_login");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("shughes@redhat.com");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("/shughes_login");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
         to.setUsernameString("/\\/\\ark");
-        assertNull(validator.isValid("usernameString", to));
+        assertNull(validator.validate("usernameString", to));
 
     }
 
@@ -147,88 +147,88 @@ public class ValidatorTest extends TestCase {
 
         // valid user names
         to.setPosixString("ab");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
         to.setPosixString("AB");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
         to.setPosixString("09");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
         to.setPosixString("aA0");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
         to.setPosixString("_-.");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
         to.setPosixString("a_B-0.Z");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
         to.setPosixString("shughes_login");
-        assertNull(validator.isValid("posixString", to));
+        assertNull(validator.validate("posixString", to));
 
         // Should fail
         to.setPosixString("-ab");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
 
         to.setPosixString("john.cusack@foobar.com");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("a$user");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("!@$^*()-_{}[]|\\:;?");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("/usr/bin");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("shughes@redhat.com");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("/shughes_login");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("/\\/\\ark");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
 
         to.setPosixString("foo&user");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("joe+page");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("joe user");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("10%users");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("joe'suser");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("`eval`");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("joe=page");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("foo#user");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("joe\"user");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("機能拡張を");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("shughes login");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString("shughes%login");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
         to.setPosixString(" shughes");
-        assertNotNull(validator.isValid("posixString", to));
+        assertNotNull(validator.validate("posixString", to));
     }
 
     public void testDateField() throws Exception {
         TestObject to = new TestObject();
         to.setDateField(new Date());
-        assertNull(validator.isValid("dateField", to));
+        assertNull(validator.validate("dateField", to));
     }
 
     public void testLongField() throws Exception {
 
         TestObject to = new TestObject();
         to.setLongField(new Long(10));
-        assertNull(validator.isValid("longField", to));
+        assertNull(validator.validate("longField", to));
         to.setLongField(new Long(100));
-        assertNotNull(validator.isValid("longField", to));
+        assertNotNull(validator.validate("longField", to));
 
-        assertNotNull(validator.isValid("numberString", to));
+        assertNotNull(validator.validate("numberString", to));
         to.setNumberString("0.5");
-        assertNotNull(validator.isValid("numberString", to));
+        assertNotNull(validator.validate("numberString", to));
         to.setNumberString(".5");
-        assertNotNull(validator.isValid("numberString", to));
+        assertNotNull(validator.validate("numberString", to));
         to.setNumberString("1");
-        assertNull(validator.isValid("numberString", to));
+        assertNull(validator.validate("numberString", to));
     }
 
     /* TODO: Implement the multi-value fields */
@@ -236,18 +236,18 @@ public class ValidatorTest extends TestCase {
         TestObject to = new TestObject();
         to.setStringField("ZZZ");
         to.setCompoundField("something");
-        assertNull(validator.isValid("compoundField", to));
+        assertNull(validator.validate("compoundField", to));
         to.setStringField("XXX");
-        assertNull(validator.isValid("compoundField", to));
+        assertNull(validator.validate("compoundField", to));
         to.setStringField("INVALID");
-        assertNull(validator.isValid("compoundField", to));
+        assertNull(validator.validate("compoundField", to));
         to.setCompoundField(null);
-        assertNull(validator.isValid("compoundField", to));
+        assertNull(validator.validate("compoundField", to));
         to.setStringField("XXX");
-        assertNotNull(validator.isValid("compoundField", to));
+        assertNotNull(validator.validate("compoundField", to));
         // Check that the length constraints work too
         to.setCompoundField("somethingmorethan20characterslong");
-        assertNotNull(validator.isValid("compoundField", to));
+        assertNotNull(validator.validate("compoundField", to));
     }
 
     public void testRequiredIfConstraint() {
@@ -257,23 +257,23 @@ public class ValidatorTest extends TestCase {
         to.setSecondStringField("");
 
         // Make sure that when both are null/empty, everything is ok
-        assertNull(validator.isValid("secondStringField", to));
+        assertNull(validator.validate("secondStringField", to));
 
         // If the secondStringField is required if stringField is not null
         to.setStringField("foo");
-        assertNotNull(validator.isValid("secondStringField", to));
+        assertNotNull(validator.validate("secondStringField", to));
 
         // Set both to something and it should be valid
         to.setSecondStringField("bar");
-        assertNull(validator.isValid("secondStringField", to));
+        assertNull(validator.validate("secondStringField", to));
 
         // Since stringField isn't ZZZ or XXX this should
         // be OK
-        assertNull(validator.isValid("secondLongField", to));
+        assertNull(validator.validate("secondLongField", to));
 
         to.setStringField("ZZZ");
         // Now it should fail
-        assertNotNull(validator.isValid("secondLongField", to));
+        assertNotNull(validator.validate("secondLongField", to));
     }
 }
 

--- a/java/code/src/com/redhat/rhn/common/validator/test/ValidatorTest.java
+++ b/java/code/src/com/redhat/rhn/common/validator/test/ValidatorTest.java
@@ -221,6 +221,10 @@ public class ValidatorTest extends TestCase {
         assertNull(validator.validate("longField", to));
         to.setLongField(new Long(100));
         assertNotNull(validator.validate("longField", to));
+        to.setThirdLongField(Long.MAX_VALUE);
+        assertNull(validator.validate("thirdLongFiled", to));
+        to.setThirdLongField(Long.MIN_VALUE);
+        assertNull(validator.validate("thirdLongFiled", to));
 
         assertNotNull(validator.validate("numberString", to));
         to.setNumberString("0.5");

--- a/java/code/src/com/redhat/rhn/frontend/dto/ActivationKeyDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ActivationKeyDto.java
@@ -29,8 +29,8 @@ public class ActivationKeyDto extends BaseDto {
     private boolean keyDisabled;
     private String note;
     private String token;
-    private Integer usageLimit;
-    private Integer systemCount;
+    private Long usageLimit;
+    private Long systemCount;
     private String orgDefault;
 
     /**
@@ -108,7 +108,7 @@ public class ActivationKeyDto extends BaseDto {
      *
      * @return the value of usageLimit
      */
-    public Integer getUsageLimit() {
+    public Long getUsageLimit() {
         return this.usageLimit;
     }
 
@@ -117,7 +117,7 @@ public class ActivationKeyDto extends BaseDto {
      *
      * @param argUsageLimit Value to assign to this.usageLimit
      */
-    public void setUsageLimit(Integer argUsageLimit) {
+    public void setUsageLimit(Long argUsageLimit) {
         this.usageLimit = argUsageLimit;
     }
 
@@ -126,7 +126,7 @@ public class ActivationKeyDto extends BaseDto {
      *
      * @return the value of systemCount
      */
-    public Integer getSystemCount() {
+    public Long getSystemCount() {
         return this.systemCount;
     }
 
@@ -135,7 +135,7 @@ public class ActivationKeyDto extends BaseDto {
      *
      * @param argSystemCount Value to assign to this.systemCount
      */
-    public void setSystemCount(Integer argSystemCount) {
+    public void setSystemCount(Long argSystemCount) {
         this.systemCount = argSystemCount;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -271,31 +271,31 @@
         </context-group>
       </trans-unit>
       <trans-unit id="errors.integer">
-        <source>{0} must be an integer.</source>
+        <source>{0} must be a whole number.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Any page that has required format fields</context>
-          <context context-type="paramnotes">Count must be an integer.</context>
+          <context context-type="paramnotes">Count must be a whole number.</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="errors.long">
-        <source>{0} must be a long.</source>
+      <trans-unit id="errors.integer.minmax">
+        <source>{0} must be a whole number between {1} and {2}.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Any page that has required format fields</context>
-          <context context-type="paramnotes">Count must be a long.</context>
+          <context context-type="paramnotes">Count must be a whole number.</context>
         </context-group>
       </trans-unit>
       <trans-unit id="errors.float">
-        <source>{0} must be a float.</source>
+        <source>{0} must be a decimal number.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Any page that has required format fields</context>
-          <context context-type="paramnotes">Count must be a float.</context>
+          <context context-type="paramnotes">Count must be a decimal number.</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="errors.double">
-        <source>{0} must be a double.</source>
+      <trans-unit id="errors.float.minmax">
+        <source>{0} must be a decimal number between {1} and {2}.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Any page that has required format fields</context>
-          <context context-type="paramnotes">Count must be a double.</context>
+          <context context-type="paramnotes">Count must be a decimal number.</context>
         </context-group>
       </trans-unit>
       <trans-unit id="errors.unexpected">


### PR DESCRIPTION
This pull request applies the following changes:
1. The message when you enter a key limit for custom keys is more comprehensive to end-users.
2. The `NumericConstraint` which was implemented with `Double`-values is split into a `DoubleConstraint` and a `LongConstraint` class. As a result the constraints for big whole numbers stay accurate until `Long.MAX_VALUE` and `Long.MIN_VALUE` instead of +/- 2^53. There is no numeric constraint without limits anymore. Both variables are initialized in the constraint constructor with `MIN_VALUE` and `MAX_VALUE` of `Double`/`Long`. An additional JUnit test has been added.
3. A big number in the database is not translated into an integer anymore. Adding a limit exceeding the range of `Integer` led to a negative key limit being displayed in the UI because of the overflow in the translation routine.
4. The method name `isValid` which is not returning a boolean has been renamed to `validate`, `TODO`-mark removed. An unused variable has been removed as well.