### PR TITLE
Update supported Oracle DB and Instant Client versions.

### DIFF
--- a/java/conf/default/rhn_taskomatic_daemon.conf
+++ b/java/conf/default/rhn_taskomatic_daemon.conf
@@ -18,8 +18,8 @@ wrapper.java.mainclass=com.redhat.rhn.taskomatic.core.TaskomaticDaemon
 # TODO need to make this work on AMD64 which would be /usr/lib64
 wrapper.java.library.path.1=/usr/lib
 wrapper.java.library.path.2=/usr/lib64
-wrapper.java.library.path.3=/usr/lib/oracle/11.2/client64/lib
-wrapper.java.library.path.4=/usr/lib/oracle/11.2/client/lib
+wrapper.java.library.path.3=/usr/lib/oracle/18.5/client64/lib
+wrapper.java.library.path.4=/usr/lib/oracle/18.5/client/lib
 
 wrapper.java.classpath.1=/usr/share/java/tanukiwrapper.jar
 wrapper.java.classpath.2=/usr/share/rhn/classes

--- a/projects/oracle-lib-compat/oracle-lib-compat.spec
+++ b/projects/oracle-lib-compat/oracle-lib-compat.spec
@@ -1,5 +1,5 @@
 Name:           oracle-lib-compat
-Version:        11.2.0.16
+Version:        15.5.0.0
 Release:        1%{?dist}
 Summary:        Compatibility package so that perl-DBD-Oracle will install
 License:        GPLv2
@@ -20,11 +20,11 @@ Requires:       oracle-instantclient-basic = %{icversion}
 Requires:       oracle-instantclient-sqlplus = %{icversion}
 %define soversion 10
 %else
-%define icversion 11.2.0.4.0
-%define icdir 11.2
-Requires:       oracle-instantclient11.2-basic = %{icversion}
-Requires:       oracle-instantclient11.2-sqlplus = %{icversion}
-%define soversion 11
+%define icversion 18.5.0.0.0
+%define icdir 18.5
+Requires:       oracle-instantclient18.5-basic = %{icversion}
+Requires:       oracle-instantclient18.5-sqlplus = %{icversion}
+%define soversion 18
 %endif
 
 Requires(post): ldconfig
@@ -103,6 +103,9 @@ find %{_prefix}/lib/oracle/%{icdir} \
         | xargs execstack -c
 
 %changelog
+* Thu 28 May 2020 Laurence Rochfort <laurence.rochfort@oracle.com> 18.5.0.0-1
+- Update instant client to 18.5 [Orabug: 31413086]
+
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 11.2.0.16-1
 - remove install/clean section initial cleanup
 - removed Group from specfile

--- a/rel-eng/packages/oracle-instantclient-selinux
+++ b/rel-eng/packages/oracle-instantclient-selinux
@@ -1,1 +1,1 @@
-11.2.0.4-1 selinux/oracle-instantclient-selinux/
+18.5.0.0-1 selinux/oracle-instantclient-selinux/

--- a/search-server/spacewalk-search/src/config/rhn-search
+++ b/search-server/spacewalk-search/src/config/rhn-search
@@ -75,7 +75,7 @@ unlock() {
 }
 
 removeindex() {
-    JAVA_LIBRARY_PATH='-Djava.library.path=/usr/lib/oracle/11.2/client/lib:/usr/lib/oracle/11.2/client64/lib:/usr/lib/gcj/postgresql-jdbc:/usr/lib64/gcj/postgresql-jdbc'
+    JAVA_LIBRARY_PATH='-Djava.library.path=/usr/lib/oracle/18.5/client/lib:/usr/lib/oracle/18.5/client64/lib:/usr/lib/gcj/postgresql-jdbc:/usr/lib64/gcj/postgresql-jdbc'
     SEARCH_CLASS_PATH=`build-classpath-directory /usr/share/rhn/search/lib /usr/share/java/ojdbc14.jar /usr/share/java/postgresql-jdbc.jar /usr/share/java/cglib-nodep.jar /usr/share/java/objectweb-asm/asm.jar /usr/share/java/cglib.jar /usr/share/java/mchange-commons.jar /usr/share/java/mchange-commons-java.jar`
     CLASSPATH=${SEARCH_CLASS_PATH} java $JAVA_LIBRARY_PATH com.redhat.satellite.search.DeleteIndexes > /dev/null
 }

