### PR TITLE
Fix: errata IDs must be unique

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
@@ -1151,7 +1152,7 @@ public class ChannelFactory extends HibernateFactory {
      * @param eids List of eids to add mappings for
      * @param cid channel id we're cloning into
      */
-    public static void addClonedErrataToChannel(List<Long> eids, Long cid) {
+    public static void addClonedErrataToChannel(Set<Long> eids, Long cid) {
         WriteMode m = ModeFactory.getWriteMode("Channel_queries",
                 "add_cloned_erratum_to_channel");
         Map<String, Object> params = new HashMap<String, Object>();

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/PublishErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/PublishErrataAction.java
@@ -95,7 +95,7 @@ public class PublishErrataAction extends RhnListAction {
         //ErrataManager.publishErrataToChannelAsync(currentChan, errataIds, user);
         List<ErrataOverview> errata = ErrataManager.errataInSet(user,
                 RhnSetDecl.setForChannelErrata(currentChan).get(user).getLabel());
-        List<Long> eids = ErrataManager.cloneChannelErrata(errata, currentChan.getId(),
+        Set<Long> eids = ErrataManager.cloneChannelErrata(errata, currentChan.getId(),
                 user);
 
 

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1476,11 +1476,11 @@ public class ErrataManager extends BaseManager {
      * @param user the requesting user
      * @return list of errata ids that were published into channel
      */
-    public static List<Long> cloneChannelErrata(List<ErrataOverview> toClone, Long toCid,
+    public static Set<Long> cloneChannelErrata(List<ErrataOverview> toClone, Long toCid,
             User user) {
         List<OwnedErrata> owned = ErrataFactory
                 .listPublishedOwnedUnmodifiedClonedErrata(user.getOrg().getId());
-        List<Long> eids = new ArrayList<Long>();
+        Set<Long> eids = new HashSet<Long>();
 
         // add published, cloned, owned errata to mapping. we want the oldest owned
         // clone to reuse. listPublishedOwnedUnmodifiedClonedErrata orders by created,


### PR DESCRIPTION
Errata IDs must be unique when cloning channel erratas. This patch
make sure that errata ID will not be duplicated before inserting them
into the database.

Fix for:
* [Bug 1539095](https://bugzilla.redhat.com/show_bug.cgi?id=1539095) - spacecmd softwarechannel_clonetree aborts with duplicate key value violates unique constraint "rhn_ce_ce_uq"