### PR TITLE
Debian: Also store Multi-Arch header in DB and write to Packages.gz

### DIFF
--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -202,6 +202,7 @@ class OracleBackend(Backend):
                   'header_start': DBint(),
                   'header_end': DBint(),
                   'last_modified': DBdateTime(),
+                  'multi_arch': DBstring(16),
               },
               pk=['org_id', 'name_id', 'evr_id', 'package_arch_id',
                   'checksum_id'],

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -32,6 +32,9 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
         headerSource.rpmBinaryPackage.__init__(self)
 
         self.tagMap = headerSource.rpmBinaryPackage.tagMap.copy()
+        self.tagMap.update({
+            'multi_arch': 'Multi-Arch',
+        })
 
         # Remove already-mapped tags
         self._already_mapped = [

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -412,6 +412,7 @@ class Package(IncompletePackage):
         'path': StringType,
         'md5sum': StringType,       # xml dumps < 3.5
         'sigmd5': StringType,
+        'multi_arch': StringType,
         # These attributes are lists of objects
         'files': [File],
         'requires': [Dependency],

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -448,7 +448,7 @@ where snc.errata_id = :errata_id
          pevr.version as version, pevr.release as release,
          p.summary, p.description, pa.label as arch_label,
          p.build_time, p.path, p.package_size, p.payload_size, p.installed_size,
-         p.copyright, p.vendor, p.build_host, p.header_start, p.header_end,
+         p.copyright, p.vendor, p.build_host, p.header_start, p.header_end, p.multi_arch,
          srpm.name as source_rpm, pg.name as package_group_name,
          cs.checksum, cs.checksum_type as checksum_type,
          prd.primary_xml as primary_xml, prd.filelist as filelist_xml, prd.other as other_xml

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -61,6 +61,7 @@ public class PackageDto extends BaseDto {
     private Blob otherXml;
     private Blob filelistXml;
     private String cookie;
+    private String multiArch;
 
 
     // Pre-existing queries returning this as a string.
@@ -583,5 +584,19 @@ public class PackageDto extends BaseDto {
      */
     public String getFile() {
         return PackageHelper.getPackageFileFromPath(getPath());
+    }
+
+    /**
+     * @param multiArchIn The Multi-Arch header value
+     */
+    public void setMultiArch(String multiArchIn) {
+        this.multiArch = multiArchIn;
+    }
+
+    /**
+     * @return The Multi-Arch value
+     */
+    public String getMultiArch() {
+        return multiArch;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -106,6 +106,13 @@ public class DebPackageWriter {
                 out.newLine();
             }
 
+            String multiArch = pkgDto.getMultiArch();
+            if (multiArch != null && !multiArch.equalsIgnoreCase("")) {
+                out.write("Multi-Arch: ");
+                out.write(multiArch);
+                out.newLine();
+            }
+
             // dependencies
             addPackageDepData(
                     out,

--- a/schema/spacewalk/common/tables/rhnPackage.sql
+++ b/schema/spacewalk/common/tables/rhnPackage.sql
@@ -68,7 +68,8 @@ CREATE TABLE rhnPackage
     header_start     NUMBER
                          DEFAULT (-1) NOT NULL,
     header_end       NUMBER
-                         DEFAULT (-1) NOT NULL
+                         DEFAULT (-1) NOT NULL,
+    multi_arch       VARCHAR2(16)
 )
 ENABLE ROW MOVEMENT
 ;

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.9-to-spacewalk-schema-2.10/005-rhnPackage-multiarch.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.9-to-spacewalk-schema-2.10/005-rhnPackage-multiarch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnPackage ADD multi_arch character varying(16);
+


### PR DESCRIPTION
Currently, within the Debian metadata files (Packages.gz), one major header is still missing. The ```Multi-Arch``` header.

I think most users of Spacewalk that also manage Debian / Ubuntu systems are using my old script (https://github.com/rpasche/spacewalk-debian-sync/tree/add-multiarch-header) to add that missing header to the ```Packages.gz``` file later.

This PR should fix this. I tested this on a Uyuni server yesterday. For this PR to work, the DB schema has to be changed. But because I don't know exactly, where to put this code, this is the command I have used to add the ```multi_arch``` column to the Postgresql DB.

```ALTER TABLE rhnPackage ADD multi_arch character varying(16);```

I was not yet able to test this on a spacewalk system...Sorry. But with this PR, admins of Debian systems could sync the Debian repos directly with Spacewalk and would not have to inject the ```Multi-Arch``` header later.

See also https://github.com/uyuni-project/uyuni/pull/1072