### PR TITLE
rhnplugin: disable cached repo if required

### DIFF
--- a/client/rhel/yum-rhn-plugin/rhnplugin.py
+++ b/client/rhel/yum-rhn-plugin/rhnplugin.py
@@ -222,8 +222,8 @@ def addCachedRepos(conduit):
             repo.baseurl = urls
             repo.urls = repo.baseurl
             repo.name = reponame
-            updateRHNRepoOptions(conduit, repo)
             repo.enable()
+            updateRHNRepoOptions(conduit, repo)
             if not repos.findRepos(repo.id):
                 repos.add(repo)
 


### PR DESCRIPTION
A repo may be disabled in the `rhnplugin.conf` file. The cache must know the repo is disabled, to avoid errors, e.g. when `yum -C check-update`.