### PR TITLE
Fix crash in satellite_tools on RH/Fedora/Mageia urlgrabber

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -207,7 +207,7 @@ class DownloadThread(Thread):
             url = urlparse.urljoin(params['urls'][self.mirror], params['relative_path'])
             ## BEWARE: This hack is introduced in order to support SUSE SCC channels
             ## This also needs a patched urlgrabber AFAIK
-            if params['authtoken']:
+            if 'authtoken' in params.keys() and params['authtoken']:
                 (scheme, netloc, path, query, _) = urlparse.urlsplit(params['urls'][self.mirror])
                 url = "%s://%s%s/%s?%s" % (scheme,netloc,path,params['relative_path'],query.rstrip('/'))
             try:


### PR DESCRIPTION
The `authtoken` parameter isn't available in non-SUSE `urlgrabber`, which causes it to crash when it attempts to execute this code. Checking for the existence of of the key in the `params` dictionary prevents the failure while preserving compatibility with SUSE systems.