### PR TITLE
1528252 - Add --config option to rhncfg-manager and rhncfg-client.

### DIFF
--- a/client/tools/rhncfg/config_common/rhn_main.py
+++ b/client/tools/rhncfg/config_common/rhn_main.py
@@ -45,7 +45,7 @@ class BaseMain:
     config_section = None
 
     def usage(self, exit_code):
-        print("Usage: %s MODE [ --server-name name ] [ params ]" % sys.argv[0])
+        print("Usage: %s MODE [ --config config_file ] [ --server-name name ] [ params ]" % sys.argv[0])
         print("Valid modes are:")
         for mode in self.modes:
             print("\t%s" % mode)
@@ -58,7 +58,7 @@ class BaseMain:
         debug_level = 3
         mode = None
 
-        dict_name_opt={'--server-name': None,'--password': None,'--username': None,}
+        dict_name_opt={'--server-name': None,'--password': None,'--username': None, '--config': None,}
         for index in range(1,len(sys.argv)):
             arg=sys.argv[index]
             param = [x for x in dict_name_opt.items() if x[1] == 0]
@@ -115,6 +115,10 @@ class BaseMain:
         server_name = dict_name_opt['--server-name']
         password = dict_name_opt['--password']
         username = dict_name_opt['--username']
+        config_file_override = dict_name_opt['--config']
+
+        if config_file_override and not os.path.isfile(config_file_override):
+            rhn_log.die(1, "Config file %s does not exist.", config_file_override)
 
         rhn_log.set_debug_level(debug_level)
 
@@ -148,9 +152,9 @@ class BaseMain:
         up2date_cfg = dict(cfg.items())
 
         if server_name:
-            local_config.init(self.config_section, defaults=up2date_cfg, server_url="https://" + server_name)
+            local_config.init(self.config_section, defaults=up2date_cfg, config_file_override=config_file_override, server_url="https://" + server_name)
         else:
-            local_config.init(self.config_section, defaults=up2date_cfg)
+            local_config.init(self.config_section, defaults=up2date_cfg, config_file_override=config_file_override)
 
             try:
                 server_name = local_config.get('server_url')
@@ -165,7 +169,7 @@ class BaseMain:
                     else:
                         up2date_cfg['server_list'] = [urlsplit(x)[1] for x in server_name]
                     server_name = (up2date_cfg['server_list'])[0]
-                    local_config.init(self.config_section, defaults=up2date_cfg, server_name=server_name)
+                    local_config.init(self.config_section, defaults=up2date_cfg, config_file_override=config_file_override,  server_name=server_name)
 
         print("Using server name %s" % server_name)
 

--- a/client/tools/rhncfg/config_management/rhncfg-manager.sgml
+++ b/client/tools/rhncfg/config_management/rhncfg-manager.sgml
@@ -24,6 +24,7 @@
     <cmdsynopsis>
         <command>&RHNCFGM;</command>
         <arg>MODE</arg>
+        <arg>--config <replaceable>config_file</replaceable></arg>
         <arg>--server-name <replaceable>name</replaceable></arg>
         <arg>--username <replaceable>user</replaceable></arg>
         <arg>--password <replaceable>pass</replaceable></arg>
@@ -46,14 +47,19 @@
     This tool is intended for use by the Config Administrator and therefore
     requires an &RHN; username and password that has the appropriate permission
     set. (The username and password may be specified in
-    <filename>/etc/sysconfig/rhn/rhncfg-manager.conf</filename> or in the [rhncfg-manager] section
-    of <filename>~/.rhncfgrc</filename>).
+    <filename>/etc/sysconfig/rhn/rhncfg-manager.conf</filename> or in
+    the [rhncfg-manager] section of <filename>~/.rhncfgrc</filename>
+    or the config file specified
+    by <term>--config=<replaceable>config_file</replaceable></term>).
 </para>
 <para>
     Note that when run as root, &RHNCFGM; attempts to pull in needed
     configuration values from the Red Hat Update Agent (up2date). When run as
     something other than root, configuration changes may be needed within the
-    <filename>~/.rhncfgrc</filename> file. The session file is cached in
+    <filename>~/.rhncfgrc</filename> file, or the config file
+    specified
+    by <term>--config=<replaceable>config_file</replaceable></term>. The
+    session file is cached in
     <filename>~/.rhncfg-manager-session</filename> to prevent logging in for
     every command.
 </para>
@@ -61,7 +67,10 @@
     The <filename>~/.rhncfgrc</filename> file overrides the values set in
     <filename>/etc/sysconfig/rhn/rhncfg-manager.conf</filename> which, by
     default, uses the values set in
-    <filename>/etc/sysconfig/rhn/up2date</filename>. Please review
+    <filename>/etc/sysconfig/rhn/up2date</filename>. The <filename>~/.rhncfgrc</filename>
+    file may itself be overridden by the command line
+    option <term>--config=<replaceable>config_file</replaceable></term>
+    Please review
     <filename>rhncfg-manager.conf</filename> for further details.
 </para>
 <para>


### PR DESCRIPTION
Add --config option to rhncfg-manager and rhncfg-client to allow user to override the config file to be used. Allows user to have multiple config files with different Spacewalk server and credential details.

Signed-off-by: Laurence Rochfort <laurence.rochfort@oracle.com>