### PR TITLE
Updated spacewalk-backend.spec to work for RHEL8

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -71,9 +71,6 @@ BuildRequires: python2
 BuildRequires: python2-rpm-macros
 BuildRequires: python2-spacewalk-usix
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} > 1310
-%if 0%{?rhel} == 8
-BuildRequires: rhnlib <= 2.10.0
-%endif
 BuildRequires: rhnlib >= 2.5.74
 BuildRequires: python2-rhn-client-tools
 BuildRequires: rpm-python
@@ -239,7 +236,7 @@ Summary: Spacewalk server and client tools libraries
 %if 0%{?suse_version}
 BuildRequires: python-devel
 %else
-Requires: python
+Requires: python2
 BuildRequires: python2-devel
 Conflicts: %{name} < 1.7.0
 Requires: python2-spacewalk-usix
@@ -356,7 +353,10 @@ Requires: %{name}-server = %{version}-%{release}
 Requires: python2-spacewalk-usix
 Requires: subscription-manager
 Requires: %{m2crypto}
+# python-argparse is included in Python 2.7
+%if 0%{?rhel} == 6
 Requires: python-argparse
+%endif
 
 %description cdn
 Tools for syncing content from Red Hat CDN


### PR DESCRIPTION
1.  Removed rhnlib max version as it does not seem to be required anymore.
2. Added versioned Python (2) for RHEL8
3. Removed argparse requirement for RHEL8 as it is included in Python 2.7