### PR TITLE
Correct issue with dists in url hostname

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -64,7 +64,7 @@ class DebRepo(object):
     # url example - http://ftp.debian.org/debian/dists/jessie/main/binary-amd64/
     def __init__(self, url, cache_dir, pkg_dir, proxy_addr="", proxy_user="", proxy_pass=""):
         self.url = url
-        parts = url.split('/dists')
+        parts = url.rsplit('/dists/', 1)
         self.base_url = [parts[0]]
         # Make sure baseurl ends with / and urljoin will work correctly
         if self.base_url[0][-1] != '/':


### PR DESCRIPTION
URLs like http://dists.examle.com/local/dists/ourmirror/ubunut/dists/... failed syncing.  The URL path was spit in the wrong place.  Patch to look for the rightmost /dists/ in the URL.  For standard debian naming, this should be fine.