### PR TITLE
Fix redirect to the complete url_bounce

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.frontend.servlets.PxtSessionDelegate;
 
 import org.apache.commons.collections.set.UnmodifiableSet;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 
 import java.io.IOException;
 import java.util.Set;
@@ -161,8 +162,13 @@ public class PxtAuthenticationService extends BaseAuthenticationService {
                 response.sendRedirect("/rhn/Login2.do");
                 return;
             }
-            response.sendRedirect("/rhn/Login.do?url_bounce=" + urlBounce +
-                    "&request_method=" + request.getMethod());
+
+            URIBuilder uriBuilder = new URIBuilder();
+            uriBuilder.setPath("/rhn/Login.do");
+            uriBuilder.addParameter("url_bounce", urlBounce);
+            uriBuilder.addParameter("request_method", request.getMethod());
+
+            response.sendRedirect(uriBuilder.toString());
         }
         catch (IOException e) {
             throw new ServletException(e);

--- a/java/code/src/com/redhat/rhn/frontend/security/test/PxtAuthenticationServiceTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/test/PxtAuthenticationServiceTest.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.security.test;
 
 import com.redhat.rhn.frontend.security.PxtAuthenticationService;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.jmock.Expectations;
 
 import java.util.Vector;
@@ -159,6 +160,10 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
         setupPxtDelegate(true, false, 1234L);
         setupGetRequestURI("/rhn/YourRhn.do");
 
+        URIBuilder uriBuilder = new URIBuilder("/rhn/Login.do");
+        uriBuilder.addParameter("url_bounce", "/rhn/YourRhn.do");
+        uriBuilder.addParameter("request_method", "POST");
+
         context().checking(new Expectations() { {
             allowing(mockRequest).getParameterNames();
             will(returnValue(new Vector<String>().elements()));
@@ -176,8 +181,7 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
             allowing(mockPxtDelegate)
                     .isPxtSessionKeyValid(with(any(HttpServletRequest.class)));
             will(returnValue(false));
-            oneOf(mockResponse).sendRedirect("/rhn/Login.do?url_bounce=" +
-                    "/rhn/YourRhn.do&request_method=POST");
+            oneOf(mockResponse).sendRedirect(uriBuilder.toString());
             will(returnValue(null));
             allowing(mockRequest).setAttribute("url_bounce", uri);
         } });
@@ -193,12 +197,18 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
         setupGetRequestURI("/rhn/YourRhn.do");
         setUpRedirectToLogin();
 
+        URIBuilder uriBounceBuilder = new URIBuilder();
+        uriBounceBuilder.setPath("/rhn/YourRhn.do");
+        uriBounceBuilder.addParameter("question", "param 1 = 'Who is the one?'");
+        uriBounceBuilder.addParameter("answer", "param 2 = 'Neo is the one!'");
+
+        URIBuilder uriBuilder = new URIBuilder();
+        uriBuilder.setPath("/rhn/Login.do");
+        uriBuilder.addParameter("url_bounce", uriBounceBuilder.toString());
+        uriBuilder.addParameter("request_method", "POST");
+
         context().checking(new Expectations() { {
-            allowing(mockResponse).sendRedirect(
-                    "/rhn/Login.do?url_bounce=/rhn/YourRhn.do?" +
-                            "question=param+1+%3D+%27Who+is+the+one%3F%27&" +
-                            "answer=param+2+%3D+%27Neo+is+the+one%21%27&" +
-                            "request_method=POST");
+            allowing(mockResponse).sendRedirect(uriBuilder.toString());
             will(returnValue(null));
             allowing(mockRequest).getRequestURI();
             will(returnValue("/rhn/YourRhn.do"));

--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
@@ -29,10 +29,7 @@ import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Date;
-import java.util.Enumeration;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -116,29 +113,6 @@ public class AuthFilter implements Filter {
         ActionMessages ams = new ActionMessages();
         ams.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(msgKey, args));
         hreq.getSession().setAttribute(Globals.ERROR_KEY, ams);
-    }
-
-    /**
-     * @param request
-     * @param response
-     * @param hreq
-     * @throws MalformedURLException
-     * @throws ServletException
-     * @throws IOException
-     */
-    private URL getHttpRequestReferer(HttpServletRequest hreq) {
-        Enumeration em = hreq.getHeaders("referer");
-        URL url = null;
-        while (em.hasMoreElements()) {
-            String urlString = (String) em.nextElement();
-            try {
-                url = new URL(urlString);
-            }
-            catch (MalformedURLException e) {
-                // it does not matter, if there's no referer
-            }
-        }
-        return url;
     }
 
     /**


### PR DESCRIPTION
This PR fixes how the `url_bounce` is built and encoded to prevent `Page Request Error` error in case the `url_bounce` contains more than one `query string` parameter

## Previous Behavior
1. url_bounce = `/rhn/systems/details/history/Event.do?sid=1000010001&aid=10`
2. login url will be = `/rhn/Login.do?url_bounce=/rhn/systems/details/history/Event.do?sid=1000010001&aid=10&request_method=GET`
3. `request.getParameter("url_bounce")` will extract only `/rhn/systems/details/history/Event.do?sid=1000010001`, losing the `aid=10` parameter that is required to be redirected to the correct page. A `Page Request Error` will be shown instead. **BUG**

## New Behavior
1. url_bounce = `/rhn/systems/details/history/Event.do?sid=1000010001&aid=10`
2. login url will be = `/rhn/Login.do?url_bounce=%2Frhn%2Fsystems%2Fdetails%2Fhistory%2FEvent.do%3Fsid%3D1000010001%26aid%3D10&request_method=GET`
3. `request.getParameter("url_bounce")` will extract and decode the complete url to be redirected to `/rhn/systems/details/history/Event.do?sid=1000010001&aid=10`
