### PR TITLE
client/debian: Fix the line endings for messages printed to apt

### DIFF
--- a/client/debian/packages-already-in-debian/apt-transport-spacewalk/spacewalk
+++ b/client/debian/packages-already-in-debian/apt-transport-spacewalk/spacewalk
@@ -44,7 +44,7 @@ class pkg_acquire_method:
     __eof = False
 
     def __init__(self):
-        print("100 Capabilities\nVersion: 1.0\nSingle-Instance: true\n\n", end=' ')
+        print("100 Capabilities\nVersion: 1.0\nSingle-Instance: true\n\n", end='')
 
     def __get_next_msg(self):
         """
@@ -83,16 +83,16 @@ class pkg_acquire_method:
         return result
 
     def status(self, **kwargs):
-        print("102 Status\n%s\n" % self.__dict2msg(kwargs), end=' ')
+        print("102 Status\n%s\n" % self.__dict2msg(kwargs), end='')
 
     def uri_start(self, msg):
-        print("200 URI Start\n%s\n" % self.__dict2msg(msg), end=' ')
+        print("200 URI Start\n%s\n" % self.__dict2msg(msg), end='')
 
     def uri_done(self, msg):
-        print("201 URI Done\n%s\n" % self.__dict2msg(msg), end=' ')
+        print("201 URI Done\n%s\n" % self.__dict2msg(msg), end='')
 
     def uri_failure(self, msg):
-        print("400 URI Failure\n%s\n" % self.__dict2msg(msg), end=' ')
+        print("400 URI Failure\n%s\n" % self.__dict2msg(msg), end='')
 
     def run(self):
         """Loop through requests on stdin"""


### PR DESCRIPTION
APT and the spacewalk transport method communicate through messages in standard input
and standard output. However, APT is very picky about how the messages are formatted.

The earlier conversion to be Python 3 compatible accidentally broke this by incorrectly
attempting to preserve the behavior of printing without a newline at the end by adding
an extra space at the end. Removing that extra space and further ensuring a newline
is not printed at the end makes the communication between APT and the spacewalk method
work again.