### PR TITLE
Add a debug flag to the spacewalk-repo-sync utility

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -312,8 +312,9 @@ class RepoSync(object):
     def __init__(self, channel_label, repo_type=None, url=None, fail=False,
                  filters=None, no_errata=False, sync_kickstart=False, latest=False,
                  metadata_only=False, strict=0, excluded_urls=None, no_packages=False,
-                 log_dir="reposync", log_level=None, force_kickstart=False, force_all_errata=False,
-                 check_ssl_dates=False, force_null_org_content=False, show_packages_only=False):
+                 log_dir="reposync", log_level=None, debug=False, force_kickstart=False,
+                 force_all_errata=False, check_ssl_dates=False, force_null_org_content=False,
+                 show_packages_only=False):
         self.regen = False
         self.fail = fail
         self.filters = filters or []
@@ -332,8 +333,11 @@ class RepoSync(object):
         rhnSQL.initDB()
 
         # setup logging
-        log_filename = channel_label + '.log'
-        log_path = default_log_location + log_dir + '/' + log_filename
+        if debug:
+            log_path = 'stdout'
+        else:
+            log_filename = channel_label + '.log'
+            log_path = default_log_location + log_dir + '/' + log_filename
         if log_level is None:
             log_level = 0
         CFG.set('DEBUG', log_level)

--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -115,6 +115,8 @@ def main():
     parser.add_option('', '--batch-size', action='store', help="max. batch size for package import (debug only)")
     parser.add_option('-v', '--verbose', action='count',
                       help="Verbose output. Possible to accumulate: -vvv")
+    parser.add_option('', '--debug', action='store_true', dest='enable_debug',
+                      default=False, help="Enable debugging output.")
     (options, args) = parser.parse_args()
 
     log_level = options.verbose
@@ -126,7 +128,10 @@ def main():
     CFG.set("TRACEBACK_MAIL", options.traceback_mail or CFG.TRACEBACK_MAIL)
     if options.email:
         initEMAIL_LOG()
-    rhnLog.initLOG(log_path, log_level)
+    if options.enable_debug:
+        rhnLog.initLOG('stdout', log_level)
+    else:
+        rhnLog.initLOG(log_path, log_level)
     log2disk(0, "Command: %s" % str(sys.argv))
 
     l_params=["no_errata", "sync_kickstart", "fail"]
@@ -240,6 +245,7 @@ def main():
                       no_errata=options.no_errata,
                       sync_kickstart=options.sync_kickstart,
                       latest=options.latest,
+                      debug=options.enable_debug,
                       log_level=options.verbose,
                       force_all_errata=options.force_all_errata, show_packages_only=options.show_packages)
         if options.batch_size:


### PR DESCRIPTION
Allows spacewalk-repo-sync to print messages to stdout instead of logging to a file, for simplifying debugging sync issues.