### PR TITLE
Performance issue when rhnpackagechangelogdata has a lot of entries

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -272,7 +272,7 @@ SELECT id, channel_label, client, reason, force, bypass_filters, next_action
    <query params="">
 <!-- DISTINCT makes the DELETE faster for postgresql (no difference for oracle) -->
     DELETE FROM rhnPackageChangeLogData
-        WHERE id NOT IN ( SELECT DISTINCT changelog_data_id FROM rhnPackageChangeLogRec )
+        WHERE id NOT EXISTS ( SELECT DISTINCT 1 FROM rhnPackageChangeLogRec WHERE rhnPackageChangeLogRec.changelog_data_id = rhnPackageChangeLogData.id  )
    </query>
 </write-mode>
 


### PR DESCRIPTION
We have encountered severe performance hit when the table is huge, so I have work on a solution

and here's my result
https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_NOT_IN
https://explainextended.com/2009/09/16/not-in-vs-not-exists-vs-left-join-is-null-postgresql/
https://amplitude.engineering/how-a-single-postgresql-config-change-improved-slow-query-performance-by-50x-85593b8991b0

 explain analyze verbose delete from rhnpackagechangelogdata where not exists ( select distinct 1 from rhnpackagechangelogrec where rhnpackagechangelogrec.changelog_data_id = rhnpackagechangelogdata.id );
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on public.rhnpackagechangelogdata  (cost=0.44..361393.90 rows=652868 width=12) (actual time=3201.388..3201.388 rows=0 loops=1)
   ->  Nested Loop Anti Join  (cost=0.44..361393.90 rows=652868 width=12) (actual time=3201.385..3201.385 rows=0 loops=1)
         Output: rhnpackagechangelogdata.ctid, rhnpackagechangelogrec.ctid
         ->  Seq Scan on public.rhnpackagechangelogdata  (cost=0.00..26162.61 rows=726761 width=12) (actual time=0.005..343.214 rows=727584 loops=1)
               Output: rhnpackagechangelogdata.ctid, rhnpackagechangelogdata.id
         ->  Index Scan using rhn_pkg_clr_cld_uq on public.rhnpackagechangelogrec  (cost=0.44..5.59 rows=261 width=12) (actual time=0.004..0.004 rows=1 loops=727584)
               Output: rhnpackagechangelogrec.ctid, rhnpackagechangelogrec.changelog_data_id
               Index Cond: (rhnpackagechangelogrec.changelog_data_id = rhnpackagechangelogdata.id)
 Planning time: 0.263 ms
 Execution time: 3201.425 ms
(10 rows)

explain analyze verbose delete from rhnpackagechangelogdata WHERE id NOT IN ( SELECT DISTINCT changelog_data_id FROM rhnpackagechangelogrec );

                                                                                              QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on public.rhnpackagechangelogdata  (cost=0.44..161614354955.65 rows=363380 width=6) (actual time=331675751.850..331675751.851 rows=0 loops=1)
   ->  Seq Scan on public.rhnpackagechangelogdata  (cost=0.44..161614354955.65 rows=363380 width=6) (actual time=331675751.846..331675751.847 rows=0 loops=1)
         Output: rhnpackagechangelogdata.ctid
         Filter: (NOT (SubPlan 1))
         Rows Removed by Filter: 727584
         SubPlan 1
           ->  Materialize  (cost=0.44..444568.04 rows=73893 width=6) (actual time=0.004..218.664 rows=363792 loops=727584)
                 Output: rhnpackagechangelogrec.changelog_data_id
                 ->  Unique  (cost=0.44..443909.58 rows=73893 width=6) (actual time=0.049..4399.265 rows=727584 loops=1)
                       Output: rhnpackagechangelogrec.changelog_data_id
                       ->  Index Only Scan using rhn_pkg_clr_cld_uq on public.rhnpackagechangelogrec  (cost=0.44..395645.44 rows=19305654 width=6) (actual time=0.049..2145.520 rows=19305525 loops=1)
                             Output: rhnpackagechangelogrec.changelog_data_id
                             Heap Fetches: 9078
 Planning time: 0.704 ms
 Execution time: 331675756.156 ms
(15 rows)

Has you can see in postgresql there's a real performance gain.