### PR TITLE
Fix wrong "python3-newt" dependency name for SUSE systems

### DIFF
--- a/client/rhel/rhn-client-tools/rhn-client-tools.spec
+++ b/client/rhel/rhn-client-tools/rhn-client-tools.spec
@@ -359,7 +359,7 @@ Python 2 specific files for rhn-setup.
 Summary: Configure and register an RHN/Spacewalk client
 %{?python_provide:%python_provide python3-rhn-setup}
 Requires: rhn-setup = %{version}-%{release}
-%if 0%{?mageia} || 0%{?debian} || 0%{?ubuntu}
+%if 0%{?mageia} || 0%{?debian} || 0%{?ubuntu} || 0%{?suse_version} >= 1140
 Requires: python3-newt
 %else
 Requires: newt-python3


### PR DESCRIPTION
This PR fixes a wrong `python3-newt` dependency name for `rhn-client-tools` on SUSE systems.