### PR TITLE
Added a systemd template for the rhnsd timer

### DIFF
--- a/client/rhel/rhnsd/10-rhnsd.preset
+++ b/client/rhel/rhnsd/10-rhnsd.preset
@@ -1,0 +1,1 @@
+enable rhnsd.timer

--- a/client/rhel/rhnsd/rhnsd.spec
+++ b/client/rhel/rhnsd/rhnsd.spec
@@ -202,6 +202,7 @@ fi
 %files
 %{_unitdir}/rhnsd.service
 %{_unitdir}/rhnsd.timer
+%{_presetdir}/10-rhnsd.preset
 %else
 %files -f %{name}.lang
 %dir %{_sysconfdir}/sysconfig/rhn


### PR DESCRIPTION
Attempt to fix [this](https://bugzilla.redhat.com/show_bug.cgi?id=1688278) bug. As I understand it, rhnsd.service should be disabled and rhnsd.timer enabled.