### PR TITLE
Keep the authtoken appended to the URL when downloading repo content

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -205,6 +205,8 @@ class DownloadThread(Thread):
         for retry in range(max(self.parent.retries, mirrors)):
             fo = None
             url = urlparse.urljoin(params['urls'][self.mirror], params['relative_path'])
+            if params['authtoken']:
+                url = "{0}?{1}".format(url, params['authtoken'])
             try:
                 try:
                     fo = PyCurlFileObjectThread(url, params['target_file'], opts, self.curl, self.parent)


### PR DESCRIPTION
SUSE repos uses authtokens which needs to be appended to the URL.
This PR implements it for the new Downloader.