### PR TITLE
Fix selinux policy (rh1517791 rh1494675  rh1522939)

### DIFF
--- a/selinux/spacewalk-selinux/spacewalk.te
+++ b/selinux/spacewalk-selinux/spacewalk.te
@@ -41,7 +41,8 @@ dontaudit httpd_sys_script_t httpd_log_t:file { ioctl };
 type spacewalk_initrc_exec_t;
 domain_entry_file(initrc_t, spacewalk_initrc_exec_t)
 
-allow tomcat_t self:netlink_audit_socket create;
+allow tomcat_t self:netlink_audit_socket { nlmsg_relay read write };
+allow tomcat_t spacewalk_log_t:file { open read };
 
 optional_policy(`
 	gen_require(`


### PR DESCRIPTION
This patch will fix the following selinux policy bugs:
* [Bug 1517791](https://bugzilla.redhat.com/show_bug.cgi?id=1517791) - AVC: Kerberos user cannot login to Spacewalk on RHEL 7 
* [Bug 1494675](https://bugzilla.redhat.com/show_bug.cgi?id=1494675) - PAM authentication no longer works after upgrading to CentOS 7.4 
* [Bug 1522939](https://bugzilla.redhat.com/show_bug.cgi?id=1522939) - Internal Server Error - Syncing Repos to Channel