### PR TITLE
Added SNI support for clients

### DIFF
--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -82,7 +82,7 @@ class SSLSocket:
             raise ValueError("Unable to read certificate file %s" % file)
         self._trusted_certs.append(file.encode("utf-8"))
 
-    def init_ssl(self):
+    def init_ssl(self, server_name=None):
         """
         Initializes the SSL connection.
         """
@@ -109,6 +109,10 @@ class SSLSocket:
 
         # Init the connection
         self._connection = SSL.Connection(self._ctx, self._sock)
+        # Set server name if defined. This allows connections to
+        # SNI-enabled servers
+        if server_name is not None:
+            self._connection.set_tlsext_host_name(server_name)
         # Place the connection in client mode
         self._connection.set_connect_state()
 

--- a/client/rhel/rhnlib/rhn/connections.py
+++ b/client/rhel/rhnlib/rhn/connections.py
@@ -197,7 +197,7 @@ class HTTPSConnection(HTTPConnection):
             raise socket.error("Unable to connect to the host and port specified")
 
         self.sock = SSL.SSLSocket(sock, self.trusted_certs)
-        self.sock.init_ssl()
+        self.sock.init_ssl(self.host)
 
 class HTTPSProxyResponse(HTTPResponse):
     def begin(self):


### PR DESCRIPTION
We need SNI support for our spacewalk clients. Spacewalk server work behind
the nginx web server and is one of a lot of virtual vhosts. For some reasons nginx uses
separate certificates for each virtual host, not one cert with many subjectAltName.
We have a problem with client connections in such environment.

Proposed changes use a call to set_tlsext_host_name() from SSLSocket when setting up
the SSL client connection, which allows connections to SNI-enabled servers. Tested on
many clients (under Ubuntu), work fine for us.