### PR TITLE
Issues with /etc/rhn/spacewalk-repo-sync/yum.conf processing

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -153,6 +153,8 @@ class ContentSource(object):
 
             if yb_cfg.has_section(self.name):
                 section_name = self.name
+            elif yb_cfg.has_section(channel_label):
+                section_name = channel_label
             elif yb_cfg.has_section('main'):
                 section_name = 'main'
 
@@ -231,7 +233,7 @@ class ContentSource(object):
             repo.copy_local = 1
 
         if self.proxy_addr:
-            repo.proxy = "http://%s" % self.proxy_addr
+            repo.proxy = self.proxy_addr
             repo.proxy_username = self.proxy_user
             repo.proxy_password = self.proxy_pass
 


### PR DESCRIPTION
Somewhere along the line between 2.6 and 2.7 a bug has been introduced where the repo name is being used to lookup custom configuration in /etc/rhn/spacewalk-repo-sync/yum.conf instead of channel label. Repo name can contain spaces and special characters which makes it unfit for this lookup, I've added channel label as a fallback option.

Also restored the requirement of getting the proxy URLs defined with a prefix, the way how it was before.