### PR TITLE
refactoring ljust methods in print

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -21,6 +21,7 @@ from spacewalk.satellite_tools.progress_bar import ProgressBar
 from spacewalk.server.rhnPackage import unlink_package_file
 from spacewalk.server import rhnSQL
 
+
 def __serverCheck(labels, unsubscribe):
     sql = """
         select distinct S.org_id, S.id, S.name
@@ -44,14 +45,10 @@ def __serverCheck(labels, unsubscribe):
     print("If you would like to automatically unsubscribe these systems, simply use the --unsubscribe flag.\n")
     print("The following systems were found to be subscribed:")
 
-    print 'org_id'.ljust(8),
-    print 'id'.ljust(14),
-    print('name')
-    print ("-" * 32)
+    print("%-8s %-14s name" % ('org_id', 'id'))
+    print("-" * 32)
     for server in server_list:
-        print str(server['org_id']).ljust(8),
-        print str(server['id']).ljust(14),
-        print(server['name'])
+        print("%-8s %-14s %s" % (server['org_id'], server['id'], server['name']))
 
     return len(server_list)
 
@@ -79,8 +76,7 @@ def __unsubscribeServers(labels):
     channel_list = channel_counts.keys()
     channel_list.sort()
     for i in channel_list:
-        print(i.ljust(40)),
-        print(str(channel_counts[i]).ljust(8))
+        print("%-40s s-8%" % (i, channel_counts[i]))
 
     pb = ProgressBar(prompt='Unsubscribing:    ', endTag=' - complete',
                      finalSize=len(server_channel_list), finalBarLength=40, stream=sys.stdout)
@@ -114,12 +110,10 @@ def __kickstartCheck(labels):
 
     print("The following kickstarts are associated with one of the specified channels. " +
           "Please remove these or change their associated base channel.\n")
-    print('org_id'.ljust(8)),
-    print('label')
+    print("%-8s label" % ('org_id', 'label'))
     print("-" * 20)
     for kickstart in kickstart_list:
-        print str(kickstart['org_id']).ljust(8),
-        print(kickstart['label'])
+        print("%-8s %s" % (kickstart['org_id'], kickstart['label']))
 
     return len(kickstart_list)
 


### PR DESCRIPTION
Rewriting old code.

```
str(len(failed)).rjust(3) -> "%3d" % len(failed)
str(action.get('id')).ljust(6) -> "%-6s % action.get('id')
```