### PR TITLE
Remove nested transaction when starting up taskomatic

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -29,7 +29,6 @@ import com.redhat.rhn.taskomatic.TaskoXmlRpcServer;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 
 import org.apache.log4j.Logger;
-import org.hibernate.Transaction;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.SchedulerFactory;
@@ -219,14 +218,12 @@ public class SchedulerKernel {
                     if (!runList.isEmpty()) {
                         // there're runs in the future
                         // reinit the schedule
-                        Transaction tx = TaskoFactory.getSession().beginTransaction();
                         log.warn("Reinitializing " + schedule.getJobLabel() + ", found " +
                         runList.size() + " runs in the future.");
                         TaskoFactory.reinitializeScheduleFromNow(schedule, now);
                         for (TaskoRun run : runList) {
                             TaskoFactory.deleteRun(run);
                         }
-                        tx.commit();
                     }
                 }
             }


### PR DESCRIPTION
Remove nested transaction when starting up taskomatic.

This does not work on postgres. We get the following stack trace in taskomatic logs right after restarting taskomatic:

java.lang.IllegalStateException: Transaction already active
 	at org.hibernate.engine.transaction.internal.TransactionImpl.begin(TransactionImpl.java:52)
 	at org.hibernate.internal.AbstractSharedSessionContract.beginTransaction(AbstractSharedSessionContract.java:387)
	at com.redhat.rhn.taskomatic.core.SchedulerKernel.initializeAllSatSchedules(SchedulerKernel.java:221)
 	at com.redhat.rhn.taskomatic.core.SchedulerKernel.startup(SchedulerKernel.java:146)
 	at com.redhat.rhn.taskomatic.core.TaskomaticDaemon$1.run(TaskomaticDaemon.java:91)
 	at java.lang.Thread.run(Thread.java:811)

To reproduce the issue:
 - change the system clock backwards
 - restart taskomatic.

The patch that was creating the nested transaction was https://github.com/spacewalkproject/spacewalk/commit/04e63ecbae519b2f6d12e65573855f23fe671e52

By looking at it, the following questions came to mind:

- Why was this needed?
- What are "runs in the future"  and when could this happen?
- Why is it necessary to remove them, even when they are in a "FINISHED" status already?

@tlestach I would appreciate if you could bring some light into this.

Thanks.