### PR TITLE
1564065 - Fix relevant_to_server_group query performance.

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -122,24 +122,26 @@ SELECT DISTINCT E.id, E.update_date, E.advisory_name, E.synopsis as advisory_syn
 
 <mode name="relevant_to_server_group" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="sgid">
-SELECT DISTINCT E.id, E.advisory, E.advisory_name, E.advisory_type, E.synopsis AS ADVISORY_SYNOPSIS,
-     E.update_date,
-     (SELECT COUNT(Distinct SGM2.server_id)
-       FROM rhnServerNeededErrataCache SNEC,
-            rhnServerGroupMembers SGM2
-       WHERE SNEC.errata_id = E.id
-       AND SNEC.server_id = SGM2.server_id
-       AND SGM2.server_group_id = :sgid) AS AFFECTED_SYSTEM_COUNT
-  FROM rhnErrata E,
-       rhnServerNeededErrataCache SNEC,
-       rhnServerGroupMembers SGM,
-       rhnServerFeaturesView SFV
- WHERE SGM.server_id = SNEC.server_id
-   AND SNEC.errata_id = E.id
-   AND SFV.server_id = SGM.server_id
-   AND SFV.label = 'ftr_system_grouping'
+SELECT DISTINCT E.id,
+       		E.advisory,
+		E.advisory_name,
+		E.advisory_type,
+		E.synopsis AS ADVISORY_SYNOPSIS,
+		E.update_date,
+		AFSC.count AS AFFECTED_SYSTEM_COUNT
+  FROM rhnErrata E
+  INNER JOIN (SELECT SNEC2.errata_id AS errata_id,
+  	     	     COUNT(DISTINCT SGM2.server_id) AS count
+  	        FROM rhnServerGroupMembers SGM2
+		JOIN rhnServerNeededErrataCache SNEC2 ON (SNEC2.server_id = SGM2.server_id)
+               WHERE SGM2.server_group_id = :sgid
+	       GROUP BY errata_id) AFSC ON (AFSC.errata_id = E.id)
+  JOIN rhnServerNeededErrataCache SNEC ON (SNEC.errata_id = E.id)
+  JOIN rhnServerGroupMembers SGM ON (SGM.server_id = SNEC.server_id)
+  JOIN rhnServerFeaturesView SFV ON (SFV.server_id = SGM.server_id)
+ WHERE SFV.label = 'ftr_system_grouping'
    AND SGM.server_group_id = :sgid
-ORDER BY E.update_date DESC, E.id
+ ORDER BY E.update_date DESC, E.id
   </query>
 </mode>
 


### PR DESCRIPTION
Correlated subquery causes 15+ minute query time.

Please see BZ for details.