--- a/search-server/spacewalk-search/src/config/search/rhn_search_daemon.conf
+++ b/search-server/spacewalk-search/src/config/search/rhn_search_daemon.conf
@@ -23,8 +23,8 @@ wrapper.java.classpath.4=/usr/share/rhn/search/lib/*.jar
 # Java Library Path (location of Wrapper.DLL or libwrapper.so)
 wrapper.java.library.path.1=/usr/lib
 wrapper.java.library.path.2=/usr/lib64
-wrapper.java.library.path.3=/usr/lib/oracle/11.2/client/lib
-wrapper.java.library.path.4=/usr/lib/oracle/11.2/client64/lib
+wrapper.java.library.path.3=/usr/lib/oracle/18.5/client/lib
+wrapper.java.library.path.4=/usr/lib/oracle/18.5/client64/lib
 wrapper.java.library.path.5=/usr/lib/gcj/postgresql-jdbc
 wrapper.java.library.path.6=/usr/lib64/gcj/postgresql-jdbc
 

--- a/selinux/oracle-instantclient-selinux/oracle-instantclient-selinux.spec
+++ b/selinux/oracle-instantclient-selinux/oracle-instantclient-selinux.spec
@@ -1,9 +1,9 @@
 %{!?fedora: %global sbinpath /sbin}%{?fedora: %global sbinpath %{_sbindir}}
 
 Name:		oracle-instantclient-selinux
-Version:	11.2.0.4
+Version:	18.5.0.0
 Release:	1%{?dist}
-Summary:	SELinux support for Oracle Instant Client 11g
+Summary:	SELinux support for Oracle Instant Client 18c
 License:	GPLv2+
 # This src.rpm is canonical upstream.
 # You can obtain it using this set of commands
@@ -15,7 +15,7 @@ BuildArch:	noarch
 
 Requires(post):	/usr/sbin/semanage, %{sbinpath}/restorecon, /usr/sbin/selinuxenabled
 Requires(postun):	/usr/sbin/semanage, %{sbinpath}/restorecon
-Requires:	oracle-instantclient11.2-basic
+Requires:	oracle-instantclient18.5-basic
 Requires:	oracle-nofcontext-selinux
 
 %description
@@ -23,7 +23,7 @@ SELinux support for Oracle Instant Client.
 
 %package -n oracle-instantclient-sqlplus-selinux
 Summary:	SELinux support for Oracle Instant Client sqlplus
-Requires:	oracle-instantclient11.2-sqlplus
+Requires:	oracle-instantclient18.5-sqlplus
 Requires:	oracle-nofcontext-selinux
 Requires(post):	/usr/sbin/semanage, %{sbinpath}/restorecon, /usr/sbin/selinuxenabled
 Requires(postun):	/usr/sbin/semanage, %{sbinpath}/restorecon
@@ -47,7 +47,7 @@ cat <<'EOS' > %{buildroot}%{_sbindir}/%{name}-enable
 for i in %used_libs ; do
 	/usr/sbin/semanage fcontext -a -t textrel_shlib_t '/usr/lib/oracle/11\.2/client.*/lib/'${i//./\\.}
 done
-%{sbinpath}/restorecon -Rvv /usr/lib/oracle/11.2/client* || :
+%{sbinpath}/restorecon -Rvv /usr/lib/oracle/18.5/client* || :
 
 EOS
 
@@ -57,7 +57,7 @@ cat <<'EOS' > %{buildroot}%{_sbindir}/oracle-instantclient-sqlplus-selinux-enabl
 /usr/sbin/semanage fcontext -a -t oracle_sqlplus_exec_t '/usr/lib/oracle/11\.2/client.*/bin/sqlplus'
 /usr/sbin/semanage fcontext -a -t textrel_shlib_t '/usr/lib/oracle/11\.2/client.*/lib/libsqlplus\.so'
 /usr/sbin/semanage fcontext -a -t textrel_shlib_t '/usr/lib/oracle/11\.2/client.*/lib/libsqlplusic\.so'
