### PR TITLE
Include 'Pre-Depends' header in deb type Packages files

### DIFF
--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -203,6 +203,7 @@ class OracleBackend(Backend):
                   'header_end': DBint(),
                   'last_modified': DBdateTime(),
                   'multi_arch': DBstring(16),
+                  'pre_depends': DBstring(1000),
               },
               pk=['org_id', 'name_id', 'evr_id', 'package_arch_id',
                   'checksum_id'],

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -34,6 +34,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
         self.tagMap = headerSource.rpmBinaryPackage.tagMap.copy()
         self.tagMap.update({
             'multi_arch': 'Multi-Arch',
+            'pre_depends': 'Pre-Depends',
         })
 
         # Remove already-mapped tags

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -413,6 +413,7 @@ class Package(IncompletePackage):
         'md5sum': StringType,       # xml dumps < 3.5
         'sigmd5': StringType,
         'multi_arch': StringType,
+        'pre_depends': StringType,
         # These attributes are lists of objects
         'files': [File],
         'requires': [Dependency],

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -449,7 +449,7 @@ where snc.errata_id = :errata_id
          pevr.version as version, pevr.release as release,
          p.summary, p.description, pa.label as arch_label,
          p.build_time, p.path, p.package_size, p.payload_size, p.installed_size,
-         p.copyright, p.vendor, p.build_host, p.header_start, p.header_end, p.multi_arch,
+         p.copyright, p.vendor, p.build_host, p.header_start, p.header_end, p.multi_arch, p.pre_depends,
          srpm.name as source_rpm, pg.name as package_group_name,
          cs.checksum, cs.checksum_type as checksum_type,
          prd.primary_xml as primary_xml, prd.filelist as filelist_xml, prd.other as other_xml

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -62,7 +62,7 @@ public class PackageDto extends BaseDto {
     private Blob filelistXml;
     private String cookie;
     private String multiArch;
-
+    private String preDepends;
 
     // Pre-existing queries returning this as a string.
     private String lastModified;
@@ -598,5 +598,19 @@ public class PackageDto extends BaseDto {
      */
     public String getMultiArch() {
         return multiArch;
+    }
+
+    /**
+     * @param preDependsIn The Pre-Depends header value
+     */
+    public void setPreDepends(String preDependsIn) {
+        this.preDepends = preDependsIn;
+    }
+
+    /**
+     * @return The Multi-Arch value
+     */
+    public String getPreDepends() {
+        return preDepends;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -113,6 +113,13 @@ public class DebPackageWriter {
                 out.newLine();
             }
 
+            String preDepends = pkgDto.getPreDepends();
+            if (preDepends != null && !preDepends.equalsIgnoreCase("")) {
+                out.write("Pre-Depends: ");
+                out.write(preDepends);
+                out.newLine();
+            }
+
             // dependencies
             addPackageDepData(
                     out,

--- a/rel-eng/packages/.README
+++ b/rel-eng/packages/.README
@@ -1,3 +1,3 @@
-the rel-eng/packages directory contains metadata files
-named after their packages. Each file has the latest tagged
-version and the project's relative directory.
+Files in this directory are updated using tito tag invoked from
+directories of individual packages.
+Do not modify these files manually without knowing what your've doing.

--- a/rel-eng/packages/.README
+++ b/rel-eng/packages/.README
@@ -1,3 +1,3 @@
-Files in this directory are updated using tito tag invoked from
-directories of individual packages.
-Do not modify these files manually without knowing what your've doing.
+the rel-eng/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/schema/spacewalk/common/tables/rhnPackage.sql
+++ b/schema/spacewalk/common/tables/rhnPackage.sql
@@ -69,7 +69,8 @@ CREATE TABLE rhnPackage
                          DEFAULT (-1) NOT NULL,
     header_end       NUMBER
                          DEFAULT (-1) NOT NULL,
-    multi_arch       VARCHAR2(16)
+    multi_arch       VARCHAR2(16),
+    pre_depends      VARCHAR2(1000),
 )
 ENABLE ROW MOVEMENT
 ;

--- a/schema/spacewalk/upgrade/spacewalk-schema-2.9-to-spacewalk-schema-2.10/007-rhnPackage-predepends.sql
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.9-to-spacewalk-schema-2.10/007-rhnPackage-predepends.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnPackage ADD pre_depends character varying(1000);
+


### PR DESCRIPTION
Lately we were getting these errors when trying to upgrade Ubuntu systems which are integrated with spacewalk 2.10:
<code>
dpkg: regarding .../libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb containing libpam-modules:amd64, pre-dependency problem:
 libpam-modules:amd64 pre-depends on libpam-modules-bin (= 1.1.8-3.2ubuntu2.1)
  libpam-modules-bin is installed, but is version 1.1.8-3.2ubuntu2.
 </code>

<code>
dpkg: error processing archive /var/cache/apt/archives/libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb (--unpack):
 pre-dependency problem - not installing libpam-modules:amd64
Errors were encountered while processing:
 /var/cache/apt/archives/libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb
</code>

These issues occurred due to missing a Pre-Depends header in the Packages and Packages.gz files for certain packages. Adding the header solves this issue.

The code adjustments in this pull request have been tested:
- RPM's have been build
- RPM's have been installed
- Reposync has been run on new repo's which import packages

Test result:
> Package: gnukhata-core-engine
> Version: 2.6.0-2
> Architecture: all
> Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
> Installed-Size: 2858
> **Pre-Depends: adduser, dbconfig-common, postgresql-client**
> Depends: postgresql, python-dateutil, python-psycopg2, python-tk, python-twisted, python-twisted-web, debconf (>= 0.5) | debconf-2.0, python:any  (<<  2.8), python:any  (>=  2.7.5-5~)
> Filename: XMLRPC/GET-REQ/xenial-base-universe/getPackage/gnukhata-core-engine_2.6.0-2.all-deb.deb
> Size: 489688
> SHA256: e19c4acd6be17e92f85a2b9d9e8e73ad8c8160f507395cbeda16a84d69f66256
> Section: python
> Description: Free Accounting Software (Core Engine) 

No issues were noticed, all works fine and after a reposync the issue was resolved.

I would like to thank @rpasche for his work on pull request: https://github.com/spacewalkproject/spacewalk/pull/697 which these code changes are based upon.