### PR TITLE
Fix: missing apt breaks and pre-depends repo headers

### DIFF
--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -72,6 +72,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
                 val = None
             self[f] = val
 
+        self['repo_type'] = 'deb'
         self['package_size'] = size
         self['checksum_type'] = checksum_type
         self['checksum'] = checksum

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -78,6 +78,7 @@ class rpmPackage(IncompletePackage):
                 val = None
             self[f] = val
 
+        self['repo_type'] = 'yum'
         self['package_size'] = size
         self['checksum_type'] = checksum_type
         self['checksum'] = checksum

--- a/backend/server/importlib/mpmSource.py
+++ b/backend/server/importlib/mpmSource.py
@@ -48,6 +48,8 @@ class mpmBinaryPackage(headerSource.rpmBinaryPackage):
         if group == '':
             self['package_group'] = 'NoGroup'
 
+        self['repo_type'] = 'misc'
+
         return self
 
     def _populateFiles(self, header):

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -235,7 +235,12 @@ class PackageImport(ChannelPackageSubscription):
         # XXX
         package['copyright'] = self._fix_encoding(package['license'])
 
-        for tag in ('recommends', 'suggests', 'supplements', 'enhances', 'breaks', 'predepends'):
+        if package['repo_type'] == 'deb':
+           tagList = ('recommends', 'suggests', 'supplements', 'enhances')
+        else:
+           tagList = ('recommends', 'suggests', 'supplements', 'enhances', 'breaks', 'predepends')
+
+        for tag in tagList:
             if not self._rpm_knows(tag) or tag not in package or type(package[tag]) != type([]):
                 # older spacewalk server do not export weak deps.
                 # and older RPM doesn't know about them either

--- a/rel-eng/packages/.readme
+++ b/rel-eng/packages/.readme
@@ -1,3 +1,3 @@
-the rel-eng/packages directory contains metadata files
-named after their packages. Each file has the latest tagged
-version and the project's relative directory.
+Files in this directory are updated using tito tag invoked from
+directories of individual packages.
+Do not modify these files manually without knowing what your've doing.

--- a/rel-eng/packages/.readme
+++ b/rel-eng/packages/.readme
@@ -1,3 +1,3 @@
-Files in this directory are updated using tito tag invoked from
-directories of individual packages.
-Do not modify these files manually without knowing what your've doing.
+the rel-eng/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.


### PR DESCRIPTION
Lately we were getting these errors when trying to upgrade Ubuntu systems which are integrated with spacewalk 2.10:

    dpkg: regarding .../libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb containing libpam-modules:amd64, pre-dependency problem: libpam-modules:amd64 pre-depends on libpam-modules-bin (= 1.1.8-3.2ubuntu2.1) libpam-modules-bin is installed, but is version 1.1.8-3.2ubuntu2.
    dpkg: error processing archive /var/cache/apt/archives/libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb (--unpack): pre-dependency problem - not installing libpam-modules:amd64 Errors were encountered while processing: /var/cache/apt/archives/libpam-modules_1.1.8-3.2ubuntu2.1_amd64.deb

These issues occurred due to missing a Pre-Depends header in the Packages and Packages.gz files for certain packages. Adding the header solves this issue.

Also; we are seeing issues with recently upgraded packages which keep being listed as upgradeable on the commandline when using apt. By adding the Breaks header in the Packages and Packages.gz files this has been resolved.

Due to this comment:

    # older spacewalk server do not export weak deps.
    # and older RPM doesn't know about them either
    # lets create an empty list

I made sure the fix did not break for RPM style packages, hence the if/else statement.

The code adjustments in this pull request have been tested:

1. RPM's have been build
2. RPM's have been installed
3. Reposync has been run on new repo's (both deb and yum) which import packages

Test results for Pre-Depends:

    Package: gnukhata-core-engine
    Version: 2.6.0-2
    Architecture: all
    Maintainer: Ubuntu Developers ubuntu-devel-discuss@lists.ubuntu.com
    Installed-Size: 2858
    Pre-Depends: adduser, dbconfig-common, postgresql-client
    Depends: postgresql, python-dateutil, python-psycopg2, python-tk, python-twisted, python-twisted-web, debconf (>= 0.5) | debconf-2.0, python:any (<< 2.8), python:any (>= 2.7.5-5~)
    Filename: XMLRPC/GET-REQ/xenial-base-universe/getPackage/gnukhata-core-engine_2.6.0-2.all-deb.deb
    Size: 489688
    SHA256: e19c4acd6be17e92f85a2b9d9e8e73ad8c8160f507395cbeda16a84d69f66256
    Section: python
    Description: Free Accounting Software (Core Engine)

Test results for Breaks:

    Package: virtualbox-guest-additions-iso
    Version: 5.2.34-1~ubuntu18.04.1
    Architecture: all
    Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
    Installed-Size: 48520
    Conflicts: virtualbox-2.0, virtualbox-2.1, virtualbox-2.2, virtualbox-3.0, virtualbox-3.1, virtualbox-3.2, virtualbox-4.0, virtualbox-4.1, virtualbox-4.2, virtualbox-4.3, virtualbox-5.0, virtualbox-5.1
    Replaces: virtualbox-guest-additions  (<<  4.0.6-1~)
    Recommends: virtualbox  (>=  5.2.34)
    Breaks: virtualbox-guest-additions  (<<  4.0.6-1~)
    Filename: XMLRPC/GET-REQ/bionic-updates-multiverse/getPackage/virtualbox-guest-additions-iso_5.2.34-1~ubuntu18.04.1.all-deb.deb
    Size: 34113588
    SHA256: f48fc07008bee11ca3618e3ca0aeb0e4bbe85309ca405aa49485cf67f917fc29
    Section: non-free/misc
    Description: guest additions iso image for VirtualBox

No issues were noticed, all works fine and after a reposync the issue was resolved.