### PR TITLE
add BuildRequires gcc

### DIFF
--- a/client/rhel/rhnsd/rhnsd.spec
+++ b/client/rhel/rhnsd/rhnsd.spec
@@ -9,6 +9,7 @@ URL:     https://github.com/spacewalkproject/spacewalk
 BuildRequires: gettext
 
 Requires: rhn-check >= 0.0.8
+BuildRequires: gcc
 %if 0%{?suse_version} >= 1210 || 0%{?fedora}
 BuildRequires: systemd
 %{?systemd_requires}


### PR DESCRIPTION
gcc will be soon removed from Fedora default buildroot and it will result into this failure:

gcc -DVERSION=\"5.0.35\" -fPIC -pie -fPIE -Wl,-z,relro,-z,now -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -mcet -fcf-protection -c -o rhnsd.o rhnsd.c
make: gcc: Command not found

adding explicit BR will make no harm on other platforms as there is gcc already present