### PR TITLE
Fix icon typo

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
@@ -81,7 +81,7 @@ public class IconTag extends TagSupport {
         icons.put("header-errata-add", "fa spacewalk-icon-patch-install");
         icons.put("header-errata-del", "fa spacewalk-icon-patch-remove");
         icons.put("header-errata-set", "fa spacewalk-icon-patch-set");
-        icons.put("header-errata-set-add", "fa pacewalk-icon-patchset-install");
+        icons.put("header-errata-set-add", "fa spacewalk-icon-patchset-install");
         icons.put("header-event-history", "fa fa-suitcase");
         icons.put("header-file", "fa fa-file-text-o");
         icons.put("header-folder", "fa fa-folder-open-o");


### PR DESCRIPTION
A probably *never-used* icon (I couldn't find any usage of `header-errata-set-add`), but at least it needs a typo fix - as per [its CSS rule definition](https://github.com/spacewalkproject/spacewalk/blob/1c236c59cc87e9dcc7f6251dbf19926a83fad033/branding/fonts/font-spacewalk/css/spacewalk-font.css#L62) - if it will be ever used in the future.