### PR TITLE
Increase repo source url max lenght in frontend

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/validation/repoForm.xsd
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/validation/repoForm.xsd
@@ -13,7 +13,7 @@
   <attribute name="url">
     <simpleType baseType="string">
       <minLength value="1" />
-      <maxLength value="512" />
+      <maxLength value="2048" />
     </simpleType>
   </attribute>
 


### PR DESCRIPTION
Increase repository source url max character lenght in frontend from 512 to 2048 so it match the DB schema changes that was made back in 2014.

Commit that changed the DB schema: a569b5e4cc06aad012f99419daa568cba3837db7