### PR TITLE
Missing square bracket

### DIFF
--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -379,7 +379,7 @@ option_list = [
     Option('', '--no-children', help="don't operate on child channels",
            action='store_true'),
     Option('-P', '--phases', default='',
-           help='comma-separated list of phases [default: dev,test,prod'),
+           help='comma-separated list of phases [default: dev,test,prod]'),
     Option('-u', '--username', help='Spacewalk username'),
     Option('-p', '--password', help='Spacewalk password'),
     Option('-s', '--server',


### PR DESCRIPTION
It fixes the missing square bracket in the `spacewalk-manage-channel-lifecycle --help` command for the `--phases` option.