### PR TITLE
BZ 1539878 - add save_cache to do_ssm_intersect

### DIFF
--- a/spacecmd/src/lib/ssm.py
+++ b/spacecmd/src/lib/ssm.py
@@ -134,6 +134,9 @@ def do_ssm_intersect(self, args):
 
     # set self.ssm to tmp_ssm, which now holds the intersection
     self.ssm = tmp_ssm
+    
+    # save the SSM for use between sessions
+    save_cache(self.ssm_cache_file, self.ssm)
 
     if self.ssm:
         logging.debug('Systems Selected: %i' % len(self.ssm))


### PR DESCRIPTION
In relation to BZ 1539878 - add `save_cache()` to `do_ssm_intersect` to allow cli ssm_intersect updates to the ssm cache across sessions.

Cf https://bugzilla.redhat.com/show_bug.cgi?id=1539878