### PR TITLE
debUtils.py: Fix edge case finding pkg install time on Debian

### DIFF
--- a/client/rhel/rhn-client-tools/src/up2date_client/debUtils.py
+++ b/client/rhel/rhn-client-tools/src/up2date_client/debUtils.py
@@ -41,11 +41,14 @@ def installTime(pkg_name, pkg_arch):
     dir = '/var/lib/dpkg/info'
     files = [ '%s.list' % pkg_name,
               '%s:%s.list' % (pkg_name, pkg_arch) ]
+    # In edge cases, pkg_name can include the arch but the .list file does not
+    if ':' in pkg_name:
+        files.append('%s.list' % (pkg_name[:pkg_name.index(':')]))
     for f in files:
         path = os.path.join(dir,f)
         if os.path.isfile(path):
             return os.path.getmtime(path)
-    return None
+    return 0
 
 #FIXME: Using Apt cache might not be an ultimate solution.
 # It could be better to parse /var/lib/dpkg/status manually.


### PR DESCRIPTION
There are limited cases, such as in wine32, where the package name
contains the target arch but the .list file in /var/lib/dpkg/info
does not. This adds another possible file path to search to account
for that possibility.

We also never want to return None here - it breaks xmlrpclib, which
refuses to marshall None. Returning 0 will cause the server to
instead indicate that the package install time is 'unspecified', so
it seems that this behavior is intended and just was never fixed in
debUtils.py.