### PR TITLE
Client: strip quotes when reading HOSTNAME out of /etc/sysconfig/network

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/hardware.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/hardware.py
@@ -566,10 +566,10 @@ def findHostByRoute():
             vals = info.split('=')
             if len(vals) <= 1:
                 continue
-            strippedstring = vals[0].strip()
-            vals[0] = strippedstring
-            if vals[0] == "HOSTNAME":
-                hostname = ''.join(vals[1:]).strip()
+            if vals[0].strip() == "HOSTNAME":
+                # /etc/sysconfig/network is of shell syntax,
+                # so values can be quoted
+                hostname = ''.join(vals[1:]).strip('"\' \t\n')
                 break
 
     if hostname == None or hostname == 'localhost.localdomain':


### PR DESCRIPTION
Because `/etc/sysconfig/network` is of shell syntax, either of those is valid:
```
1. HOSTNAME=foo.bar
2. HOSTNAME='foo.bar'
3. HOSTNAME="foo.bar"
```
When the entry is not in format (1), `findHostByRoute()` returns hostname *with* the quotes, which later in `read_network()` leads to things like `getaddrinfo('"foo.bar"', None)` which is probably always wrong.

Strip quotes (in addition to whitespaces) to fix this behaviour.

While at it, simplify the code - no need for "strippedstring" at all.
