### PR TITLE
1528248 - add --config option to spacecmd.

### DIFF
--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -49,6 +49,8 @@ if __name__ == '__main__':
         sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
     optionsTable = [
+        Option('-c', '--config', action='store',
+               help='config file to use [default: ~/.spacecmd/config]'),
         Option('-u', '--username', action='store',
                help='use this username to connect to the server'),
         Option('-p', '--password', action='store',
@@ -107,24 +109,33 @@ if __name__ == '__main__':
     else:
         shell.config['server'] = gethostname()
 
+    # don't automatically create config files passed via --config
+    if shell.options.config:
+        if not os.path.isfile(shell.options.config):
+            logging.error('Config file %s does not exist.', shell.options.config)
+            sys.exit(1)
+    else:
     # create an empty configuration file if one's not present
-    if not os.path.isfile(user_conf_file):
-        try:
-            # create ~/.spacecmd
-            if not os.path.isdir(conf_dir):
-                logging.debug('Creating %s', conf_dir)
-                os.mkdir(conf_dir, 0700)
+        if not os.path.isfile(user_conf_file):
+            try:
+                # create ~/.spacecmd
+                if not os.path.isdir(conf_dir):
+                    logging.debug('Creating %s', conf_dir)
+                    os.mkdir(conf_dir, 0700)
 
-            # create a template configuration file
-            logging.debug('Creating configuration file: %s', user_conf_file)
-            handle = open(user_conf_file, 'w')
-            handle.write('[spacecmd]\n')
-            handle.close()
-        except IOError:
-            logging.error('Could not create %s', user_conf_file)
+                # create a template configuration file
+                logging.debug('Creating configuration file: %s', user_conf_file)
+                handle = open(user_conf_file, 'w')
+                handle.write('[spacecmd]\n')
+                handle.close()
+            except IOError:
+                logging.error('Could not create %s', user_conf_file)
 
     # load options from configuration files
-    files_read = config.read([_SYSTEM_CONF_FILE, user_conf_file])
+    if shell.options.config:
+        files_read = config.read([_SYSTEM_CONF_FILE, user_conf_file, shell.options.config])
+    else:
+        files_read = config.read([_SYSTEM_CONF_FILE, user_conf_file])
 
     for item in files_read:
         logging.debug('Read configuration from %s', item)

--- a/spacecmd/src/doc/spacecmd.1
+++ b/spacecmd/src/doc/spacecmd.1
@@ -35,6 +35,8 @@ spacecmd -s server1 -- softwarechannel_create -n \\'My Channel\\' \\
 .fi
 .SH OPTIONS
 .TP
+.B \-c CONFIG_FILE, \-\-config=CONFIG_FILE
+config file to use [default: ~/.spacecmd/config]
 .B \-u USERNAME, \-\-username=USERNAME
 use this username to connect to the server
 .TP
@@ -64,10 +66,11 @@ show this help message and exit
 .fi
 .SH CONFIGURATION FILES
 .nf
-Configuration files are loaded from /etc/spacecmd.conf and ~/.spacecmd/config.
-The default section is [spacecmd].  It can then be overridden with server
-specific sections.  Command-line arguments always override options in the
-configuration files.
+Configuration files are loaded from /etc/spacecmd.conf and
+~/.spacecmd/config, unless overridden by the --config option.  The
+default section is [spacecmd].  It can then be overridden with server
+specific sections.  Command-line arguments always override options in
+the configuration files.
 .fi
 .P
 .nf


### PR DESCRIPTION
Add --config option to spacecmd to allow user to specify which config file to use. This allows the user to have multiple config files with different server and credential details.

Signed-off-by: Laurence Rochfort <laurence.rochfort@oracle.com>