### PR TITLE
Add --json to format output as json not ruby string

### DIFF
--- a/utils/spacewalk-api
+++ b/utils/spacewalk-api
@@ -37,6 +37,8 @@ def processCommandline(argv):
             help='If we should log in or not. Default is to log in.'),
         Option('--nologin', action='store_false', dest='login',
             help='If we should log in or not. Default is to log in.'),
+        Option('--json', action='store_true', dest='json',
+            help='Format output in json format suitable to pipe to other tools(e.g., jq)'),
     ]
     optionParser = OptionParser(
         usage="Usage: %s --server=<server> [--login] [--user=<user>] [--password=<password>]" % sys.argv[0],
@@ -92,7 +94,11 @@ if __name__ == '__main__':
 
     try:
         result = getattr(client, params[0])(*params[1:])
-        sys.stdout.write(str(result) + '\n')
+        if options.json:
+            import json
+            sys.stdout.write(json.dumps(result))
+        else:
+            sys.stdout.write(str(result) + '\n')
     except xmlrpclib.Fault:
         sys.stderr.write('Fault returned from XML RPC Server: %s\n' % str(sys.exc_info()[1]))
         sys.exit(1)

--- a/utils/spacewalk-api.sgml
+++ b/utils/spacewalk-api.sgml
@@ -63,6 +63,12 @@ Call Spacawalk API from command line.
             <para>If you do not specify this and unless --nologin is specified, you will be prompted for your password.</para>
         </listitem>
     </varlistentry>
+    <varlistentry>
+        <term>--json</term>
+        <listitem>
+            <para>Format output through json dumper suitable for other tools (e.g., jq).</para>
+        </listitem>
+    </varlistentry>
 </variablelist>
 </RefSect1>
 


### PR DESCRIPTION
spacewalk-api outputs the results from xmlrpc calls as ruby strings.  Addining a --json option that outputs the results in json suitable to parse via other tools (e.g., jq)