### PR TITLE
1703076 - Add search server JDBC idle time config options to rhn_sear…

### DIFF
--- a/search-server/spacewalk-search/src/config/com/redhat/satellite/search/db/config.xml
+++ b/search-server/spacewalk-search/src/config/com/redhat/satellite/search/db/config.xml
@@ -17,6 +17,8 @@
                                 <dataSource type="com.redhat.satellite.search.config.translator.C3P0DataSourceFactory">
                                                 <property name="driverClass" value="${search.connection.driver_class}"/>
                                                 <property name="jdbcUrl" value="${search.connection.driver_proto}:${db_name}"/>
+                                                <property name="maxIdleTime" value="${search.connection.max_idle_time}"/>
+                                                <property name="maxIdleTimeExcessConnections" value="${search.connection.max_idle_time_excess_connections}"/>
                                                 <property name="user" value="${db_user}"/>
                                                 <property name="password" value="${db_password}"/>
                         <property name="connectionCustomizerClassName" value="com.redhat.satellite.search.config.translator.RhnConnectionCustomizer" />

--- a/search-server/spacewalk-search/src/config/search/rhn_search.conf
+++ b/search-server/spacewalk-search/src/config/search/rhn_search.conf
@@ -1,6 +1,10 @@
 search.index_work_dir=/var/lib/rhn/search/indexes
 search.rpc_handlers=index:com.redhat.satellite.search.rpc.handlers.IndexHandler,db:com.redhat.satellite.search.rpc.handlers.DatabaseHandler,admin:com.redhat.satellite.search.rpc.handlers.AdminHandler
 search.connection.driver_class=oracle.jdbc.driver.OracleDriver
+# https://www.mchange.com/projects/c3p0/#maxIdleTime
+search.connection.max_idle_time=0
+# https://www.mchange.com/projects/c3p0/#maxIdleTimeExcessConnections
+search.connection.max_idle_time_excess_connections=0
 search.score_threshold=.10
 search.system_score_threshold=.01
 search.errata_score_threshold=.01


### PR DESCRIPTION
…ch.conf

Add C3P0 config options for maxIdleTime and
maxIdletimeExcessConnections to the search server mybatis config.

The search server uses mybatis for it's ORM persistence layer, which
in turn uses C3P0 for JDBC connection pooling. C3P0 is actually
configured without pooling, and with unlimited connection idle time by
default. This causes ORA-02396 errors when the target Oracle DB has
the IDLE_TIME property set in the user's profile because the
connection idle limit is exceeded.

Adding config options allows the search server's JDBC idle time to be
set so that it doesn't conflict with the DB's idle time.

The config options are set with the default of 0, meaning
unlimited. They may be overridden from the central /etc/rhn/rhn.conf file.

Orabug: 28537551

Signed-off-by: Laurence Rochfort <laurence.rochfort@oracle.com>
Reviewed-by: Alex Burmashev <alexander.burmashev@oracle.com>