### PR TITLE
Fix weird case sensitivity issue with .readme .README

### DIFF
--- a/rel-eng/packages/.README
+++ b/rel-eng/packages/.README
@@ -1,3 +1,0 @@
-Files in this directory are updated using tito tag invoked from
-directories of individual packages.
-Do not modify these files manually without knowing what your've doing.

--- a/rel-eng/packages/.readme
+++ b/rel-eng/packages/.readme
@@ -1,3 +1,0 @@
-the rel-eng/packages directory contains metadata files
-named after their packages. Each file has the latest tagged
-version and the project's relative directory.

--- a/rel-eng/packages/.readme
+++ b/rel-eng/packages/.readme
@@ -1,0 +1,3 @@
+Files in this directory are updated using tito tag invoked from
+directories of individual packages.
+Do not modify these files manually without knowing what your've doing.


### PR DESCRIPTION
If editing the readme on a Mac with a case insensitive filesystem, something weird happens with the readme in `rel-eng/packages`.  It shows up as two different files.

This shows up after a fresh clone:
```
jacobsalmela:~/Documents/git$ git clone https://github.com/jacobsalmela/spacewalk.git
Cloning into 'spacewalk'...
remote: Enumerating objects: 39, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (29/29), done.
remote: Total 567023 (delta 12), reused 24 (delta 7), pack-reused 566984
Receiving objects: 100% (567023/567023), 726.83 MiB | 24.25 MiB/s, done.
Resolving deltas: 100% (431172/431172), done.
Updating files: 100% (10847/10847), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  'rel-eng/packages/.README'
  'rel-eng/packages/.readme'
```
`git status` shows:
```
jacobsalmela:~/Documents/git/spacewalk (master)$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   rel-eng/packages/.README

no changes added to commit (use "git add" and/or "git commit -a")
```
