### PR TITLE
[spacecmd] Fix softwarechannel_listsyncschedule

### DIFF
--- a/spacecmd/src/lib/softwarechannel.py
+++ b/spacecmd/src/lib/softwarechannel.py
@@ -2403,7 +2403,7 @@ def do_softwarechannel_listsyncschedule(self, args):
     print(csched_fmt.format('-----', '---------------------', '---------------'))
 
     # Sort and print(the channel names and associated repo-sync schedule (if any))
-    for key,value in sorted(chan_name.items(), key=lambda k,v: (v,k)):
+    for key,value in sorted(chan_name.items()):
         print(csched_fmt.format(str(key), value, chan_sched[int(key)]))
 
 ####################


### PR DESCRIPTION
Without this fix, the function is returning the following error:
`ERROR: <lambda>() takes exactly 2 arguments (1 given)`