### PR TITLE
client/debian: Port apt-spacewalk to be Python 3 ready

### DIFF
--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/control
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/debian/control
@@ -12,7 +12,7 @@ Vcs-Git: git://anonscm.debian.org/collab-maint/spacewalk/apt-spacewalk.git
 Package: apt-transport-spacewalk
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, apt, python-apt,
- rhn-client-tools
+ rhn-client-tools, python-six
 Provides: ${python:Provides}
 Recommends: rhnsd
 Description: APT transport for communicating with Spacewalk servers

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/packages.py
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/packages.py
@@ -17,6 +17,8 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+from __future__ import print_function
+
 import os
 import sys
 import time
@@ -143,7 +145,7 @@ def refresh_list(rhnsd=None, cache_only=None):
     try:
         rhnPackageInfo.updatePackageProfile()
     except:
-        print "ERROR: refreshing remote package list for System Profile"
+        print("ERROR: refreshing remote package list for System Profile")
         return (20, "Error refreshing package list", {})
 
     touch_time_stamp()

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/post_invoke.py
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/post_invoke.py
@@ -16,6 +16,8 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 
+from __future__ import print_function
+
 import sys
 
 # Once we have the up2date stuff in a site-packages,
@@ -34,10 +36,10 @@ if __name__ == '__main__':
     systemid = up2dateAuth.getSystemId()
     if systemid:
         try:
-            print "Apt-Spacewalk: Updating package profile"
+            print("Apt-Spacewalk: Updating package profile")
             s = rhnserver.RhnServer()
             s.registration.update_packages(systemid,
                 pkgUtils.getInstalledPackageList(getArch=1))
-        except up2dateErrors.RhnServerException, e:
-            print "Package profile information could not be sent."
-            print str(e)
+        except up2dateErrors.RhnServerException as e:
+            print("Package profile information could not be sent.")
+            print(str(e))

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/pre_invoke.py
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/pre_invoke.py
@@ -16,9 +16,11 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 
+from __future__ import print_function
+
 import sys
 import os
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 from aptsources import sourceslist
 import apt_pkg
 
@@ -80,5 +82,5 @@ def update_sources_list():
     sources.save()
 
 if __name__ == '__main__':
-    print "Apt-Spacewalk: Updating sources.list"
+    print("Apt-Spacewalk: Updating sources.list")
     update_sources_list()

--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/spacewalk
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/spacewalk
@@ -16,6 +16,8 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 
+from __future__ import print_function
+
 import sys
 import re
 import hashlib
@@ -24,7 +26,7 @@ import warnings
 warnings.filterwarnings("ignore", message="the md5 module is deprecated; use hashlib instead")
 sys.path.append("/usr/share/rhn/")
 
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 from rhn.connections import HTTPConnection, HTTPSConnection
 from up2date_client import config
 from up2date_client import rhnChannel
@@ -42,7 +44,7 @@ class pkg_acquire_method:
     __eof = False
 
     def __init__(self):
-        print "100 Capabilities\nVersion: 1.0\nSingle-Instance: true\n\n",
+        print("100 Capabilities\nVersion: 1.0\nSingle-Instance: true\n\n", end=' ')
 
     def __get_next_msg(self):
         """
@@ -75,22 +77,22 @@ class pkg_acquire_method:
     def __dict2msg(self, msg):
         """Convert dictionary to http like message"""
         result = ""
-        for item in msg.keys():
+        for item in list(msg.keys()):
             if msg[item] != None:
                 result += item + ": " + msg[item] + "\n"
         return result
 
     def status(self, **kwargs):
-        print "102 Status\n%s\n" % self.__dict2msg(kwargs),
+        print("102 Status\n%s\n" % self.__dict2msg(kwargs), end=' ')
 
     def uri_start(self, msg):
-        print "200 URI Start\n%s\n" % self.__dict2msg(msg),
+        print("200 URI Start\n%s\n" % self.__dict2msg(msg), end=' ')
 
     def uri_done(self, msg):
-        print "201 URI Done\n%s\n" % self.__dict2msg(msg),
+        print("201 URI Done\n%s\n" % self.__dict2msg(msg), end=' ')
 
     def uri_failure(self, msg):
-        print "400 URI Failure\n%s\n" % self.__dict2msg(msg),
+        print("400 URI Failure\n%s\n" % self.__dict2msg(msg), end=' ')
 
     def run(self):
         """Loop through requests on stdin"""
@@ -101,9 +103,9 @@ class pkg_acquire_method:
             if msg['_number'] == 600:
                 try:
                     self.fetch(msg)
-                except Exception, e:
+                except Exception as e:
                     self.fail(e.__class__.__name__ + ": " + str(e))
-                except up2dateErrors.Error, e:
+                except up2dateErrors.Error as e:
                     self.fail(e.__class__.__name__ + ": " + str(e))
             else:
                 return 100
@@ -111,7 +113,7 @@ class pkg_acquire_method:
 
 
 def get_ssl_ca_cert(up2date_cfg):
-    if not (up2date_cfg.has_key('sslCACert') and up2date_cfg['sslCACert']):
+    if not ('sslCACert' in up2date_cfg and up2date_cfg['sslCACert']):
        raise BadSslCaCertConfig
 
     ca_certs = up2date_cfg['sslCACert']
@@ -172,7 +174,7 @@ class spacewalk_method(pkg_acquire_method):
                                   'X-RHN-Auth-Expire-Offset']
             self.http_headers = {};
             for header in rhn_needed_headers:
-                if not self.login_info.has_key(header):
+                if header not in self.login_info:
                     raise up2date_client.AuthenticationError(
                         "Missing required login information %s" % (header))
                 self.http_headers[header] = self.login_info[header]


### PR DESCRIPTION
All of apt-spacewalk's dependencies are Python 3 ready in the latest Debian and Ubuntu releases, but this is not necessarily true for earlier releases that may be actively managed by Spacewalk today.

The dsc packaging for apt-spacewalk is adjusted so that `python-six` is a runtime dependency of apt-spacewalk, since the code uses `six` for `urlparse()` now.