-%{sbinpath}/restorecon -Rvv /usr/lib/oracle/11.2/client* || :
+%{sbinpath}/restorecon -Rvv /usr/lib/oracle/18.5/client* || :
 
 EOS
 
@@ -71,7 +71,7 @@ fi
 %posttrans
 #this may be safely remove when BZ 505066 is fixed
 if /usr/sbin/selinuxenabled ; then
-	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/11.2/client* || :
+	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/18.5/client* || :
 fi
 
 %postun
@@ -79,7 +79,7 @@ if [ $1 -eq 0 ]; then
 	for i in %used_libs ; do
 		/usr/sbin/semanage fcontext -d -t textrel_shlib_t '/usr/lib/oracle/11\.2/client.*/lib/'${i//./\\.}
 	done
-	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/11.2/client* || :
+	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/18.5/client* || :
 fi
 
 %post -n oracle-instantclient-sqlplus-selinux
@@ -90,7 +90,7 @@ fi
 %posttrans -n oracle-instantclient-sqlplus-selinux
 #this may be safely remove when BZ 505066 is fixed
 if /usr/sbin/selinuxenabled ; then
-	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/11.2/client* || :
+	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/18.5/client* || :
 fi
 
 %postun -n oracle-instantclient-sqlplus-selinux
@@ -98,7 +98,7 @@ if [ $1 -eq 0 ]; then
 	/usr/sbin/semanage fcontext -d -t oracle_sqlplus_exec_t '/usr/lib/oracle/11\.2/client.*/bin/sqlplus'
 	/usr/sbin/semanage fcontext -d -t textrel_shlib_t '/usr/lib/oracle/11\.2/client.*/lib/libsqlplus\.so'
 	/usr/sbin/semanage fcontext -d -t textrel_shlib_t '/usr/lib/oracle/11\.2/client.*/lib/libsqlplusic\.so'
-	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/11.2/client* || :
+	%{sbinpath}/restorecon -Rvv /usr/lib/oracle/18.5/client* || :
 fi
 
 %files
@@ -108,6 +108,9 @@ fi
 %attr(0755,root,root) %{_sbindir}/oracle-instantclient-sqlplus-selinux-enable
 
 %changelog
+* Thu 28 May 2020 Laurence Rochfort <laurence.rochfort@oracle.com> 18.5.0.0-1
+- Update instant client to 18.5 [Orabug: 31413086]
+
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 11.2.0.4-1
 - remove install/clean section initial cleanup
 - removed Group from specfile

--- a/selinux/oracle-xe-selinux/oracle-xe-selinux-enable
+++ b/selinux/oracle-xe-selinux/oracle-xe-selinux-enable
@@ -9,7 +9,7 @@ for selinuxvariant in mls strict targeted
   done
 
 /usr/sbin/semanage port -a -t oracle_port_t -p tcp 9055 || :
-/usr/sbin/getsebool oracle_11g_support > /dev/null 2>&1 && /usr/sbin/setsebool -P oracle_11g_support 1
+/usr/sbin/getsebool oracle_18c_support > /dev/null 2>&1 && /usr/sbin/setsebool -P oracle_18c_support 1
 
 # Relabel oracle-xe's files
 rpm -qlf /etc/init.d/oracle-xe | xargs -n 100 /sbin/restorecon -Rivv
@@ -19,7 +19,9 @@ rpm -qlf /etc/init.d/oracle-xe | xargs -n 100 /sbin/restorecon -Rivv
 
 EXTRA_SUBDIRS=''
 ORACLE_XE_VERSION=$( rpm -qf --qf '%{version}\n' /etc/init.d/oracle-xe )
-if [ ${ORACLE_XE_VERSION%%.*} == 11 ] ; then
+if [ ${ORACLE_XE_VERSION%%.*} == 18 ] ; then
+    EXTRA_SUBDIRS="/u01/app/oracle/admin /u01/app/oracle/admin/XE/adump /u01/app/oracle/diag /u01/app/oracle/diag/tnslsnr /u01/app/oracle/fast_recovery_area/XE /u01/app/oracle/oradata /u01/app/oracle/product/18.4.0/xe/log/$( hostname -s )/client /u01/app/oracle/oradiag_oracle /u01/app/oracle/oradiag_oracle/diag /u01/app/oracle/product/18\.4\.0/xe/config/log"
+elif [ ${ORACLE_XE_VERSION%%.*} == 11 ] ; then
 	EXTRA_SUBDIRS="/u01/app/oracle/admin /u01/app/oracle/admin/XE/adump /u01/app/oracle/diag /u01/app/oracle/diag/tnslsnr /u01/app/oracle/fast_recovery_area/XE /u01/app/oracle/oradata /u01/app/oracle/product/11.2.0/xe/log/$( hostname -s )/client /u01/app/oracle/oradiag_oracle /u01/app/oracle/oradiag_oracle/diag /u01/app/oracle/product/11\.2\.0/xe/config/log"
 elif [ ${ORACLE_XE_VERSION%%.*} == 10 ] ; then
 	EXTRA_SUBDIRS='/usr/lib/oracle/xe/app/oracle/product/10.2.0/server/log /usr/lib/oracle/xe/app/oracle/flash_recovery_area /usr/lib/oracle/xe/app/oracle/admin /usr/lib/oracle/xe/oradata /var/tmp/.oracle'

--- a/selinux/oracle-xe-selinux/oracle-xe.fc
+++ b/selinux/oracle-xe-selinux/oracle-xe.fc
@@ -7,7 +7,7 @@
 /usr/lib/oracle/xe/oradata(/.*)?          gen_context(system_u:object_r:oracle_dbfile_t,s0)
 /usr/lib/oracle/xe/app/oracle/flash_recovery_area(/.*)?          gen_context(system_u:object_r:oracle_dbfile_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
+# for oracle-database-xe-18c-1.0-1.x86_64
 /u01/app/oracle/oradata(/.*)?					gen_context(system_u:object_r:oracle_dbfile_t,s0)
 /u01/app/oracle/fast_recovery_area/XE(/.*)?			gen_context(system_u:object_r:oracle_dbfile_t,s0)
 
@@ -20,12 +20,12 @@
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?server/config/scripts/backup\.sh          gen_context(user_u:object_r:oracle_sqlplus_exec_t,s0)
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?server/config/scripts/restore\.sh          gen_context(user_u:object_r:oracle_sqlplus_exec_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
-/u01/app/oracle/product/11\.2\.0/xe/config(/.*)?		gen_context(user_u:object_r:oracle_db_log_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/config/scripts(/.*)?	gen_context(user_u:object_r:oracle_sqlplus_log_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/config/scripts/backup\.sh	gen_context(user_u:object_r:oracle_sqlplus_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/config/scripts/restore\.sh	gen_context(user_u:object_r:oracle_sqlplus_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/config/log(/.*)?		gen_context(user_u:object_r:oracle_sqlplus_log_t,s0)
+# for oracle-database-xe-18c-1.0-1.x86_64
+/u01/app/oracle/product/18\.4\.0/xe/config(/.*)?		gen_context(user_u:object_r:oracle_db_log_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/config/scripts(/.*)?	gen_context(user_u:object_r:oracle_sqlplus_log_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/config/scripts/backup\.sh	gen_context(user_u:object_r:oracle_sqlplus_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/config/scripts/restore\.sh	gen_context(user_u:object_r:oracle_sqlplus_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/config/log(/.*)?		gen_context(user_u:object_r:oracle_sqlplus_log_t,s0)
 /u01/app/oracle/admin/XE/adump(/.*)?				gen_context(user_u:object_r:oracle_db_log_t,s0)
 
 # otherwise these would default to bin_t
@@ -36,20 +36,20 @@
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?bin/tnslsnr          gen_context(system_u:object_r:oracle_tnslsnr_exec_t,s0)
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?bin/rman          gen_context(system_u:object_r:oracle_db_exec_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
-/u01/app/oracle/product/11\.2\.0/xe/bin/lsnrctl			gen_context(system_u:object_r:oracle_lsnrctl_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/bin/oracle			gen_context(system_u:object_r:oracle_db_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/bin/orapwd			gen_context(system_u:object_r:oracle_db_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/bin/sqlplus			gen_context(system_u:object_r:oracle_sqlplus_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/bin/tnslsnr			gen_context(system_u:object_r:oracle_tnslsnr_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/bin/rman			gen_context(system_u:object_r:oracle_db_exec_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/bin/oradism			gen_context(system_u:object_r:oracle_db_exec_t,s0)
+# for oracle-database-xe-18c-1.0-1.x86_64
+/u01/app/oracle/product/18\.4\.0/xe/bin/lsnrctl			gen_context(system_u:object_r:oracle_lsnrctl_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/bin/oracle			gen_context(system_u:object_r:oracle_db_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/bin/orapwd			gen_context(system_u:object_r:oracle_db_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/bin/sqlplus			gen_context(system_u:object_r:oracle_sqlplus_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/bin/tnslsnr			gen_context(system_u:object_r:oracle_tnslsnr_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/bin/rman			gen_context(system_u:object_r:oracle_db_exec_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/bin/oradism			gen_context(system_u:object_r:oracle_db_exec_t,s0)
 
 # many jars are not located under lib, jre, or java directories
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?.+\.jar          gen_context(system_u:object_r:shlib_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
-/u01/app/oracle/product/11\.2\.0/xe/(.*/)?.+\.jar		gen_context(system_u:object_r:shlib_t,s0)
+# for oracle-database-xe-18c-1.0-1.x86_64
+/u01/app/oracle/product/18\.4\.0/xe/(.*/)?.+\.jar		gen_context(system_u:object_r:shlib_t,s0)
 
 # otherwise these would default to shlib_t
 # for 10gR2
@@ -63,16 +63,16 @@
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?lib/libocci\.so\.10\.1          gen_context(system_u:object_r:texrel_shlib_t,s0)
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?lib/libdbcfg10\.so          gen_context(system_u:object_r:texrel_shlib_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
-/u01/app/oracle/product/11\.2\.0/xe/lib/libclntsh\.so\.11.*	gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libnnz11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libnque11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libagtsh\.so\.1\.0	gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libsqlplus\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libocrutl11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libhasgen11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libocci\.so\.11\.1	gen_context(system_u:object_r:texrel_shlib_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/lib/libdbcfg11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
+# for # oracle-database-xe-18c-1.0-1.x86_64
+/u01/app/oracle/product/18\.4\.0/xe/lib/libclntsh\.so\.11.*	gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libnnz11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libnque11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libagtsh\.so\.1\.0	gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libsqlplus\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libocrutl11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libhasgen11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libocci\.so\.11\.1	gen_context(system_u:object_r:texrel_shlib_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/lib/libdbcfg11\.so		gen_context(system_u:object_r:texrel_shlib_t,s0)
 
 # certain logs are kept under the ORACLE_HOME hierarchy
 # the database writes to these locations
@@ -81,11 +81,11 @@
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?server/config/log(/.*)?	gen_context(user_u:object_r:oracle_sqlplus_log_t,s0)
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?rdbms/audit(/.*)?          gen_context(user_u:object_r:oracle_db_log_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
-/u01/app/oracle/product/11\.2\.0/xe/dbs(/.*)?			gen_context(user_u:object_r:oracle_db_log_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/log(/.*)?			gen_context(user_u:object_r:oracle_db_log_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/rdbms/audit(/.*)?		gen_context(user_u:object_r:oracle_db_log_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/rdbms/log(/.*)?		gen_context(user_u:object_r:oracle_db_log_t,s0)
+# for # oracle-database-xe-18c-1.0-1.x86_64
+/u01/app/oracle/product/18\.4\.0/xe/dbs(/.*)?			gen_context(user_u:object_r:oracle_db_log_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/log(/.*)?			gen_context(user_u:object_r:oracle_db_log_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/rdbms/audit(/.*)?		gen_context(user_u:object_r:oracle_db_log_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/rdbms/log(/.*)?		gen_context(user_u:object_r:oracle_db_log_t,s0)
 /u01/app/oracle/diag(/.*)?					gen_context(user_u:object_r:oracle_db_log_t,s0)
 /u01/app/oracle/oradiag_oracle/diag(/.*)?			gen_context(user_u:object_r:oracle_sqlplus_log_t,s0)
 
@@ -93,9 +93,9 @@
 /usr/lib/oracle/xe/app/oracle/product/(.*[0-9]/)?server/log(/.*)?          gen_context(user_u:object_r:oracle_tnslsnr_log_t,s0)
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?network/log(/.*)?          gen_context(user_u:object_r:oracle_tnslsnr_log_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
+# for # oracle-database-xe-18c-1.0-1.x86_64
 /u01/app/oracle/diag/tnslsnr(/.*)?				gen_context(user_u:object_r:oracle_tnslsnr_log_t,s0)
-/u01/app/oracle/product/11\.2\.0/xe/log/.*/client(/.*)?		gen_context(user_u:object_r:oracle_tnslsnr_log_t,s0)
+/u01/app/oracle/product/18\.4\.0/xe/log/.*/client(/.*)?		gen_context(user_u:object_r:oracle_tnslsnr_log_t,s0)
 
 # upon ORA-3136, database writes to network/log/sqlnet.log
 /usr/lib/oracle/xe/app/oracle/product/(.*/)?network/log/sqlnet\.log(.*)?          gen_context(user_u:object_r:oracle_db_log_t,s0)
@@ -103,6 +103,6 @@
 # otherwise this would be unlabeled
 /var/tmp/.oracle(/.*)?          gen_context(user_u:object_r:oracle_tmp_t,s0)
 
-# for oracle-xe-11.2.0-1.0.x86_64
+# for # oracle-database-xe-18c-1.0-1.x86_64
 /u01(/.*)?							gen_context(system_u:object_r:lib_t,s0)
 

--- a/selinux/oracle-xe-selinux/oracle-xe.te
+++ b/selinux/oracle-xe-selinux/oracle-xe.te
@@ -47,7 +47,7 @@ mcs_ptrace_all(oracle_db_t)
 
 allow oracle_sqlplus_t urandom_device_t:chr_file read;
 
-# for oracle-xe-11.2.0-1.0.x86_64
+# for oracle-database-xe-18c-1.0-1.x86_64
 allow oracle_lsnrctl_t self:netlink_route_socket { bind create getattr nlmsg_read };
 
 corenet_udp_bind_generic_node(oracle_lsnrctl_t)

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -92,8 +92,8 @@ Obsoletes: spacewalk < 0.7.0
 Requires:  spacewalk-common = %{version}-%{release}
 Conflicts: spacewalk-postgresql
 
-Requires: oracle-instantclient11.2-basic
-Requires: oracle-instantclient11.2-sqlplus
+Requires: oracle-instantclient18.5-basic
+Requires: oracle-instantclient18.5-sqlplus
 Conflicts: oracle-instantclient-basic <= 10.2.0.4
 Conflicts: oracle-instantclient-sqlplus <= 10.2.0.4
 Requires: spacewalk-java-oracle
@@ -170,6 +170,9 @@ rm -rf %{buildroot}
 %{_datadir}/spacewalk/setup/defaults.d/postgresql-backend.conf
 
 %changelog
+* Thu May 28 2020 Laurence Rochfort <laurence.rochfort@oracle.com> 2.11.0-1
+- Update Instant Client version to 18.5 [Orabug: 31413086]
+
 * Tue Feb 11 2020 Michael Mraka <michael.mraka@redhat.com> 2.10.3-1
 - let's change release name after 10 years
 

--- a/spacewalk/setup/bin/spacewalk-setup-tomcat
+++ b/spacewalk/setup/bin/spacewalk-setup-tomcat
@@ -17,7 +17,7 @@ use strict;
 use Spacewalk::Setup;
 use File::Spec;
 
-use constant ORACLE_LDCONF    => "/etc/ld.so.conf.d/oracle-instantclient-11.2.conf";
+use constant ORACLE_LDCONF    => "/etc/ld.so.conf.d/oracle-instantclient-18.5.conf";
 use constant TOMCAT_PAM_LDAP  => "/lib{64,}/security/pam_ldap.so";
 use constant TOMCAT_JAVA_OPTS =>
         File::Spec->catfile(Spacewalk::Setup::SHARED_DIR, "tomcat.java_opts");

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -1429,7 +1429,7 @@ EOQ
     $dbh->disconnect();
 
     my $version = join('.', (split(/\./, $v))[0 .. 2]);
-    my @allowed_db_versions = qw/12.2.0 12.1.0 11.2.0 11.1.0 10.2.0/;
+    my @allowed_db_versions = qw/19.3.0 18.4.0 18.3.0 12.2.0 12.1.0 11.2.0 11.1.0 10.2.0/;
 
     unless (grep { $version eq $_ } @allowed_db_versions) {
         die "Version [$version] is not supported (does not match "

--- a/spacewalk/setup/share/tomcat.2
+++ b/spacewalk/setup/share/tomcat.2
@@ -1,1 +1,1 @@
-^_HACK_AROUND_PARSEOPTIONS=1; test -f /etc/ld.so.conf.d/oracle-instantclient-11.2.conf.+LD_LIBRARY_PATH=.+\n
+^_HACK_AROUND_PARSEOPTIONS=1; test -f /etc/ld.so.conf.d/oracle-instantclient-18.5.conf.+LD_LIBRARY_PATH=.+\n

--- a/spec-tree/cx_Oracle/cx_Oracle.spec
+++ b/spec-tree/cx_Oracle/cx_Oracle.spec
@@ -9,9 +9,9 @@
 %define oraclever 10.2.0.3
 %define oracleicver %{oraclever}
 %else
-%define oraclever 11.2
+%define oraclever 18.5
 %define oracleicname instantclient%{oraclever}
-%define oracleicver 11.2.0.4.0
+%define oracleicver 18.5.0.0.0
 %endif
 %endif
 
@@ -60,6 +60,9 @@ export ORACLE_HOME=%{oracle_home}
 %doc LICENSE.txt README.txt BUILD.txt samples test
 
 %changelog
+* Thu 28 May 2020 Laurence Rochfort <laurence.rochfort@oracle.com> 18.5.0.0-1
+- Update instant client to 18.5 [Orabug: 31413086]
+
 * Tue Oct 01 2019 Michael Mraka <michael.mraka@redhat.com> 5.3-5
 - we can use python2 packages and macros everywhere
 

--- a/spec-tree/perl-DBD-Oracle/perl-DBD-Oracle.spec
+++ b/spec-tree/perl-DBD-Oracle/perl-DBD-Oracle.spec
@@ -8,7 +8,7 @@ Source1: demo.mk
 Url: http://www.cpan.org
 BuildRequires: perl >= 0:5.6.1, perl(DBI)
 BuildRequires: perl(ExtUtils::MakeMaker)
-BuildRequires: oracle-instantclient11.2-devel
+BuildRequires: oracle-instantclient18.5-devel
 BuildRequires:  coreutils
 BuildRequires:  findutils
 BuildRequires:  make
@@ -54,7 +54,7 @@ ORACLE_HOME=$(find /usr/lib/oracle/ -name client64 | tail -1)
 ORACLE_HOME=$(find /usr/lib/oracle/ -name client | tail -1)
 %endif
 export ORACLE_HOME
-perl Makefile.PL -m $MKFILE INSTALLDIRS="vendor" PREFIX=%{_prefix} -V 11.2.0.4.0
+perl Makefile.PL -m $MKFILE INSTALLDIRS="vendor" PREFIX=%{_prefix} -V 18.5.0.0.0
 make  %{?_smp_mflags} OPTIMIZE="%{optflags}"
 
 %clean
@@ -70,6 +70,9 @@ rm -f `find $RPM_BUILD_ROOT -type f -name perllocal.pod -o -name .packlist`
 %{_mandir}/man3/*
 
 %changelog
+* Thu 28 May 2020 Laurence Rochfort <laurence.rochfort@oracle.com> 18.5.0.0-1
+- Update instant client to 18.5 [Orabug: 31413086]
+
 * Tue Oct 01 2019 Michael Mraka <michael.mraka@redhat.com> 1.62-7
 - workaround RHEL8 buildrequires modules issue
 


### PR DESCRIPTION
Update supported Oracle DB versions to include XE 18.4, and
Standard/Enterprise 18.3, 18.4, and 19.3.

Update the Instant Client version to 18.5.

Orabug: 31413086

Signed-off-by: Laurence Rochfort <laurence.rochfort@oracle.com>