### PR TITLE
client/rhel: Enable DNF plugin for Mageia 6+ and openSUSE Leap 15.0+

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
@@ -1,4 +1,4 @@
-%if 0%{?fedora} || 0%{?rhel} >= 8
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?mageia} >= 6 || 0%{?suse_version} >= 1500
 %global build_py3   1
 %global default_py3 1
 %endif

--- a/client/rhel/rhn-client-tools/rhn-client-tools.spec
+++ b/client/rhel/rhn-client-tools/rhn-client-tools.spec
@@ -1,4 +1,4 @@
-%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
+%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8 || 0%{?mageia}
 %global build_py3   1
 %global default_py3 1
 %endif
@@ -32,7 +32,7 @@ Requires: %{pythonX}-%{name} = %{version}-%{release}
 %if 0%{?suse_version}
 Requires: zypper
 %else
-%if 0%{?fedora} || 0%{?rhel} >= 8
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?mageia} >= 6
 Requires: dnf
 %else
 Requires: yum
@@ -52,6 +52,10 @@ BuildRequires: desktop-file-utils
 
 %if 0%{?fedora}
 BuildRequires: fedora-logos
+BuildRequires: dnf
+%endif
+
+%if 0%{?mageia} >= 6
 BuildRequires: dnf
 %endif
 
@@ -165,7 +169,7 @@ Requires: %{pythonX}-rhn-check = %{version}-%{release}
 %if 0%{?suse_version}
 Requires: zypp-plugin-spacewalk
 %else
-%if 0%{?fedora} || 0%{?rhel} >= 8
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?mageia} >= 6
 Requires: dnf-plugin-spacewalk >= 2.4.0
 %else
 Requires: yum-rhn-plugin >= 1.6.4-1
@@ -203,6 +207,9 @@ Requires: %{pythonX}-rhn-setup = %{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
 Requires: usermode >= 1.36
 %endif
+%if 0%{?mageia}
+Requires: usermode-consoleonly >= 1.36
+%endif
 Requires: %{name} = %{version}-%{release}
 Requires: rhnsd
 
@@ -218,6 +225,9 @@ Requires: rhn-setup = %{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
 Requires: newt-python
 %endif
+%if 0%{?mageia}
+Requires: python-newt
+%endif
 
 %description -n python2-rhn-setup
 Python 2 specific files for rhn-setup.
@@ -228,7 +238,11 @@ Python 2 specific files for rhn-setup.
 Summary: Configure and register an RHN/Spacewalk client
 %{?python_provide:%python_provide python3-rhn-setup}
 Requires: rhn-setup = %{version}-%{release}
+%if 0%{?mageia}
+Requires: python3-newt
+%else
 Requires: newt-python3
+%endif
 
 %description -n python3-rhn-setup
 Python 3 specific files for rhn-setup.
@@ -255,11 +269,22 @@ Requires: rhn-setup-gnome = %{version}-%{release}
 %if 0%{?suse_version}
 Requires: python-gnome python-gtk
 %else
+%if 0%{?mageia}
+Requires: pygtk2.0 pygtk2.0-libglade
+Requires: usermode
+%else
 Requires: pygtk2 pygtk2-libglade
 Requires: usermode-gtk
 %endif
-%if 0%{?fedora} || 0%{?rhel}
+%endif
+%if 0%{?rhel} || 0%{?fedora}
 Requires: liberation-sans-fonts
+%endif
+%if 0%{?mageia}
+Requires: fonts-ttf-liberation
+%endif
+%if 0%{?suse_version}
+Requires: liberation-fonts
 %endif
 
 %description -n python2-rhn-setup-gnome
@@ -271,15 +296,26 @@ Python 2 specific files for rhn-setup-gnome.
 Summary: Configure and register an RHN/Spacewalk client
 %{?python_provide:%python_provide python3-rhn-setup-gnome}
 Requires: rhn-setup-gnome = %{version}-%{release}
-%if 0%{?suse_version}
-Requires: python-gnome python-gtk
-%else
-Requires: python3-gobject-base gtk3
 # gtk-builder-convert
 BuildRequires: gtk2-devel
+Requires: gtk3
+%if 0%{?suse_version}
+Requires: python3-gobject
+%else
+%if 0%{?mageia}
+Requires: python3-gobject3
+%else
+Requires: python3-gobject-base
 %endif
-%if 0%{?fedora} || 0%{?rhel}
+%endif
+%if 0%{?rhel} || 0%{?fedora}
 Requires: liberation-sans-fonts
+%endif
+%if 0%{?mageia}
+Requires: fonts-ttf-liberation
+%endif
+%if 0%{?suse_version}
+Requires: liberation-fonts
 %endif
 
 %description -n python3-rhn-setup-gnome
@@ -323,13 +359,13 @@ ln -s spacewalk-channel $RPM_BUILD_ROOT%{_sbindir}/rhn-channel
 mkdir -p $RPM_BUILD_ROOT/var/lib/up2date
 mkdir -pm700 $RPM_BUILD_ROOT%{_localstatedir}/spool/up2date
 touch $RPM_BUILD_ROOT%{_localstatedir}/spool/up2date/loginAuth.pkl
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?mageia}
 mkdir -p $RPM_BUILD_ROOT/%{_presetdir}
 install 50-spacewalk-client.preset $RPM_BUILD_ROOT/%{_presetdir}
 %endif
 
 %if 0%{?build_py2}
-%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1140
+%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1140 || 0%{?mageia}
 rm $RPM_BUILD_ROOT%{python_sitelib}/up2date_client/hardware_hal.*
 %else
 rm $RPM_BUILD_ROOT%{python_sitelib}/up2date_client/hardware_gudev.*
@@ -433,7 +469,7 @@ make -f Makefile.rhn-client-tools test
 #public keys and certificates
 %{_datadir}/rhn/RHNS-CA-CERT
 
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?mageia}
 %{_presetdir}/50-spacewalk-client.preset
 %endif
 
