### PR TITLE
Fix xmlrpc error when running configure-proxy in SW2.8

### DIFF
--- a/java/code/src/com/redhat/rhn/common/client/ClientCertificate.java
+++ b/java/code/src/com/redhat/rhn/common/client/ClientCertificate.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class ClientCertificate {
 
     public static final String SYSTEM_ID = "system_id";
-    private static final String FIELDS = "fields";
+    public static final String FIELDS = "fields";
     private final List<Member> members;
     private final Map<String, String[]> byName;
     private final Map<String, String> checksumFields;
@@ -86,7 +86,7 @@ public class ClientCertificate {
      * Add a member to the certificate.
      * @param member Member to be added.
      */
-    private void addMember(Member member) {
+    public void addMember(Member member) {
         members.add(member);
         byName.put(member.getName(), member.getValues());
     }


### PR DESCRIPTION
This PR just reverts a previous commit.

This reverts commit 43d11cc68a5c37967356e0ef583eeaf8e45b1820.

This fixes the xmlrpc error you get when you try to connect a spacewalk proxy
to the spacewalk server in version 2.8. This error is thrown because of

[TP-Processor2] ERROR org.apache.commons.digester.Digester - End event threw exception
java.lang.NoSuchMethodException: No such accessible method: addMember() on object:
  com.redhat.rhn.common.client.ClientCertificate

See also https://www.redhat.com/archives/spacewalk-list/2018-May/msg00123.html
for further information.