### PR TITLE
reflect copr.fedorainfracloud.org packages moving for spacewalk-2.8

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -37,7 +37,12 @@ _spacewalk_nightly_gpgkey_fingerprint = 85AC E11D 3A41 8D77 FC4F  0F30 E481 344A
 _spacewalk_nightlyclient_gpgkey_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/pubkey.gpg
 _spacewalk_nightlyclient_gpgkey_id = 1B9881E5
 _spacewalk_nightlyclient_gpgkey_fingerprint = 44B8 3746 B8D6 0089 EC0D  5479 D4B9 8439 1B98 81E5
-
+_spacewalk_28_gpgkey_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/pubkey.gpg
+_spacewalk_28_gpgkey_id = BAD596D6
+_spacewalk_28_gpgkey_fingerprint = E810 498D 6A68 D4B8 C919  2EDB E26A 9033 BAD5 96D6
+_spacewalk_28client_gpgkey_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/pubkey.gpg
+_spacewalk_28client_gpgkey_id = BE4B0BC2
+_spacewalk_28client_gpgkey_fingerprint = FF8D 0364 E7B5 EFD3 4FBF  9CD1 BDAA D72F BE4B 0BC2
 
 [fedora26]
 archs    = %(_x86_archs)s
@@ -585,145 +590,145 @@ yumrepo_url = http://yum.spacewalkproject.org/2.7-client/RHEL/7/%(arch)s/
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = centos6-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/RHEL/6/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/epel-6-%(arch)s/
 
 [spacewalk28-server-centos7]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = centos7-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/RHEL/7/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/epel-7-%(arch)s/
 
 [spacewalk28-server-scientific6]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = scientific6-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/RHEL/6/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/epel-6-%(arch)s/
 
 [spacewalk28-server-fedora26]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = fedora26-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/Fedora/26/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/fedora-26-%(arch)s/
 
 [spacewalk28-server-fedora27]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = fedora27-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/Fedora/27/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/fedora-27-%(arch)s/
 
 [spacewalk28-server-fedora28]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = fedora28-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/Fedora/28/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/fedora-28-%(arch)s/
 
 [spacewalk28-server-oraclelinux6]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = oraclelinux6-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/RHEL/6/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/epel-6-%(arch)s/
 
 [spacewalk28-server-oraclelinux7]
 name     = Spacewalk Server 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = oraclelinux7-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8/RHEL/7/%(arch)s/
+gpgkey_url = %(_spacewalk_28_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8/epel-7-%(arch)s/
 
 [spacewalk28-client-centos6]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = centos6-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/RHEL/6/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
 
 [spacewalk28-client-centos7]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = centos7-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/RHEL/7/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-7-%(arch)s/
 
 [spacewalk28-client-scientific6]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = scientific6-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/RHEL/6/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
 
 [spacewalk28-client-fedora26]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = fedora26-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/Fedora/26/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-26-%(arch)s/
 
 [spacewalk28-client-fedora27]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = fedora27-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/Fedora/27/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-27-%(arch)s/
 
 [spacewalk28-client-fedora28]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = fedora28-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/Fedora/28/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-28-%(arch)s/
 
 [spacewalk28-client-oraclelinux6]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = oraclelinux6-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/RHEL/6/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
 
 [spacewalk28-client-oraclelinux7]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = oraclelinux7-%(arch)s
-gpgkey_url = %(_spacewalk_gpgkey_url)s
-gpgkey_id = %(_spacewalk_gpgkey_id)s
-gpgkey_fingerprint = %(_spacewalk_gpgkey_fingerprint)s
-yumrepo_url = http://yum.spacewalkproject.org/2.8-client/RHEL/7/%(arch)s/
+gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
+gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
+gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
+yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-7-%(arch)s/
 
 [spacewalk-nightly-server-fedora25]
 name     = Spacewalk Server nightly for %(base_channel_name)s


### PR DESCRIPTION
2.8 packages (both server and client) are not in yum.spacewalkproject.org repos anymore but there were moved to copr-be.cloud.fedoraproject.org
For a reference of the issue: https://www.redhat.com/archives/spacewalk-list/2018-April/msg00120.html