### PR TITLE
1654647 - Capture return bind var from bulk_set_custom_value calls.

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2305,7 +2305,7 @@ DELETE FROM rhnServerCustomDataValue
 
 <callable-mode name="bulk_set_custom_values">
     <query params="key_label, value, set_label, user_id">
-    { call rhn_server.bulk_set_custom_value(:key_label, :value, :set_label, :user_id) }
+    {:retval = call rhn_server.bulk_set_custom_value(:key_label, :value, :set_label, :user_id)}
     </query>
 </callable-mode>
 

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3170,12 +3170,19 @@ public class SystemManager extends BaseManager {
             String value) {
         CallableMode mode = ModeFactory.getCallableMode("System_queries",
                 "bulk_set_custom_values");
+
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("user_id", user.getId());
         params.put("set_label", setLabel);
         params.put("key_label", keyLabel);
         params.put("value", value);
-        mode.execute(params, new HashMap<String, Integer>());
+
+        Map<String, Integer> out = new HashMap<String, Integer>();
+        out.put("retval", new Integer(Types.NUMERIC));
+
+        Map<String, Object> result = mode.execute(params, out);
+        Long retval = (Long) result.get("retval");
+        log.debug("bulk_set_custom_value returns: " + retval.intValue());
     }
 
     /**


### PR DESCRIPTION
Add a return bind variable to the rhn_server.bulk_set_custom_value
PL/SQL call definition, and capture it in SystemManager to prevent an
ISE when attempting to set custom info keys via SSM.

PL/SQL was throwing an error because the return value wasn't being
captured by Java persistence layer.

PL/SQL error encountered:

ERROR
com.redhat.rhn.frontend.servlets.SessionFilter - Error during transaction.
Rolling back
javax.servlet.ServletException: com.redhat.rhn.common.db.WrappedSQLException:
ORA-06550: line 1, column 7:
PLS-00221: 'BULK_SET_CUSTOM_VALUE' is not a procedure or is undefined
ORA-06550: line 1, column 7:
PL/SQL: Statement ignored

Signed-off-by: Laurence Rochfort <laurence.rochfort@oracle.com>
Reviewed-by: Yinbo Wang <yinbo.wang@oracle.com>

Please see [BZ 1654647](https://bugzilla.redhat.com/show_bug.cgi?id=1654647) for details.