### PR TITLE
spacewalk-java updates for Tomcat 9

### DIFF
--- a/java/conf/rhn-tomcat9.xml
+++ b/java/conf/rhn-tomcat9.xml
@@ -1,0 +1,13 @@
+<!--
+  This is a Tomcat 9 Context file.  For more information see:
+    https://tomcat.apache.org/tomcat-9.0-doc/config/resources.html
+
+  reloadable - indicates to Tomcat that the webapp should be reloaded
+    when a change occurs.
+
+  allowLinking - true to allow Tomcat to follow symlinks.
+-->
+
+<Context reloadable="false">
+  <Resources allowLinking="true" />
+</Context>

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -487,11 +487,15 @@ fi
 ant -Dprefix=$RPM_BUILD_ROOT install-tomcat
 install -d -m 755 $RPM_BUILD_ROOT%{_sysconfdir}/tomcat/Catalina/localhost/
 
-# Need to use 2 versions of rhn.xml, Tomcat 8 changed syntax
+# Need to use multiple versions of rhn.xml, Tomcat changed syntax
 %if 0%{?fedora} >= 23
 install -m 644 conf/rhn-tomcat8.xml $RPM_BUILD_ROOT%{_sysconfdir}/tomcat/Catalina/localhost/rhn.xml
 %else
+%if 0%{?rhel} >= 8
+install -m 644 conf/rhn-tomcat9.xml $RPM_BUILD_ROOT%{_sysconfdir}/tomcat/Catalina/localhost/rhn.xml
+%else
 install -m 644 conf/rhn-tomcat5.xml $RPM_BUILD_ROOT%{_sysconfdir}/tomcat/Catalina/localhost/rhn.xml
+%endif
 %endif
 
 %else


### PR DESCRIPTION
1. Updated spec file to also consider RHEL8 for Tomcat version check.
2. Added separate config template file for Tomcat 9 (path would give a warning in the Catalina logs otherwise)