### PR TITLE
[selinux] Really fix pam authentication

### DIFF
--- a/selinux/spacewalk-selinux/spacewalk.te
+++ b/selinux/spacewalk-selinux/spacewalk.te
@@ -41,7 +41,7 @@ dontaudit httpd_sys_script_t httpd_log_t:file { ioctl };
 type spacewalk_initrc_exec_t;
 domain_entry_file(initrc_t, spacewalk_initrc_exec_t)
 
-allow tomcat_t self:netlink_audit_socket { nlmsg_relay read write };
+allow tomcat_t self:netlink_audit_socket { nlmsg_relay read write create };
 allow tomcat_t spacewalk_log_t:file { open read };
 
 optional_policy(`


### PR DESCRIPTION
I'm sorry but I've just noticed that my previous selinux patch was missing the "create" permission on the *netlink_audit_socket* for the *tomcat_t* labelled processes. This should definitely fix the following 2 bugs:

* [Bug 1517791](https://bugzilla.redhat.com/show_bug.cgi?id=1517791) - AVC: Kerberos user cannot login to Spacewalk on RHEL 7 
* [Bug 1494675](https://bugzilla.redhat.com/show_bug.cgi?id=1494675) - PAM authentication no longer works after upgrading to CentOS 7.4