@@ -562,7 +598,7 @@ make -f Makefile.rhn-client-tools test
 
 %config(noreplace) %{_sysconfdir}/security/console.apps/rhn_register
 %config(noreplace) %{_sysconfdir}/pam.d/rhn_register
-%if 0%{?fedora} || 0%{?rhel}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?mageia}
 %{_bindir}/rhn_register
 %endif
 %{_sbindir}/rhn_register
@@ -611,7 +647,7 @@ make -f Makefile.rhn-client-tools test
 %{_datadir}/icons/hicolor/24x24/apps/up2date.png
 %{_datadir}/icons/hicolor/32x32/apps/up2date.png
 %{_datadir}/icons/hicolor/48x48/apps/up2date.png
-%if 0%{?rhel} > 6 || 0%{?fedora}
+%if 0%{?rhel} > 6 || 0%{?fedora} || 0%{?mageia}
 %{_datadir}/icons/hicolor/22x22/apps/up2date.png
 %{_datadir}/icons/hicolor/256x256/apps/up2date.png
 %endif

--- a/client/rhel/rhnlib/rhnlib.spec
+++ b/client/rhel/rhnlib/rhnlib.spec
@@ -1,4 +1,4 @@
-%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
+%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8 || 0%{?mageia}
 %global build_py3   1
 %endif
 
@@ -51,7 +51,11 @@ rhnlib is a collection of python modules used by the Spacewalk (http://spacewalk
 %package -n python3-rhnlib
 Summary: Python libraries for the Spacewalk project
 BuildRequires: python3-devel
+%if 0%{?mageia}
+Requires: python3-OpenSSL
+%else
 Requires: python3-pyOpenSSL
+%endif
 %{?python_provide:%python_provide python3-rhnlib}
 Conflicts: rhncfg < 5.10.45
 Conflicts: spacewalk-proxy-installer < 1.3.2

--- a/client/rhel/rhnsd/rhnsd.spec
+++ b/client/rhel/rhnsd/rhnsd.spec
@@ -10,7 +10,9 @@ BuildRequires: gettext
 
 Requires: rhn-check >= 0.0.8
 BuildRequires: gcc
-%if 0%{?suse_version} >= 1210 || 0%{?fedora}
+%if 0%{?suse_version} >= 1210 || 0%{?fedora} || 0%{?mageia}
+%{?mageia:BuildRequires: systemd-devel}
+%{?suse_version:BuildRequires: systemd-rpm-macros}
 BuildRequires: systemd
 %{?systemd_requires}
 %endif
@@ -50,7 +52,7 @@ make -f Makefile.rhnsd install VERSION=%{version}-%{release} PREFIX=$RPM_BUILD_R
 %if 0%{?suse_version} && 0%{?suse_version} < 1210
 install -m 0755 rhnsd.init.SUSE $RPM_BUILD_ROOT/%{_initrddir}/rhnsd
 %endif
-%if 0%{?fedora} || 0%{?suse_version} >= 1210
+%if 0%{?fedora} || 0%{?suse_version} >= 1210 || 0%{?mageia}
 rm $RPM_BUILD_ROOT/%{_initrddir}/rhnsd
 mkdir -p $RPM_BUILD_ROOT/%{_unitdir}
 install -m 0644 rhnsd.service $RPM_BUILD_ROOT/%{_unitdir}/
@@ -92,7 +94,7 @@ fi
 %service_del_preun rhnsd.service
 %else
 if [ $1 = 0 ] ; then
-    %if 0%{?fedora}
+    %if 0%{?fedora} || 0%{?mageia}
         %systemd_preun rhnsd.service
     %else
     service rhnsd stop >/dev/null 2>&1
@@ -108,7 +110,7 @@ fi
 %service_del_postun rhnsd.service
 %else
 if [ "$1" -ge "1" ]; then
-    %if 0%{?fedora}
+    %if 0%{?fedora} || 0%{?mageia}
     %systemd_postun_with_restart rhnsd.service
     %else
     service rhnsd condrestart >/dev/null 2>&1 || :
@@ -121,7 +123,7 @@ fi
 %dir %{_sysconfdir}/sysconfig/rhn
 %config(noreplace) %{_sysconfdir}/sysconfig/rhn/rhnsd
 %{_sbindir}/rhnsd
-%if 0%{?fedora} || 0%{?suse_version} >= 1210
+%if 0%{?fedora} || 0%{?suse_version} >= 1210 || 0%{?mageia}
 %{_unitdir}/rhnsd.service
 %else
 %{_initrddir}/rhnsd

--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.spec
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.spec
@@ -8,7 +8,7 @@ URL:     https://github.com/spacewalkproject/spacewalk
 %if %{?suse_version: %{suse_version} > 1110} %{!?suse_version:1}
 BuildArch: noarch
 %endif
-%if 0%{?fedora} >= 28
+%if 0%{?fedora} >= 28 || 0%{?mageia}
 BuildRequires: python2
 %else
 BuildRequires: python


### PR DESCRIPTION
Since Mageia 6 and openSUSE Leap 15.0, DNF has been available in the distributions for usage. In addition, Mageia 6 offers DNF as a fully supported package manager option, with plans to transition to it as the only system package manager in the next release.

This will permit Mageia and openSUSE machines using DNF to work with Spacewalk.

In addition, the yum plugin was trivially adapted to be able to build for Mageia, too, since Mageia has a working yum now, too.