### PR TITLE
 contrib/swapi.py TypeError fix

### DIFF
--- a/contrib/swapi.py
+++ b/contrib/swapi.py
@@ -417,7 +417,7 @@ def results_to_json_str(results, indent=2):
     >>> results_to_json_str([123, 'abc', {'x':'yz'}])
     '[\\n  123, \\n  "abc", \\n  {\\n    "x": "yz"\\n  }\\n]'
     """
-    return simplejson.dumps(results, ensure_ascii=False, indent=indent)
+    return simplejson.dumps(results, ensure_ascii=False, indent=4, sort_keys=True, default=str)
 
 
 def configure_with_configfile(config_file, profile=""):


### PR DESCRIPTION
With the current `swapi.py` script a API request using this script will raise a type error if you want to fetch the system details:
`$ /usr/sbin/swapi.py -C /etc/swapi.conf -P spacewalk --no-cache -A 1000010000 -I 0 system.getDetails`

Error:
```
Traceback (most recent call last):
  File "/usr/sbin/swapi.py", line 659, in <module>
    sys.exit(main(sys.argv))
  File "/usr/sbin/swapi.py", line 602, in main
    print >> out, results_to_json_str(res, options.indent)
  File "/usr/sbin/swapi.py", line 420, in results_to_json_str
    return simplejson.dumps(results, ensure_ascii=False, indent=indent)
  File "/usr/lib64/python2.7/site-packages/simplejson/__init__.py", line 397, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python2.7/site-packages/simplejson/encoder.py", line 293, in encode
    chunks = list(chunks)
  File "/usr/lib64/python2.7/site-packages/simplejson/encoder.py", line 665, in _iterencode
    for chunk in _iterencode_list(o, _current_indent_level):
  File "/usr/lib64/python2.7/site-packages/simplejson/encoder.py", line 515, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib64/python2.7/site-packages/simplejson/encoder.py", line 634, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/site-packages/simplejson/encoder.py", line 697, in _iterencode
    o = _default(o)
  File "/usr/lib64/python2.7/site-packages/simplejson/encoder.py", line 268, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <DateTime '20191117T09:53:54' at 7f617c40b2d8> is not JSON serializable
```

This error is being raised due to this part:
```
  File "/usr/sbin/swapi.py", line 420, in results_to_json_str
    return simplejson.dumps(results, ensure_ascii=False, indent=indent)
```

By adding a few parameters to the `simplejson.dumps` call this can be fixed:
```
simplejson.dumps(results, ensure_ascii=False, indent=4, sort_keys=True, default=str)
```

Instead of:
```
simplejson.dumps(results, ensure_ascii=False, indent=indent)
```