### PR TITLE
rhnRepository.py: add support for Debian / Ubuntu Release files

### DIFF
--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -238,7 +238,8 @@ class Repository(rhnRepository.Repository):
         if file_name in ["repomd.xml", "comps.xml"]:
             content_type = "text/xml"
         elif file_name not in ["primary.xml.gz", "other.xml.gz",
-                               "filelists.xml.gz", "updateinfo.xml.gz", "Packages.gz", "modules.yaml"]:
+                               "filelists.xml.gz", "updateinfo.xml.gz", "Packages.gz", "modules.yaml",
+                               "InRelease", "Release", "Release.gpg"]:
             log_debug(2, "Unknown repomd file requested: %s" % file_name)
             raise rhnFault(6)
 


### PR DESCRIPTION
Please see https://bugzilla.redhat.com/show_bug.cgi?id=1198723 for more
information. @philicious added the patches needed to get
Debian / Ubuntu repos signed. This is just the part needed on the server.

Further modification is needed on client side in package "apt-transport-spacewalk"

I was also able to rebuild the apt-transport-spacewalk package from source (apt-get source) and modified that to use the "quilt" format and applied the patches @philicious created in the bugreport mentioned above.

Bigger problem might be, that the apt-spacewalk package is going to disappear from debian as mentioned in https://tracker.debian.org/pkg/apt-spacewalk, so maybe I'm also trying to modify the files within this repo, so this package can be built from here.

