### PR TITLE
Fix apt-transport-spacewalk to support signed repos

### DIFF
--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/50spacewalk
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/50spacewalk
@@ -6,10 +6,10 @@ APT {
   Update {
         List-Refresh "true";
         Pre-Invoke {
-            "if [ -x /usr/lib/apt-spacewalk/post_invoke.py ]; then /usr/lib/apt-spacewalk/post_invoke.py; fi";
+            "if [ -x /usr/lib/apt-spacewalk/pre_invoke.py ]; then /usr/lib/apt-spacewalk/pre_invoke.py; fi";
         }
   }
 };
 DPkg::Post-Invoke {
-    "/usr/lib/apt-spacewalk/post_invoke.py";
+    "if [ -x /usr/lib/apt-spacewalk/post_invoke.py ]; then /usr/lib/apt-spacewalk/post_invoke.py; fi";
 };

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/changelog
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/changelog
@@ -1,3 +1,11 @@
+apt-spacewalk (1.0.6-2.1) UNRELEASED; urgency=medium
+
+  * Non-maintainer upload.
+  * Added support for signed repos
+    see https://bugzilla.redhat.com/show_bug.cgi?id=1198723
+
+ -- Robert Paschedag <robert.paschedag@web.de>  Thu, 05 Apr 2018 18:14:03 +0200
+
 apt-spacewalk (1.0.6-2) unstable; urgency=low
 
   * [22c43b83] Rename binary package to apt-transport-spacewalk

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/changelog
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/changelog
@@ -1,10 +1,9 @@
-apt-spacewalk (1.0.6-2.1) UNRELEASED; urgency=medium
+apt-spacewalk (1.0.7-1) UNRELEASED; urgency=medium
 
-  * Non-maintainer upload.
-  * Added support for signed repos
+  * added support for signed repositories
     see https://bugzilla.redhat.com/show_bug.cgi?id=1198723
 
- -- Robert Paschedag <robert.paschedag@web.de>  Thu, 05 Apr 2018 18:14:03 +0200
+ -- Robert Paschedag <robert.paschedag@web.de>  Fri, 06 Apr 2018 21:42:45 +0200
 
 apt-spacewalk (1.0.6-2) unstable; urgency=low
 

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/control
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/control
@@ -16,8 +16,8 @@ Depends: ${misc:Depends}, ${python:Depends}, apt, python-apt,
 Provides: ${python:Provides}
 Recommends: rhnsd
 Description: APT transport for communicating with Spacewalk servers
- makes it possible to use
- 'deb spacewalk://your-spacewalk-server/XMLRPC channels: channel1 channel2'
- type lines in your sources.list. Also it provides the necessary hooks to
- update your sources.list automatically according to the settings on
- your Spacewalk server.
+ creates repository entries like
+ 'deb spacewalk://your-spacewalk-server/ channel repodata'
+ for every channel the client has subscribed in your sources.list.
+ Also it provides the necessary hooks to update your sources.list
+ automatically according to the settings on your Spacewalk server.

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/pre_invoke.py
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/pre_invoke.py
@@ -37,10 +37,9 @@ from up2date_client import up2dateErrors
 def get_channels():
     """Return channels associated with a machine"""
     try:
-        channels = ['main']
+        channels = []
         for channel in rhnChannel.getChannelDetails():
-            if channel['parent_channel']:
-                channels.append(channel['label'])
+            channels.append(channel['label'])
         return channels
     except up2dateErrors.Error:
         return []

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/pre_invoke.py
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/pre_invoke.py
@@ -66,15 +66,16 @@ def update_sources_list():
             source.set_enabled(False)
             sw_source.append(source)
 
+    for source in sw_source:
+        sources.remove(source)
     if up2dateAuth.getSystemId():
         channels = get_channels()
         if len(channels):
-            for source in sw_source:
-                sources.remove(source)
-            sources.add(type='deb',
+            for chan in channels:
+                sources.add(type='deb',
                         uri='spacewalk://' + get_server(),
-                        dist='channels:',
-                        orig_comps=channels,
+                        dist=chan,
+                        orig_comps=['repodata'],
                         file=get_conf_file()
                         )
     sources.save()

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/spacewalk
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/spacewalk
@@ -191,10 +191,11 @@ class spacewalk_method(pkg_acquire_method):
 
     def __transform_document(self, document):
         """Transform url given by apt to real spacewalk url"""
-        document = document.replace('dists/channels:/main/',
-                'dists/channels:/' + self.base_channel  + '/', 1)
-        document = re.sub('/binary-[\d\w]*/', '/repodata/', document, 1)
-        document = document.replace('dists/channels:/', '/XMLRPC/GET-REQ/', 1)
+        document = document.replace('dists/', '/XMLRPC/GET-REQ/', 1)
+        document = re.sub('/binary-[\d\w]*/', '/', document, 1)
+        document = re.sub('/(InRelease|Release|Release.gpg)', r'/repodata/\1', document, 1)
+        # point i18n to wrong path so we dont get traceback mails when not having i18n in repodata
+        document = document.replace('repodata/i18n', '/i18n', 1)
         return document
 
 


### PR DESCRIPTION
This is the *client* part of #636 to be able to use signed Debian / Ubuntu repositories. See https://bugzilla.redhat.com/show_bug.cgi?id=1198723 for more information.

It also looks like the package is going lost on Debian (see https://tracker.debian.org/pkg/apt-spacewalk). 

Therefore, I patched the files within this repository, so that we can be able to rebuild the package. I also increased the version of the Debian package to ```1.0.7-1```, so the package is newer than the last official debian package.

The creation of the Release and Release.gpg files still needs to be done manually on the server for each channel. See also @philicious blog entry http://www.devops-blog.net/spacewalk/gpg-signing-apt-repository-in-spacewalk