### PR TITLE
Extra semicolon leads to "SQL command not properly ended" with Oracle

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2232,7 +2232,7 @@ select a.id
             FROM rhnServerFeaturesView
             WHERE rhnSet.element = rhnServerFeaturesView.server_id
               AND rhnServerFeaturesView.label = :feature_label
-        ) = 0;
+        ) = 0
   </query>
 </mode>
 


### PR DESCRIPTION
See discussion at https://www.redhat.com/archives/spacewalk-list/2019-February/msg00000.html for details.

I couldn't test it, but as this is the only SQL statement ending with a semicolon, it has to be the reason for ORA-00933: SQL command not properly ended

Regards, Christian
