### PR TITLE
Fix race condition in lookup_evr and possibly similar others

### DIFF
--- a/schema/spacewalk/postgres/procs/create_pxt_session.sql
+++ b/schema/spacewalk/postgres/procs/create_pxt_session.sql
@@ -26,11 +26,15 @@ declare
 begin
     l_id := nextval( 'pxt_id_seq' );
 
-    perform pg_dblink_exec(
-        'insert into PXTSessions (id, value, expires, web_user_id) values (' ||
-        l_id || ', ' || coalesce(quote_literal(p_value), 'NULL') ||
-        ', ' || p_expires || ', ' || coalesce(quote_literal(p_web_user_id), 'NULL') || '); commit');
+    insert into PXTSessions (id, value, expires, web_user_id)
+        values (l_id, p_value, p_expires, p_web_user_id)
+        on conflict do nothing;
 
-	return l_id;
+    select id
+        into strict l_id
+        from PXTSessions
+        where value = p_value and expires = p_expires and web_user_id = p_web_user_id;
+
+	  return l_id;
 end;
 $$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_client_capability.sql
+++ b/schema/spacewalk/postgres/procs/lookup_client_capability.sql
@@ -27,19 +27,17 @@ begin
 
     if not found then
         cap_name_id := nextval('rhn_client_capname_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnClientCapabilityName(id, name) values (' ||
-                cap_name_id  || ' ,' ||
-                coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict cap_name_id
-              from rhnclientcapabilityname
+
+        insert into rhnClientCapabilityName(id, name)
+            values (cap_name_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict cap_name_id
+            from rhnclientcapabilityname
             where name = name_in;
-        end;
     end if;
 
     return cap_name_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_config_filename.sql
+++ b/schema/spacewalk/postgres/procs/lookup_config_filename.sql
@@ -27,19 +27,17 @@ begin
 
     if not found then
         name_id := nextval('rhn_cfname_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnConfigFileName (id, path) values (' ||
-                name_id || ', ' ||
-                coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict name_id
-              from rhnconfigfilename
-             where path = name_in;
-        end;
+
+        insert into rhnConfigFileName (id, path)
+            values (name_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict name_id
+            from rhnconfigfilename
+            where path = name_in;
     end if;
 
     return name_id;
-end; $$
-language plpgsql;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_config_info.sql
+++ b/schema/spacewalk/postgres/procs/lookup_config_info.sql
@@ -47,21 +47,14 @@ begin
     end loop;
     -- If we got here, we don't have the id
     v_id := nextval('rhn_confinfo_id_seq');
-    begin
-        perform pg_dblink_exec(
-            'insert into rhnConfigInfo ' ||
-            '(id, username, groupname, filemode, selinux_ctx, symlink_target_filename_id)' ||
-            'values (' || v_id || ', ' ||
-            coalesce(quote_literal(username_in), 'NULL') || ', ' ||
-            coalesce(quote_literal(groupname_in), 'NULL') || ', ' ||
-            coalesce(quote_literal( filemode_in), 'NULL') || ', ' ||
-            coalesce(quote_literal(selinux_ctx_in), 'NULL') || ', ' ||
-            coalesce(quote_literal(symlink_target_id), 'NULL') || ')');
-    exception when unique_violation then
-        for r in lookup_cursor loop
-            return r.id;
-        end loop;
-    end;
+
+    insert into rhnConfigInfo (id, username, groupname, filemode, selinux_ctx, symlink_target_filename_id)
+        values (v_id, username_in, groupname_in, filemode_in, selinux_ctx_in, symlink_target_id)
+        on conflict do nothing;
+
+    for r in lookup_cursor loop
+        return r.id;
+    end loop;
     return v_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_cve.sql
+++ b/schema/spacewalk/postgres/procs/lookup_cve.sql
@@ -27,17 +27,17 @@ begin
 
     if not found then
         name_id := nextval('rhn_cve_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnCVE (id, name) values (' || name_id || ', ' ||
-                coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict name_id
-              from rhnCVE
-             where name = name_in;
-        end;
+
+        insert into rhnCVE (id, name)
+            values (name_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict name_id
+            from rhnCVE
+            where name = name_in;
     end if;
 
     return name_id;
-end; $$ language plpgsql immutable;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_package_delta.sql
+++ b/schema/spacewalk/postgres/procs/lookup_package_delta.sql
@@ -27,18 +27,17 @@ begin
 
     if not found then
         name_id := nextval('rhn_packagedelta_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnPackageDelta(id, label) values (' ||
-                name_id || ', ' || coalesce(quote_literal(n_in), 'NULL'), ')' );
-        exception when unique_violation then
-            select id
-              into strict name_id
-              from rhnpackagedelta
-             where label = n_in;
-        end;
+
+        insert into rhnPackageDelta(id, label)
+            values (name_id, n_in)
+            on conflict do nothing;
+
+        select id
+            into strict name_id
+            from rhnpackagedelta
+            where label = n_in;
     end if;
 
     return name_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_package_group.sql
+++ b/schema/spacewalk/postgres/procs/lookup_package_group.sql
@@ -28,19 +28,17 @@ begin
 
     if not found then
         package_id := nextval('rhn_package_group_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnPackageGroup(id, name) values (' ||
-                package_id || ', ' || coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict package_id
-              from rhnPackageGroup
-             where name = name_in;
-        end;
+
+        insert into rhnPackageGroup(id, name)
+            values (package_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict package_id
+            from rhnPackageGroup
+            where name = name_in;
     end if;
 
     return package_id;
 end;
-$$
-language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_package_name.sql
+++ b/schema/spacewalk/postgres/procs/lookup_package_name.sql
@@ -32,18 +32,17 @@ begin
 
     if not found then
         name_id := nextval('rhn_pkg_name_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnPackageName(id, name) values (' || name_id || ', ' ||
-                coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict name_id
-              from rhnPackageName
-             where name = name_in;
-        end;
+
+        insert into rhnPackageName(id, name)
+            values (name_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict name_id
+            from rhnPackageName
+            where name = name_in;
     end if;
 
     return name_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_source_name.sql
+++ b/schema/spacewalk/postgres/procs/lookup_source_name.sql
@@ -28,19 +28,17 @@ begin
 
     if not found then
         source_id := nextval('rhn_sourcerpm_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnSourceRPM(id, name) values (' ||
-                source_id || ', ' || coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict source_id
-              from rhnSourceRPM
-             where name = name_in;
-        end;
+
+        insert into rhnSourceRPM(id, name)
+            values (source_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict source_id
+            from rhnSourceRPM
+            where name = name_in;
     end if;
 
     return source_id;
 end;
-$$
-language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_tag.sql
+++ b/schema/spacewalk/postgres/procs/lookup_tag.sql
@@ -31,19 +31,18 @@ begin
 
     if not found then
         tag_id := nextval('rhn_tag_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnTag(id, org_id, name_id) values (' ||
-                tag_id || ', ' || org_id_in || ', ' || tag_name_id || ')');
-        exception when unique_violation then
-            select id
-              into strict tag_id
-              from rhnTag
-             where org_id = org_id_in and
-                   name_id = lookup_tag_name(name_in);
-        end;
+
+        insert into rhnTag(id, org_id, name_id)
+            values (tag_id, org_id_in, tag_name_id)
+            on conflict do nothing;
+
+        select id
+            into strict tag_id
+            from rhnTag
+            where org_id = org_id_in and
+                name_id = lookup_tag_name(name_in);
     end if;
 
     return tag_id;
-end; $$
-language plpgsql immutable;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_tag_name.sql
+++ b/schema/spacewalk/postgres/procs/lookup_tag_name.sql
@@ -28,18 +28,17 @@ begin
 
     if not found then
         name_id := nextval('rhn_tagname_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnTagName(id, name) values (' ||
-                name_id || ', ' || coalesce(quote_literal(name_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict name_id
-              from rhnTagName
-             where name = name_in;
-        end;
+
+        insert into rhnTagName(id, name)
+            values (name_id, name_in)
+            on conflict do nothing;
+
+        select id
+            into strict name_id
+            from rhnTagName
+            where name = name_in;
     end if;
 
     return name_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_transaction_package.sql
+++ b/schema/spacewalk/postgres/procs/lookup_transaction_package.sql
@@ -58,23 +58,17 @@ begin
 
     if not found then
         tp_id := nextval('rhn_transpack_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnTransactionPackage (id, operation, name_id, evr_id, package_arch_id)' ||
-                ' values (' || tp_id || ', ' || o_id || ', ' || n_id || ', ' || e_id ||
-                ', ' || ( case when p_arch_id is null then 'NULL' else p_arch_id::varchar end )  || ')');
-        exception when unique_violation then
-            select id
-              into strict tp_id
-              from rhnTransactionPackage
-             where operation = o_id and
-                   name_id = n_id and
-                   evr_id = e_id and
-                   (package_arch_id = p_arch_id or (p_arch_id is null and package_arch_id is null));
-        end;
-    end if;
 
+        insert into rhnTransactionPackage (id, operation, name_id, evr_id, package_arch_id)
+            values (tp_id, o_id, n_id, e_id, p_arch_id)
+            on conflict do nothing;
+
+        select id
+            into strict tp_id
+            from rhnTransactionPackage
+         where operation = o_id and name_id = n_id and evr_id = e_id and
+            (package_arch_id = p_arch_id or (p_arch_id is null and package_arch_id is null));
+    end if;
     return tp_id;
 end;
-$$
-language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_xccdf_benchmark.sql
+++ b/schema/spacewalk/postgres/procs/lookup_xccdf_benchmark.sql
@@ -29,20 +29,17 @@ begin
 
     if not found then
         benchmark_id := nextval('rhn_xccdf_benchmark_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnXccdfBenchmark (id, identifier, version) values (' ||
-                benchmark_id || ', ' ||
-                coalesce(quote_literal(identifier_in), 'NULL') || ', ' ||
-                coalesce(quote_literal(version_in), 'NULL') || ')');
-        exception when unique_violation then
-            select id
-              into strict benchmark_id
-              from rhnXccdfBenchmark
-             where identifier = identifier_in and version = version_in;
-        end;
+
+        insert into rhnXccdfBenchmark (id, identifier, version)
+            values (benchmark_id, identifier_in, version_in)
+            on conflict do nothing;
+
+        select id
+            into strict benchmark_id
+            from rhnXccdfBenchmark
+            where identifier = identifier_in and version = version_in;
     end if;
 
     return benchmark_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_xccdf_ident.sql
+++ b/schema/spacewalk/postgres/procs/lookup_xccdf_ident.sql
@@ -28,16 +28,15 @@ begin
      where system = system_in;
     if not found then
         ident_sys_id := nextval('rhn_xccdf_identsytem_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnXccdfIdentSystem (id, system) values (' ||
-                ident_sys_id || ', ' || coalesce(quote_literal(system_in)) || ')');
-        exception when unique_violation then
-            select id
-              into strict ident_sys_id
-              from rhnXccdfIdentSystem
-             where system = system_in;
-        end;
+
+        insert into rhnXccdfIdentSystem (id, system)
+            values (ident_sys_id, system_in)
+            on conflict do nothing;
+
+        select id
+            into strict ident_sys_id
+            from rhnXccdfIdentSystem
+            where system = system_in;
     end if;
 
     select id
@@ -46,18 +45,16 @@ begin
      where identsystem_id = ident_sys_id and identifier = identifier_in;
     if not found then
         xccdf_ident_id := nextval('rhn_xccdf_ident_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnXccdfIdent (id, identsystem_id, identifier) values (' ||
-                xccdf_ident_id || ', ' || ident_sys_id || ', ' ||
-                coalesce(quote_literal( identifier_in)) || ')');
-        exception when unique_violation then
-            select id
-              into strict xccdf_ident_id
-              from rhnXccdfIdent
-             where identsystem_id = ident_sys_id and identifier = identifier_in;
-        end;
+
+        insert into rhnXccdfIdent (id, identsystem_id, identifier)
+            values (xccdf_ident_id, ident_sys_id, identifier_in)
+            on conflict do nothing;
+
+        select id
+            into strict xccdf_ident_id
+            from rhnXccdfIdent
+            where identsystem_id = ident_sys_id and identifier = identifier_in;
     end if;
     return xccdf_ident_id;
 end;
-$$ language plpgsql immutable;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_xccdf_profile.sql
+++ b/schema/spacewalk/postgres/procs/lookup_xccdf_profile.sql
@@ -29,18 +29,15 @@ begin
 
     if not found then
         profile_id := nextval('rhn_xccdf_profile_id_seq');
-        begin
-            perform pg_dblink_exec(
-                'insert into rhnXccdfProfile (id, identifier, title) values (' ||
-                profile_id || ', ' ||
-                coalesce(quote_literal(identifier_in), 'NULL') || ', ' ||
-                coalesce(quote_literal(title_in), 'NULL') || ')' );
-        exception when unique_violation then
-            select id
-              into profile_id
-              from rhnXccdfProfile
-             where identifier = identifier_in and title = title_in;
-        end;
+
+        insert into rhnXccdfProfile (id, identifier, title)
+            values (profile_id, identifier_in, title_in)
+            on conflict do nothing;
+
+        select id
+            into profile_id
+            from rhnXccdfProfile
+            where identifier = identifier_in and title = title_in;
     end if;
 
     return profile_id;


### PR DESCRIPTION
## The problem

When a new package is added to the database (at client/minion registration time or during reposync), its EVR is inserted in `rhnPackageEvr` via the `lookup_evr()` stored procedure.

There is a small window of time in which the stored procedure can fail if multiple transaction try `INSERT`ing the same EVR at the same time. This has been successfully reproduced in Postgres.

The following traces appear in Postgres logs:

```
2018-04-18 09:51:51 CEST susemanager postgres ERROR:  duplicate key value violates unique constraint "rhn_pe_v_r_uq"
2018-04-18 09:51:51 CEST susemanager postgres DETAIL:  Key (version, release)=(1.12.5, 39.2) already exists.
2018-04-18 09:51:51 CEST susemanager postgres STATEMENT:  insert into rhnPackageEVR(id, epoch, version, release, evr) values (2483, NULL, '1.12.5', '39.2', evr_t(NULL, '1.12.5', '39.2'))
2018-04-18 09:51:51 CEST susemanager spacewalk ERROR:  query returned no rows
2018-04-18 09:51:51 CEST susemanager spacewalk CONTEXT:  PL/pgSQL function lookup_evr(character varying,character varying,character varying) line 25 at SQL statement
2018-04-18 09:51:51 CEST susemanager spacewalk STATEMENT:  select * from lookup_evr($1,$2, $3, $4) as result
2018-04-18 09:51:51 CEST susemanager spacewalk ERROR:  current transaction is aborted, commands ignored until end of transaction block
```

## The Reproducer

To reproduce, run the [hammer_evr.rb](https://gist.github.com/moio/9bdb684102b1af89db3f47ad8ab2bc62) script against a server in multiple parallel copies at the same time:

```sh
$ ruby hammer_evr.rb & ruby hammer_evr.rb &ruby hammer_evr.rb &ruby hammer_evr.rb &ruby hammer_evr.rb & ruby hammer_evr.rb & wait
```

Note: change connection details, if needed, on line 12.


The script will produce the following error:

```
hammer_evr.rb:25:in `exec_prepared': ERROR:  query returned no rows (PG::NoDataFound)
CONTEXT:  PL/pgSQL function lookup_evr(character varying,character varying,character varying) line 25 at SQL statement
        from hammer_evr.rb:25:in `block (2 levels) in <main>'
        from hammer_evr.rb:20:in `each'
        from hammer_evr.rb:20:in `block in <main>'
        from hammer_evr.rb:18:in `transaction'
        from hammer_evr.rb:18:in `<main>'
```

## The proposed solution

This PR changes `lookup_` functions to use a feature available starting with Postgres 9.5 (the `ON CONFLICT` clause) to avoid this race condition. This approach was briefly discussed in `#spacewalk-devel` and it is already implemented in SUSE Manager. So far, our testing does not indicate regressions but still this is a vital area of the product, so please review carefully.

If the approach is OKed I will also produce migration scripts.